### PR TITLE
v1.0.1: fix() revert nanoid dependency to version supporting CJS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "kucoin-api",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kucoin-api",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.4",
         "isomorphic-ws": "^4.0.1",
-        "nanoid": "^5.0.6",
+        "nanoid": "^3.3.7",
         "ws": "^7.4.0"
       },
       "devDependencies": {
@@ -4015,9 +4015,9 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.0.6.tgz",
-      "integrity": "sha512-rRq0eMHoGZxlvaFOUdK1Ev83Bd1IgzzR+WJ3IbDJ7QOSdAxYjlurSPqFs9s4lJg29RT6nPwizFtJhQS6V5xgiA==",
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
       "funding": [
         {
           "type": "github",
@@ -4025,10 +4025,10 @@
         }
       ],
       "bin": {
-        "nanoid": "bin/nanoid.js"
+        "nanoid": "bin/nanoid.cjs"
       },
       "engines": {
-        "node": "^18 || >=20"
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/natural-compare": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kucoin-api",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Complete & robust Node.js SDK for Kucoin's REST APIs and WebSockets, with TypeScript & strong end to end tests.",
   "scripts": {
     "clean": "rm -rf dist",
@@ -28,7 +28,7 @@
   "dependencies": {
     "axios": "^1.7.4",
     "isomorphic-ws": "^4.0.1",
-    "nanoid": "^5.0.6",
+    "nanoid": "^3.3.7",
     "ws": "^7.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
<!-- Add a brief description of the pr: -->
Looks like v4+ releases of nanoid mistakenly cause issues with CJS projects (by design, unfortunately: https://github.com/ai/nanoid/issues/365)

V3 seems to be maintained and the last version supporting CJS, so we'll use that for now.

## Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
