### PR TITLE
Fix submit sltp order params

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kucoin-api",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kucoin-api",
-      "version": "1.0.15",
+      "version": "1.0.16",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kucoin-api",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "description": "Complete & robust Node.js SDK for Kucoin's REST APIs and WebSockets, with TypeScript & strong end to end tests.",
   "scripts": {
     "clean": "rm -rf dist",

--- a/src/FuturesClient.ts
+++ b/src/FuturesClient.ts
@@ -23,6 +23,7 @@ import {
   GetTransfersRequest,
   MaxOpenSizeRequest,
   Order,
+  SLTPOrder,
   SubmitTransfer,
   UpdateSubAPIRequest,
 } from './types/request/futures.types.js';
@@ -338,7 +339,7 @@ export class FuturesClient extends BaseRestClient {
     return this.deletePrivate('api/v1/orders/multi-cancel', params);
   }
 
-  submitSLTPOrder(params: Order): Promise<
+  submitSLTPOrder(params: SLTPOrder): Promise<
     APISuccessResponse<{
       orderId?: string;
       clientOid?: string;

--- a/src/types/request/futures.types.ts
+++ b/src/types/request/futures.types.ts
@@ -136,6 +136,11 @@ export interface Order {
   marginMode?: 'ISOLATED' | 'CROSS';
 }
 
+export interface SLTPOrder extends Order {
+  triggerStopDownPrice?: string;
+  triggerStopUpPrice?: string;
+}
+
 export interface GetOrdersRequest {
   status?: 'active' | 'done';
   symbol?: string;


### PR DESCRIPTION
## Summary
Hi @tiagosiebler! 👋🏼 

I found that there were some missing parameters in the `FuturesClient.submitSLTPOrder` method, the missing params are:
- triggerStopUpPrice
- triggerStopDownPrice

I added a new interface that extends the existing one and confirms that the other parameters look great. I also bumped the package version!

Please, let me know if something else is required

## Additional Information

Reference:
- [Place take profit and stop loss order](https://www.kucoin.com/docs/rest/futures-trading/orders/place-take-profit-and-stop-loss-order)
