### PR TITLE
Fix/get trading pair fee

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kucoin-api",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kucoin-api",
-      "version": "1.0.13",
+      "version": "1.0.14",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kucoin-api",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "Complete & robust Node.js SDK for Kucoin's REST APIs and WebSockets, with TypeScript & strong end to end tests.",
   "scripts": {
     "clean": "rm -rf dist",

--- a/src/FuturesClient.ts
+++ b/src/FuturesClient.ts
@@ -189,7 +189,7 @@ export class FuturesClient extends BaseRestClient {
    * REST - FUNDING - TRADE FEE
    */
 
-  getTradingPairFee(params: { symbols: string }): Promise<
+  getTradingPairFee(params: { symbol: string }): Promise<
     APISuccessResponse<{
       symbol: string;
       takerFeeRate: string;


### PR DESCRIPTION
## Summary

Hi! 👋🏼 

I found a typo at the params of the `FuturesClient.getTradingPairFee`, they should be be `params: { symbol: string }`
I also updated the package version

## Additional Information

Reference:

[Futures - Trading pair fee](https://www.kucoin.com/docs/rest/funding/trade-fee/trading-pair-actual-fee-futures)
