### PR TITLE
v1.0.17 feat(): updated request and response types

### DIFF
--- a/docs/endpointFunctionList.md
+++ b/docs/endpointFunctionList.md
@@ -49,159 +49,159 @@ This table includes all endpoints from the official Exchange API docs and corres
 
 | Function | AUTH | HTTP Method | Endpoint |
 | -------- | :------: | :------: | -------- |
-| [getServiceStatus()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L256) |  | GET | `api/v1/status` |
-| [getAnnouncements()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L260) |  | GET | `api/v3/announcements` |
-| [getAccountSummary()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L272) | :closed_lock_with_key:  | GET | `api/v2/user-info` |
-| [getBalances()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L281) | :closed_lock_with_key:  | GET | `api/v1/accounts` |
-| [getAccountDetail()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L287) | :closed_lock_with_key:  | GET | `api/v1/accounts/{accountId}` |
-| [getTransactions()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L296) | :closed_lock_with_key:  | GET | `api/v1/accounts/ledgers` |
-| [getHFTransactions()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L305) | :closed_lock_with_key:  | GET | `api/v1/hf/accounts/ledgers` |
-| [getHFMarginTransactions()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L314) | :closed_lock_with_key:  | GET | `api/v3/hf/margin/account/ledgers` |
-| [getSubAccountsV1()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L326) | :closed_lock_with_key:  | GET | `api/v1/sub/user` |
-| [getSubAccountsV2()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L330) | :closed_lock_with_key:  | GET | `api/v2/sub/user` |
-| [createSubAccount()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L337) | :closed_lock_with_key:  | POST | `api/v2/sub/user/created` |
-| [getSubAccountBalance()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L343) | :closed_lock_with_key:  | GET | `api/v1/sub-accounts/{subUserId}` |
-| [getSubAccountBalancesV1()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L350) | :closed_lock_with_key:  | GET | `api/v1/sub-accounts` |
-| [getSubAccountBalancesV2()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L354) | :closed_lock_with_key:  | GET | `api/v2/sub-accounts` |
-| [getSubAPIs()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L368) | :closed_lock_with_key:  | GET | `api/v1/sub/api-key` |
-| [createSubAPI()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L375) | :closed_lock_with_key:  | POST | `api/v1/sub/api-key` |
-| [updateSubAPI()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L381) | :closed_lock_with_key:  | POST | `api/v1/sub/api-key/update` |
-| [deleteSubAPI()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L387) | :closed_lock_with_key:  | DELETE | `api/v1/sub/api-key` |
-| [getMarginBalances()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L399) | :closed_lock_with_key:  | GET | `api/v1/margin/account` |
-| [getMarginBalance()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L408) | :closed_lock_with_key:  | GET | `api/v3/margin/accounts` |
-| [getIsolatedMarginBalance()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L414) | :closed_lock_with_key:  | GET | `api/v3/isolated/accounts` |
-| [createDepositAddress()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L429) | :closed_lock_with_key:  | POST | `api/v1/deposit-addresses` |
-| [createDepositAddressV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L436) | :closed_lock_with_key:  | POST | `api/v3/deposit-address/create` |
-| [getDepositAddressesV2()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L445) | :closed_lock_with_key:  | GET | `api/v2/deposit-addresses` |
-| [getDepositAddressV1()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L454) | :closed_lock_with_key:  | GET | `api/v1/deposit-addresses` |
-| [getDepositAddressesV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L461) | :closed_lock_with_key:  | GET | `api/v3/deposit-addresses` |
-| [getDeposits()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L469) | :closed_lock_with_key:  | GET | `api/v1/deposits` |
-| [getHistoricalDepositsV1()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L475) | :closed_lock_with_key:  | GET | `api/v1/hist-deposits` |
-| [getWithdrawals()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L487) | :closed_lock_with_key:  | GET | `api/v1/withdrawals` |
-| [getHistoricalWithdrawalsV1()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L493) | :closed_lock_with_key:  | GET | `api/v1/hist-withdrawals` |
-| [getWithdrawalQuotas()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L499) | :closed_lock_with_key:  | GET | `api/v1/withdrawals/quotas` |
-| [submitWithdraw()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L509) | :closed_lock_with_key:  | POST | `api/v1/withdrawals` |
-| [submitWithdrawV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L515) | :closed_lock_with_key:  | POST | `api/v3/withdrawals` |
-| [cancelWithdrawal()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L523) | :closed_lock_with_key:  | DELETE | `api/v1/withdrawals/{withdrawalId}` |
-| [getTransferable()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L535) | :closed_lock_with_key:  | GET | `api/v1/accounts/transferable` |
-| [submitFlexTransfer()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L541) | :closed_lock_with_key:  | POST | `api/v3/accounts/universal-transfer` |
-| [submitTransferMasterSub()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L549) | :closed_lock_with_key:  | POST | `api/v2/accounts/sub-transfer` |
-| [submitInnerTransfer()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L557) | :closed_lock_with_key:  | POST | `api/v2/accounts/inner-transfer` |
-| [getBasicUserFee()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L571) | :closed_lock_with_key:  | GET | `api/v1/base-fee` |
-| [getTradingPairFee()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L580) | :closed_lock_with_key:  | GET | `api/v1/trade-fees` |
-| [getCurrencies()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L598) |  | GET | `api/v3/currencies` |
-| [getCurrency()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L602) |  | GET | `api/v3/currencies/{currency}` |
-| [getSymbols()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L609) |  | GET | `api/v2/symbols` |
-| [getSymbol()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L615) |  | GET | `api/v2/symbols/{symbol}` |
-| [getTicker()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L621) |  | GET | `api/v1/market/orderbook/level1` |
-| [getTickers()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L625) |  | GET | `api/v1/market/allTickers` |
-| [get24hrStats()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L634) |  | GET | `api/v1/market/stats` |
-| [getMarkets()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L640) |  | GET | `api/v1/markets` |
-| [getOrderBookLevel20()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L644) |  | GET | `api/v1/market/orderbook/level2_20` |
-| [getOrderBookLevel100()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L650) |  | GET | `api/v1/market/orderbook/level2_100` |
-| [getFullOrderBook()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L656) | :closed_lock_with_key:  | GET | `api/v3/market/orderbook/level2` |
-| [getTradeHistories()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L662) |  | GET | `api/v1/market/histories` |
-| [getKlines()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L668) |  | GET | `api/v1/market/candles` |
-| [getFiatPrice()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L674) |  | GET | `api/v1/prices` |
-| [getUserType()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L684) | :closed_lock_with_key:  | GET | `api/v1/hf/accounts/opened` |
-| [submitHFOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L688) | :closed_lock_with_key:  | POST | `api/v1/hf/orders` |
-| [submitHFOrderTest()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L697) | :closed_lock_with_key:  | POST | `api/v1/hf/orders/test` |
-| [submitHFOrderSync()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L701) | :closed_lock_with_key:  | POST | `api/v1/hf/orders/sync` |
-| [submitHFMultipleOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L707) | :closed_lock_with_key:  | POST | `api/v1/hf/orders/multi` |
-| [submitHFMultipleOrdersSync()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L713) | :closed_lock_with_key:  | POST | `api/v1/hf/orders/multi/sync` |
-| [updateHFOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L719) | :closed_lock_with_key:  | POST | `api/v1/hf/orders/alter` |
-| [cancelHFOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L728) | :closed_lock_with_key:  | DELETE | `api/v1/hf/orders/{orderId}` |
-| [cancelHFOrderSync()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L736) | :closed_lock_with_key:  | DELETE | `api/v1/hf/orders/sync/{orderId}` |
-| [cancelHFOrderByClientOId()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L746) | :closed_lock_with_key:  | DELETE | `api/v1/hf/orders/client-order/{clientOid}` |
-| [cancelHFOrderSyncByClientOId()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L760) | :closed_lock_with_key:  | DELETE | `api/v1/hf/orders/sync/client-order/{clientOid}` |
-| [cancelHFOrdersNumber()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L770) | :closed_lock_with_key:  | DELETE | `api/v1/hf/orders/cancel/{orderId}` |
-| [cancelHFAllOrdersBySymbol()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L779) | :closed_lock_with_key:  | DELETE | `api/v1/hf/orders` |
-| [cancelHFAllOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L788) | :closed_lock_with_key:  | DELETE | `api/v1/hf/orders/cancelAll` |
-| [getHFActiveOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L792) | :closed_lock_with_key:  | GET | `api/v1/hf/orders/active` |
-| [getHFActiveSymbols()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L798) | :closed_lock_with_key:  | GET | `api/v1/hf/orders/active/symbols` |
-| [getHFCompletedOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L806) | :closed_lock_with_key:  | GET | `api/v1/hf/orders/done` |
-| [getHFOrderDetailsByOrderId()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L815) | :closed_lock_with_key:  | GET | `api/v1/hf/orders/{orderId}` |
-| [getHFOrderDetailsByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L822) | :closed_lock_with_key:  | GET | `api/v1/hf/orders/client-order/{clientOid}` |
-| [cancelHFOrderAutoSetting()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L832) | :closed_lock_with_key:  | POST | `api/v1/hf/orders/dead-cancel-all` |
-| [cancelHFOrderAutoSettingQuery()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L844) | :closed_lock_with_key:  | GET | `api/v1/hf/orders/dead-cancel-all/query` |
-| [getHFFilledOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L850) | :closed_lock_with_key:  | GET | `api/v1/hf/fills` |
-| [submitOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L866) | :closed_lock_with_key:  | POST | `api/v1/orders` |
-| [submitOrderTest()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L875) | :closed_lock_with_key:  | POST | `api/v1/orders/test` |
-| [submitMultipleOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L880) | :closed_lock_with_key:  | POST | `api/v1/orders/multi` |
-| [cancelOrderById()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L888) | :closed_lock_with_key:  | DELETE | `api/v1/orders/{orderId}` |
-| [cancelOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L897) | :closed_lock_with_key:  | DELETE | `api/v1/order/client-order/{clientOid}` |
-| [cancelAllOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L907) | :closed_lock_with_key:  | DELETE | `api/v1/orders` |
-| [getOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L916) | :closed_lock_with_key:  | GET | `api/v1/orders` |
-| [getRecentOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L923) | :closed_lock_with_key:  | GET | `api/v1/limit/orders` |
-| [getOrderByOrderId()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L931) | :closed_lock_with_key:  | GET | `api/v1/orders/{orderId}` |
-| [getOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L938) | :closed_lock_with_key:  | GET | `api/v1/order/client-order/{clientOid}` |
-| [getFills()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L951) | :closed_lock_with_key:  | GET | `api/v1/fills` |
-| [getRecentFills()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L958) | :closed_lock_with_key:  | GET | `api/v1/limit/fills` |
-| [submitStopOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L969) | :closed_lock_with_key:  | POST | `api/v1/stop-order` |
-| [cancelStopOrderById()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L982) | :closed_lock_with_key:  | DELETE | `api/v1/stop-order/{orderId}` |
-| [cancelStopOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L992) | :closed_lock_with_key:  | DELETE | `api/v1/stop-order/cancelOrderByClientOid` |
-| [cancelStopOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1009) | :closed_lock_with_key:  | DELETE | `api/v1/stop-order/cancel` |
-| [getStopOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1019) | :closed_lock_with_key:  | GET | `api/v1/stop-order` |
-| [getStopOrderByOrderId()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1027) | :closed_lock_with_key:  | GET | `api/v1/stop-order/{orderId}` |
-| [getStopOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1036) | :closed_lock_with_key:  | GET | `api/v1/stop-order/queryOrderByClientOid` |
-| [submitOCOOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1050) | :closed_lock_with_key:  | POST | `api/v3/oco/order` |
-| [cancelOCOOrderById()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1061) | :closed_lock_with_key:  | DELETE | `api/v3/oco/order/{orderId}` |
-| [cancelOCOOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1072) | :closed_lock_with_key:  | DELETE | `api/v3/oco/client-order/{clientOid}` |
-| [cancelMultipleOCOOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1083) | :closed_lock_with_key:  | DELETE | `api/v3/oco/orders` |
-| [getOCOOrderByOrderId()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1097) | :closed_lock_with_key:  | GET | `api/v3/oco/order/{orderId}` |
-| [getOCOOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1106) | :closed_lock_with_key:  | GET | `api/v3/oco/client-order/{clientOid}` |
-| [getOCOOrderDetails()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1115) | :closed_lock_with_key:  | GET | `api/v3/oco/order/details/{orderId}` |
-| [getOCOOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1124) | :closed_lock_with_key:  | GET | `api/v3/oco/orders` |
-| [submitHFMarginOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1136) | :closed_lock_with_key:  | POST | `api/v3/hf/margin/order` |
-| [submitHFMarginOrderTest()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1144) | :closed_lock_with_key:  | POST | `api/v3/hf/margin/order/test` |
-| [cancelHFMarginOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1148) | :closed_lock_with_key:  | DELETE | `api/v3/hf/margin/orders/{orderId}` |
-| [cancelHFMarginOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1159) | :closed_lock_with_key:  | DELETE | `api/v3/hf/margin/orders/client-order/{clientOid}` |
-| [cancelHFAllMarginOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1173) | :closed_lock_with_key:  | DELETE | `api/v3/hf/margin/orders` |
-| [getHFActiveMarginOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1177) | :closed_lock_with_key:  | GET | `api/v3/hf/margin/orders/active` |
-| [getHFMarginFilledOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1183) | :closed_lock_with_key:  | GET | `api/v3/hf/margin/orders/done` |
-| [getHFMarginOrderByOrderId()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1192) | :closed_lock_with_key:  | GET | `api/v3/hf/margin/orders/{orderId}` |
-| [getHFMarginOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1199) | :closed_lock_with_key:  | GET | `api/v3/hf/margin/orders/client-order/{clientOid}?symbol={symbol}` |
-| [getHFMarginFills()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1208) | :closed_lock_with_key:  | GET | `api/v3/hf/margin/fills` |
-| [getHFMarginOpenSymbols()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1217) | :closed_lock_with_key:  | GET | `api/v3/hf/margin/order/active/symbols` |
-| [submitMarginOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1229) | :closed_lock_with_key:  | POST | `api/v1/margin/order` |
-| [submitMarginOrderTest()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1235) | :closed_lock_with_key:  | POST | `api/v1/margin/order/test` |
-| [getMarginLeveragedToken()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1245) |  | GET | `api/v3/etf/info` |
-| [getMarginMarkPrices()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1251) |  | GET | `api/v3/mark-price/all-symbols` |
-| [getMarginMarkPrice()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1255) |  | GET | `api/v1/mark-price/{symbol}/current` |
-| [getMarginConfigInfo()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1261) |  | GET | `api/v1/margin/config` |
-| [getMarginRiskLimitConfig()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1265) |  | GET | `api/v3/margin/currencies` |
-| [getIsolatedMarginSymbolsConfig()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1277) | :closed_lock_with_key:  | GET | `api/v1/isolated/symbols` |
-| [getIsolatedMarginAccounts()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1283) | :closed_lock_with_key:  | GET | `api/v1/isolated/accounts` |
-| [getIsolatedMarginAccount()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1289) | :closed_lock_with_key:  | GET | `api/v1/isolated/account/{symbol}` |
-| [marginBorrowV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1301) | :closed_lock_with_key:  | POST | `api/v3/margin/borrow` |
-| [marginRepayV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1307) | :closed_lock_with_key:  | POST | `api/v3/margin/repay` |
-| [getMarginBorrowHistoryV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1313) | :closed_lock_with_key:  | GET | `api/v3/margin/borrow` |
-| [getMarginRepayHistoryV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1319) | :closed_lock_with_key:  | GET | `api/v3/margin/repay` |
-| [getMarginInterestRecordsV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1325) | :closed_lock_with_key:  | GET | `api/v3/margin/interest` |
-| [getMarginActivePairsV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1331) | :closed_lock_with_key:  | GET | `api/v3/margin/symbols` |
-| [updateMarginLeverageV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1337) | :closed_lock_with_key:  | POST | `api/v3/position/update-user-leverage` |
-| [getLendingCurrencyV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1351) |  | GET | `api/v3/project/list` |
-| [getLendingInterestRateV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1357) |  | GET | `api/v3/project/marketInterestRate` |
-| [submitLendingSubscriptionV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1368) | :closed_lock_with_key:  | POST | `api/v3/purchase` |
-| [submitLendingRedemptionV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1380) | :closed_lock_with_key:  | POST | `api/v3/redeem` |
-| [updateLendingSubscriptionOrdersV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1392) | :closed_lock_with_key:  | POST | `api/v3/lend/purchase/update` |
-| [getLendingRedemptionOrdersV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1398) | :closed_lock_with_key:  | GET | `api/v3/redeem/orders` |
-| [getLendingSubscriptionOrdersV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1404) | :closed_lock_with_key:  | GET | `api/v3/purchase/orders` |
-| [subscribeEarnFixedIncome()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1422) | :closed_lock_with_key:  | POST | `api/v1/earn/orders` |
-| [submitRedemption()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1434) | :closed_lock_with_key:  | DELETE | `api/v1/earn/orders` |
-| [getEarnRedeemPreview()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1445) | :closed_lock_with_key:  | GET | `api/v1/earn/redeem-preview` |
-| [getEarnSavingsProducts()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1462) | :closed_lock_with_key:  | GET | `api/v1/earn/saving/products` |
-| [getEarnFixedIncomeHoldAssets()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1473) | :closed_lock_with_key:  | GET | `api/v1/earn/hold-assets` |
-| [getEarnPromotionProducts()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1484) | :closed_lock_with_key:  | GET | `api/v1/earn/promotion/products` |
-| [getEarnKcsStakingProducts()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1502) | :closed_lock_with_key:  | GET | `api/v1/earn/kcs-staking/products` |
-| [getEarnStakingProducts()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1513) | :closed_lock_with_key:  | GET | `api/v1/earn/staking/products` |
-| [getEarnEthStakingProducts()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1525) | :closed_lock_with_key:  | GET | `api/v1/earn/eth-staking/products` |
-| [getOtcLoan()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1540) | :closed_lock_with_key:  | GET | `api/v1/otc-loan/loan` |
-| [getOtcLoanAccounts()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1549) | :closed_lock_with_key:  | GET | `api/v1/otc-loan/accounts` |
-| [getAffiliateUserRebateInfo()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1567) | :closed_lock_with_key:  | GET | `api/v2/affiliate/inviter/statistics` |
-| [getBrokerRebateOrderDownloadLink()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1580) | :closed_lock_with_key:  | GET | `api/v1/broker/api/rebase/download` |
-| [getPublicWSConnectionToken()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1594) |  | POST | `api/v1/bullet-public` |
-| [getPrivateWSConnectionToken()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1598) | :closed_lock_with_key:  | POST | `api/v1/bullet-private` |
+| [getServiceStatus()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L259) |  | GET | `api/v1/status` |
+| [getAnnouncements()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L263) |  | GET | `api/v3/announcements` |
+| [getAccountSummary()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L275) | :closed_lock_with_key:  | GET | `api/v2/user-info` |
+| [getBalances()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L284) | :closed_lock_with_key:  | GET | `api/v1/accounts` |
+| [getAccountDetail()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L290) | :closed_lock_with_key:  | GET | `api/v1/accounts/{accountId}` |
+| [getTransactions()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L299) | :closed_lock_with_key:  | GET | `api/v1/accounts/ledgers` |
+| [getHFTransactions()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L308) | :closed_lock_with_key:  | GET | `api/v1/hf/accounts/ledgers` |
+| [getHFMarginTransactions()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L317) | :closed_lock_with_key:  | GET | `api/v3/hf/margin/account/ledgers` |
+| [getSubAccountsV1()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L329) | :closed_lock_with_key:  | GET | `api/v1/sub/user` |
+| [getSubAccountsV2()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L333) | :closed_lock_with_key:  | GET | `api/v2/sub/user` |
+| [createSubAccount()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L340) | :closed_lock_with_key:  | POST | `api/v2/sub/user/created` |
+| [getSubAccountBalance()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L346) | :closed_lock_with_key:  | GET | `api/v1/sub-accounts/{subUserId}` |
+| [getSubAccountBalancesV1()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L353) | :closed_lock_with_key:  | GET | `api/v1/sub-accounts` |
+| [getSubAccountBalancesV2()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L357) | :closed_lock_with_key:  | GET | `api/v2/sub-accounts` |
+| [getSubAPIs()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L371) | :closed_lock_with_key:  | GET | `api/v1/sub/api-key` |
+| [createSubAPI()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L378) | :closed_lock_with_key:  | POST | `api/v1/sub/api-key` |
+| [updateSubAPI()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L384) | :closed_lock_with_key:  | POST | `api/v1/sub/api-key/update` |
+| [deleteSubAPI()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L390) | :closed_lock_with_key:  | DELETE | `api/v1/sub/api-key` |
+| [getMarginBalances()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L402) | :closed_lock_with_key:  | GET | `api/v1/margin/account` |
+| [getMarginBalance()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L411) | :closed_lock_with_key:  | GET | `api/v3/margin/accounts` |
+| [getIsolatedMarginBalance()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L417) | :closed_lock_with_key:  | GET | `api/v3/isolated/accounts` |
+| [createDepositAddress()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L432) | :closed_lock_with_key:  | POST | `api/v1/deposit-addresses` |
+| [createDepositAddressV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L439) | :closed_lock_with_key:  | POST | `api/v3/deposit-address/create` |
+| [getDepositAddressesV2()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L448) | :closed_lock_with_key:  | GET | `api/v2/deposit-addresses` |
+| [getDepositAddressV1()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L457) | :closed_lock_with_key:  | GET | `api/v1/deposit-addresses` |
+| [getDepositAddressesV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L464) | :closed_lock_with_key:  | GET | `api/v3/deposit-addresses` |
+| [getDeposits()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L472) | :closed_lock_with_key:  | GET | `api/v1/deposits` |
+| [getHistoricalDepositsV1()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L478) | :closed_lock_with_key:  | GET | `api/v1/hist-deposits` |
+| [getWithdrawals()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L490) | :closed_lock_with_key:  | GET | `api/v1/withdrawals` |
+| [getHistoricalWithdrawalsV1()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L496) | :closed_lock_with_key:  | GET | `api/v1/hist-withdrawals` |
+| [getWithdrawalQuotas()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L502) | :closed_lock_with_key:  | GET | `api/v1/withdrawals/quotas` |
+| [submitWithdraw()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L512) | :closed_lock_with_key:  | POST | `api/v1/withdrawals` |
+| [submitWithdrawV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L518) | :closed_lock_with_key:  | POST | `api/v3/withdrawals` |
+| [cancelWithdrawal()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L526) | :closed_lock_with_key:  | DELETE | `api/v1/withdrawals/{withdrawalId}` |
+| [getTransferable()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L538) | :closed_lock_with_key:  | GET | `api/v1/accounts/transferable` |
+| [submitFlexTransfer()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L544) | :closed_lock_with_key:  | POST | `api/v3/accounts/universal-transfer` |
+| [submitTransferMasterSub()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L552) | :closed_lock_with_key:  | POST | `api/v2/accounts/sub-transfer` |
+| [submitInnerTransfer()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L560) | :closed_lock_with_key:  | POST | `api/v2/accounts/inner-transfer` |
+| [getBasicUserFee()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L574) | :closed_lock_with_key:  | GET | `api/v1/base-fee` |
+| [getTradingPairFee()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L583) | :closed_lock_with_key:  | GET | `api/v1/trade-fees` |
+| [getCurrencies()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L601) |  | GET | `api/v3/currencies` |
+| [getCurrency()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L605) |  | GET | `api/v3/currencies/{currency}` |
+| [getSymbols()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L612) |  | GET | `api/v2/symbols` |
+| [getSymbol()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L618) |  | GET | `api/v2/symbols/{symbol}` |
+| [getTicker()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L624) |  | GET | `api/v1/market/orderbook/level1` |
+| [getTickers()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L628) |  | GET | `api/v1/market/allTickers` |
+| [get24hrStats()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L637) |  | GET | `api/v1/market/stats` |
+| [getMarkets()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L643) |  | GET | `api/v1/markets` |
+| [getOrderBookLevel20()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L647) |  | GET | `api/v1/market/orderbook/level2_20` |
+| [getOrderBookLevel100()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L653) |  | GET | `api/v1/market/orderbook/level2_100` |
+| [getFullOrderBook()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L659) | :closed_lock_with_key:  | GET | `api/v3/market/orderbook/level2` |
+| [getTradeHistories()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L665) |  | GET | `api/v1/market/histories` |
+| [getKlines()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L671) |  | GET | `api/v1/market/candles` |
+| [getFiatPrice()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L677) |  | GET | `api/v1/prices` |
+| [getUserType()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L687) | :closed_lock_with_key:  | GET | `api/v1/hf/accounts/opened` |
+| [submitHFOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L691) | :closed_lock_with_key:  | POST | `api/v1/hf/orders` |
+| [submitHFOrderTest()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L700) | :closed_lock_with_key:  | POST | `api/v1/hf/orders/test` |
+| [submitHFOrderSync()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L704) | :closed_lock_with_key:  | POST | `api/v1/hf/orders/sync` |
+| [submitHFMultipleOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L710) | :closed_lock_with_key:  | POST | `api/v1/hf/orders/multi` |
+| [submitHFMultipleOrdersSync()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L716) | :closed_lock_with_key:  | POST | `api/v1/hf/orders/multi/sync` |
+| [updateHFOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L722) | :closed_lock_with_key:  | POST | `api/v1/hf/orders/alter` |
+| [cancelHFOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L731) | :closed_lock_with_key:  | DELETE | `api/v1/hf/orders/{orderId}` |
+| [cancelHFOrderSync()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L739) | :closed_lock_with_key:  | DELETE | `api/v1/hf/orders/sync/{orderId}` |
+| [cancelHFOrderByClientOId()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L749) | :closed_lock_with_key:  | DELETE | `api/v1/hf/orders/client-order/{clientOid}` |
+| [cancelHFOrderSyncByClientOId()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L763) | :closed_lock_with_key:  | DELETE | `api/v1/hf/orders/sync/client-order/{clientOid}` |
+| [cancelHFOrdersNumber()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L773) | :closed_lock_with_key:  | DELETE | `api/v1/hf/orders/cancel/{orderId}` |
+| [cancelHFAllOrdersBySymbol()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L782) | :closed_lock_with_key:  | DELETE | `api/v1/hf/orders` |
+| [cancelHFAllOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L791) | :closed_lock_with_key:  | DELETE | `api/v1/hf/orders/cancelAll` |
+| [getHFActiveOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L795) | :closed_lock_with_key:  | GET | `api/v1/hf/orders/active` |
+| [getHFActiveSymbols()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L801) | :closed_lock_with_key:  | GET | `api/v1/hf/orders/active/symbols` |
+| [getHFCompletedOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L809) | :closed_lock_with_key:  | GET | `api/v1/hf/orders/done` |
+| [getHFOrderDetailsByOrderId()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L818) | :closed_lock_with_key:  | GET | `api/v1/hf/orders/{orderId}` |
+| [getHFOrderDetailsByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L825) | :closed_lock_with_key:  | GET | `api/v1/hf/orders/client-order/{clientOid}` |
+| [cancelHFOrderAutoSetting()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L835) | :closed_lock_with_key:  | POST | `api/v1/hf/orders/dead-cancel-all` |
+| [cancelHFOrderAutoSettingQuery()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L847) | :closed_lock_with_key:  | GET | `api/v1/hf/orders/dead-cancel-all/query` |
+| [getHFFilledOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L853) | :closed_lock_with_key:  | GET | `api/v1/hf/fills` |
+| [submitOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L869) | :closed_lock_with_key:  | POST | `api/v1/orders` |
+| [submitOrderTest()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L878) | :closed_lock_with_key:  | POST | `api/v1/orders/test` |
+| [submitMultipleOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L883) | :closed_lock_with_key:  | POST | `api/v1/orders/multi` |
+| [cancelOrderById()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L891) | :closed_lock_with_key:  | DELETE | `api/v1/orders/{orderId}` |
+| [cancelOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L900) | :closed_lock_with_key:  | DELETE | `api/v1/order/client-order/{clientOid}` |
+| [cancelAllOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L910) | :closed_lock_with_key:  | DELETE | `api/v1/orders` |
+| [getOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L919) | :closed_lock_with_key:  | GET | `api/v1/orders` |
+| [getRecentOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L926) | :closed_lock_with_key:  | GET | `api/v1/limit/orders` |
+| [getOrderByOrderId()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L934) | :closed_lock_with_key:  | GET | `api/v1/orders/{orderId}` |
+| [getOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L941) | :closed_lock_with_key:  | GET | `api/v1/order/client-order/{clientOid}` |
+| [getFills()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L954) | :closed_lock_with_key:  | GET | `api/v1/fills` |
+| [getRecentFills()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L961) | :closed_lock_with_key:  | GET | `api/v1/limit/fills` |
+| [submitStopOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L972) | :closed_lock_with_key:  | POST | `api/v1/stop-order` |
+| [cancelStopOrderById()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L985) | :closed_lock_with_key:  | DELETE | `api/v1/stop-order/{orderId}` |
+| [cancelStopOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L995) | :closed_lock_with_key:  | DELETE | `api/v1/stop-order/cancelOrderByClientOid` |
+| [cancelStopOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1012) | :closed_lock_with_key:  | DELETE | `api/v1/stop-order/cancel` |
+| [getStopOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1022) | :closed_lock_with_key:  | GET | `api/v1/stop-order` |
+| [getStopOrderByOrderId()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1030) | :closed_lock_with_key:  | GET | `api/v1/stop-order/{orderId}` |
+| [getStopOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1039) | :closed_lock_with_key:  | GET | `api/v1/stop-order/queryOrderByClientOid` |
+| [submitOCOOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1053) | :closed_lock_with_key:  | POST | `api/v3/oco/order` |
+| [cancelOCOOrderById()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1064) | :closed_lock_with_key:  | DELETE | `api/v3/oco/order/{orderId}` |
+| [cancelOCOOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1075) | :closed_lock_with_key:  | DELETE | `api/v3/oco/client-order/{clientOid}` |
+| [cancelMultipleOCOOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1086) | :closed_lock_with_key:  | DELETE | `api/v3/oco/orders` |
+| [getOCOOrderByOrderId()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1100) | :closed_lock_with_key:  | GET | `api/v3/oco/order/{orderId}` |
+| [getOCOOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1109) | :closed_lock_with_key:  | GET | `api/v3/oco/client-order/{clientOid}` |
+| [getOCOOrderDetails()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1118) | :closed_lock_with_key:  | GET | `api/v3/oco/order/details/{orderId}` |
+| [getOCOOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1127) | :closed_lock_with_key:  | GET | `api/v3/oco/orders` |
+| [submitHFMarginOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1139) | :closed_lock_with_key:  | POST | `api/v3/hf/margin/order` |
+| [submitHFMarginOrderTest()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1147) | :closed_lock_with_key:  | POST | `api/v3/hf/margin/order/test` |
+| [cancelHFMarginOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1151) | :closed_lock_with_key:  | DELETE | `api/v3/hf/margin/orders/{orderId}` |
+| [cancelHFMarginOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1162) | :closed_lock_with_key:  | DELETE | `api/v3/hf/margin/orders/client-order/{clientOid}` |
+| [cancelHFAllMarginOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1176) | :closed_lock_with_key:  | DELETE | `api/v3/hf/margin/orders` |
+| [getHFActiveMarginOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1180) | :closed_lock_with_key:  | GET | `api/v3/hf/margin/orders/active` |
+| [getHFMarginFilledOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1186) | :closed_lock_with_key:  | GET | `api/v3/hf/margin/orders/done` |
+| [getHFMarginOrderByOrderId()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1195) | :closed_lock_with_key:  | GET | `api/v3/hf/margin/orders/{orderId}` |
+| [getHFMarginOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1202) | :closed_lock_with_key:  | GET | `api/v3/hf/margin/orders/client-order/{clientOid}?symbol={symbol}` |
+| [getHFMarginFills()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1211) | :closed_lock_with_key:  | GET | `api/v3/hf/margin/fills` |
+| [getHFMarginOpenSymbols()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1220) | :closed_lock_with_key:  | GET | `api/v3/hf/margin/order/active/symbols` |
+| [submitMarginOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1232) | :closed_lock_with_key:  | POST | `api/v1/margin/order` |
+| [submitMarginOrderTest()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1238) | :closed_lock_with_key:  | POST | `api/v1/margin/order/test` |
+| [getMarginLeveragedToken()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1248) |  | GET | `api/v3/etf/info` |
+| [getMarginMarkPrices()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1254) |  | GET | `api/v3/mark-price/all-symbols` |
+| [getMarginMarkPrice()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1258) |  | GET | `api/v1/mark-price/{symbol}/current` |
+| [getMarginConfigInfo()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1264) |  | GET | `api/v1/margin/config` |
+| [getMarginRiskLimitConfig()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1268) |  | GET | `api/v3/margin/currencies` |
+| [getIsolatedMarginSymbolsConfig()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1280) | :closed_lock_with_key:  | GET | `api/v1/isolated/symbols` |
+| [getIsolatedMarginAccounts()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1286) | :closed_lock_with_key:  | GET | `api/v1/isolated/accounts` |
+| [getIsolatedMarginAccount()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1292) | :closed_lock_with_key:  | GET | `api/v1/isolated/account/{symbol}` |
+| [marginBorrowV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1304) | :closed_lock_with_key:  | POST | `api/v3/margin/borrow` |
+| [marginRepayV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1310) | :closed_lock_with_key:  | POST | `api/v3/margin/repay` |
+| [getMarginBorrowHistoryV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1316) | :closed_lock_with_key:  | GET | `api/v3/margin/borrow` |
+| [getMarginRepayHistoryV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1322) | :closed_lock_with_key:  | GET | `api/v3/margin/repay` |
+| [getMarginInterestRecordsV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1328) | :closed_lock_with_key:  | GET | `api/v3/margin/interest` |
+| [getMarginActivePairsV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1334) | :closed_lock_with_key:  | GET | `api/v3/margin/symbols` |
+| [updateMarginLeverageV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1340) | :closed_lock_with_key:  | POST | `api/v3/position/update-user-leverage` |
+| [getLendingCurrencyV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1354) |  | GET | `api/v3/project/list` |
+| [getLendingInterestRateV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1360) |  | GET | `api/v3/project/marketInterestRate` |
+| [submitLendingSubscriptionV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1371) | :closed_lock_with_key:  | POST | `api/v3/purchase` |
+| [submitLendingRedemptionV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1383) | :closed_lock_with_key:  | POST | `api/v3/redeem` |
+| [updateLendingSubscriptionOrdersV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1395) | :closed_lock_with_key:  | POST | `api/v3/lend/purchase/update` |
+| [getLendingRedemptionOrdersV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1401) | :closed_lock_with_key:  | GET | `api/v3/redeem/orders` |
+| [getLendingSubscriptionOrdersV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1407) | :closed_lock_with_key:  | GET | `api/v3/purchase/orders` |
+| [subscribeEarnFixedIncome()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1425) | :closed_lock_with_key:  | POST | `api/v1/earn/orders` |
+| [submitRedemption()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1437) | :closed_lock_with_key:  | DELETE | `api/v1/earn/orders` |
+| [getEarnRedeemPreview()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1448) | :closed_lock_with_key:  | GET | `api/v1/earn/redeem-preview` |
+| [getEarnSavingsProducts()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1465) | :closed_lock_with_key:  | GET | `api/v1/earn/saving/products` |
+| [getEarnFixedIncomeHoldAssets()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1476) | :closed_lock_with_key:  | GET | `api/v1/earn/hold-assets` |
+| [getEarnPromotionProducts()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1487) | :closed_lock_with_key:  | GET | `api/v1/earn/promotion/products` |
+| [getEarnKcsStakingProducts()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1505) | :closed_lock_with_key:  | GET | `api/v1/earn/kcs-staking/products` |
+| [getEarnStakingProducts()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1516) | :closed_lock_with_key:  | GET | `api/v1/earn/staking/products` |
+| [getEarnEthStakingProducts()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1528) | :closed_lock_with_key:  | GET | `api/v1/earn/eth-staking/products` |
+| [getOtcLoan()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1543) | :closed_lock_with_key:  | GET | `api/v1/otc-loan/loan` |
+| [getOtcLoanAccounts()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1552) | :closed_lock_with_key:  | GET | `api/v1/otc-loan/accounts` |
+| [getAffiliateUserRebateInfo()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1570) | :closed_lock_with_key:  | GET | `api/v2/affiliate/inviter/statistics` |
+| [getBrokerRebateOrderDownloadLink()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1583) | :closed_lock_with_key:  | GET | `api/v1/broker/api/rebase/download` |
+| [getPublicWSConnectionToken()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1597) |  | POST | `api/v1/bullet-public` |
+| [getPrivateWSConnectionToken()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1601) | :closed_lock_with_key:  | POST | `api/v1/bullet-private` |
 
 # FuturesClient.ts
 
@@ -209,66 +209,66 @@ This table includes all endpoints from the official Exchange API docs and corres
 
 | Function | AUTH | HTTP Method | Endpoint |
 | -------- | :------: | :------: | -------- |
-| [getServiceStatus()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L97) |  | GET | `api/v1/status` |
-| [getTransactions()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L106) | :closed_lock_with_key:  | GET | `api/v1/transaction-history` |
-| [getSubAPIs()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L119) | :closed_lock_with_key:  | GET | `api/v1/sub/api-key` |
-| [createSubAPI()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L125) | :closed_lock_with_key:  | POST | `api/v1/sub/api-key` |
-| [updateSubAPI()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L131) | :closed_lock_with_key:  | POST | `api/v1/sub/api-key/update` |
-| [deleteSubAPI()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L137) | :closed_lock_with_key:  | DELETE | `api/v1/sub/api-key` |
-| [getBalance()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L150) | :closed_lock_with_key:  | GET | `api/v1/account-overview` |
-| [getSubBalances()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L156) | :closed_lock_with_key:  | GET | `api/v1/account-overview-all` |
-| [submitTransferOut()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L169) | :closed_lock_with_key:  | POST | `api/v3/transfer-out` |
-| [submitTransferIn()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L175) | :closed_lock_with_key:  | POST | `api/v1/transfer-in` |
-| [getTransfers()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L179) | :closed_lock_with_key:  | GET | `api/v1/transfer-list` |
-| [getTradingPairFee()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L189) | :closed_lock_with_key:  | GET | `api/v1/trade-fees` |
-| [getSymbols()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L205) |  | GET | `api/v1/contracts/active` |
-| [getSymbol()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L209) |  | GET | `api/v1/contracts/{symbol}` |
-| [getTicker()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L215) |  | GET | `api/v1/ticker` |
-| [getTickers()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L221) |  | GET | `api/v1/allTickers` |
-| [getFullOrderBookLevel2()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L225) |  | GET | `api/v1/level2/snapshot` |
-| [getPartOrderBookLevel2Depth20()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L231) |  | GET | `api/v1/level2/depth20` |
-| [getPartOrderBookLevel2Depth100()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L237) |  | GET | `api/v1/level2/depth100` |
-| [getMarketTrades()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L243) |  | GET | `api/v1/trade/history` |
-| [getKlines()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L249) |  | GET | `api/v1/kline/query` |
-| [getInterestRates()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L255) |  | GET | `api/v1/interest/query` |
-| [getIndex()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L264) |  | GET | `api/v1/index/query` |
-| [getMarkPrice()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L273) |  | GET | `api/v1/mark-price/{symbol}/current` |
-| [getPremiumIndex()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L279) |  | GET | `api/v1/premium/query` |
-| [get24HourTransactionVolume()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L288) |  | GET | `api/v1/trade-statistics` |
-| [submitOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L302) | :closed_lock_with_key:  | POST | `api/v1/orders` |
-| [submitNewOrderTest()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L311) | :closed_lock_with_key:  | POST | `api/v1/orders/test` |
-| [cancelOrderById()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L318) | :closed_lock_with_key:  | DELETE | `api/v1/orders/{orderId}` |
-| [cancelOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L324) | :closed_lock_with_key:  | DELETE | `api/v1/orders/client-order/{clientOid}` |
-| [batchCancelOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L330) | :closed_lock_with_key:  | DELETE | `api/v1/orders/multi-cancel` |
-| [submitSLTPOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L338) | :closed_lock_with_key:  | POST | `api/v1/st-orders` |
-| [submitMultipleOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L347) | :closed_lock_with_key:  | POST | `api/v1/orders/multi` |
-| [cancelAllOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L353) | :closed_lock_with_key:  | DELETE | `api/v1/orders` |
-| [cancelAllStopOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L359) | :closed_lock_with_key:  | DELETE | `api/v1/stopOrders` |
-| [getOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L365) | :closed_lock_with_key:  | GET | `api/v1/orders` |
-| [getStopOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L371) | :closed_lock_with_key:  | GET | `api/v1/stopOrders` |
-| [getRecentOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L377) | :closed_lock_with_key:  | GET | `api/v1/recentDoneOrders` |
-| [getOrderByOrderId()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L383) | :closed_lock_with_key:  | GET | `api/v1/orders/{orderId}` |
-| [getOrderByClientOrderId()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L389) | :closed_lock_with_key:  | GET | `api/v1/orders/byClientOid` |
-| [getFills()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L407) | :closed_lock_with_key:  | GET | `api/v1/fills` |
-| [getRecentFills()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L418) | :closed_lock_with_key:  | GET | `api/v1/recentFills` |
-| [getOpenOrderStatistics()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L424) | :closed_lock_with_key:  | GET | `api/v1/openOrderStatistics` |
-| [getMaxOpenSize()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L436) | :closed_lock_with_key:  | GET | `api/v2/getMaxOpenSize` |
-| [getPosition()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L442) | :closed_lock_with_key:  | GET | `api/v1/position` |
-| [getPositions()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L448) | :closed_lock_with_key:  | GET | `api/v1/positions` |
-| [getHistoryPositions()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L454) | :closed_lock_with_key:  | GET | `api/v1/history-positions` |
-| [updateAutoDepositStatus()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L464) | :closed_lock_with_key:  | POST | `api/v1/position/margin/auto-deposit-status` |
-| [getMaxWithdrawMargin()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L474) | :closed_lock_with_key:  | GET | `api/v1/margin/maxWithdrawMargin` |
-| [withdrawMargin()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L480) | :closed_lock_with_key:  | POST | `api/v1/margin/withdrawMargin` |
-| [depositMargin()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L487) | :closed_lock_with_key:  | POST | `api/v1/position/margin/deposit-margin` |
-| [getMarginMode()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L495) | :closed_lock_with_key:  | GET | `api/v2/position/getMarginMode` |
-| [updateMarginMode()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L504) | :closed_lock_with_key:  | POST | `api/v2/position/changeMarginMode` |
-| [getCrossMarginLeverage()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L516) | :closed_lock_with_key:  | GET | `api/v2/getCrossUserLeverage` |
-| [changeCrossMarginLeverage()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L525) | :closed_lock_with_key:  | POST | `api/v2/changeCrossUserLeverage` |
-| [getRiskLimitLevel()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L543) | :closed_lock_with_key:  | GET | `api/v1/contracts/risk-limit/{symbol}` |
-| [updateRiskLimitLevel()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L549) | :closed_lock_with_key:  | POST | `api/v1/position/risk-limit-level/change` |
-| [getFundingRate()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L562) |  | GET | `api/v1/funding-rate/{symbol}/current` |
-| [getFundingRates()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L568) |  | GET | `api/v1/contract/funding-rates` |
-| [getFundingHistory()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L574) | :closed_lock_with_key:  | GET | `api/v1/funding-history` |
-| [getBrokerRebateOrderDownloadLink()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L588) | :closed_lock_with_key:  | GET | `api/v1/broker/api/rebase/download` |
-| [getPublicWSConnectionToken()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L602) |  | POST | `api/v1/bullet-public` |
-| [getPrivateWSConnectionToken()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L606) | :closed_lock_with_key:  | POST | `api/v1/bullet-private` |
+| [getServiceStatus()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L101) |  | GET | `api/v1/status` |
+| [getTransactions()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L110) | :closed_lock_with_key:  | GET | `api/v1/transaction-history` |
+| [getSubAPIs()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L123) | :closed_lock_with_key:  | GET | `api/v1/sub/api-key` |
+| [createSubAPI()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L129) | :closed_lock_with_key:  | POST | `api/v1/sub/api-key` |
+| [updateSubAPI()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L135) | :closed_lock_with_key:  | POST | `api/v1/sub/api-key/update` |
+| [deleteSubAPI()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L141) | :closed_lock_with_key:  | DELETE | `api/v1/sub/api-key` |
+| [getBalance()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L154) | :closed_lock_with_key:  | GET | `api/v1/account-overview` |
+| [getSubBalances()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L160) | :closed_lock_with_key:  | GET | `api/v1/account-overview-all` |
+| [submitTransferOut()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L173) | :closed_lock_with_key:  | POST | `api/v3/transfer-out` |
+| [submitTransferIn()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L179) | :closed_lock_with_key:  | POST | `api/v1/transfer-in` |
+| [getTransfers()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L183) | :closed_lock_with_key:  | GET | `api/v1/transfer-list` |
+| [getTradingPairFee()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L193) | :closed_lock_with_key:  | GET | `api/v1/trade-fees` |
+| [getSymbols()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L209) |  | GET | `api/v1/contracts/active` |
+| [getSymbol()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L213) |  | GET | `api/v1/contracts/{symbol}` |
+| [getTicker()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L219) |  | GET | `api/v1/ticker` |
+| [getTickers()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L225) |  | GET | `api/v1/allTickers` |
+| [getFullOrderBookLevel2()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L229) |  | GET | `api/v1/level2/snapshot` |
+| [getPartOrderBookLevel2Depth20()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L235) |  | GET | `api/v1/level2/depth20` |
+| [getPartOrderBookLevel2Depth100()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L241) |  | GET | `api/v1/level2/depth100` |
+| [getMarketTrades()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L247) |  | GET | `api/v1/trade/history` |
+| [getKlines()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L253) |  | GET | `api/v1/kline/query` |
+| [getInterestRates()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L259) |  | GET | `api/v1/interest/query` |
+| [getIndex()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L268) |  | GET | `api/v1/index/query` |
+| [getMarkPrice()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L277) |  | GET | `api/v1/mark-price/{symbol}/current` |
+| [getPremiumIndex()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L283) |  | GET | `api/v1/premium/query` |
+| [get24HourTransactionVolume()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L292) |  | GET | `api/v1/trade-statistics` |
+| [submitOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L306) | :closed_lock_with_key:  | POST | `api/v1/orders` |
+| [submitNewOrderTest()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L315) | :closed_lock_with_key:  | POST | `api/v1/orders/test` |
+| [cancelOrderById()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L322) | :closed_lock_with_key:  | DELETE | `api/v1/orders/{orderId}` |
+| [cancelOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L328) | :closed_lock_with_key:  | DELETE | `api/v1/orders/client-order/{clientOid}` |
+| [batchCancelOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L334) | :closed_lock_with_key:  | DELETE | `api/v1/orders/multi-cancel` |
+| [submitSLTPOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L342) | :closed_lock_with_key:  | POST | `api/v1/st-orders` |
+| [submitMultipleOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L351) | :closed_lock_with_key:  | POST | `api/v1/orders/multi` |
+| [cancelAllOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L357) | :closed_lock_with_key:  | DELETE | `api/v1/orders` |
+| [cancelAllStopOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L363) | :closed_lock_with_key:  | DELETE | `api/v1/stopOrders` |
+| [getOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L369) | :closed_lock_with_key:  | GET | `api/v1/orders` |
+| [getStopOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L375) | :closed_lock_with_key:  | GET | `api/v1/stopOrders` |
+| [getRecentOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L381) | :closed_lock_with_key:  | GET | `api/v1/recentDoneOrders` |
+| [getOrderByOrderId()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L387) | :closed_lock_with_key:  | GET | `api/v1/orders/{orderId}` |
+| [getOrderByClientOrderId()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L393) | :closed_lock_with_key:  | GET | `api/v1/orders/byClientOid` |
+| [getFills()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L411) | :closed_lock_with_key:  | GET | `api/v1/fills` |
+| [getRecentFills()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L422) | :closed_lock_with_key:  | GET | `api/v1/recentFills` |
+| [getOpenOrderStatistics()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L428) | :closed_lock_with_key:  | GET | `api/v1/openOrderStatistics` |
+| [getMaxOpenSize()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L440) | :closed_lock_with_key:  | GET | `api/v2/getMaxOpenSize` |
+| [getPosition()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L446) | :closed_lock_with_key:  | GET | `api/v1/position` |
+| [getPositions()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L452) | :closed_lock_with_key:  | GET | `api/v1/positions` |
+| [getHistoryPositions()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L458) | :closed_lock_with_key:  | GET | `api/v1/history-positions` |
+| [updateAutoDepositStatus()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L468) | :closed_lock_with_key:  | POST | `api/v1/position/margin/auto-deposit-status` |
+| [getMaxWithdrawMargin()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L478) | :closed_lock_with_key:  | GET | `api/v1/margin/maxWithdrawMargin` |
+| [withdrawMargin()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L484) | :closed_lock_with_key:  | POST | `api/v1/margin/withdrawMargin` |
+| [depositMargin()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L491) | :closed_lock_with_key:  | POST | `api/v1/position/margin/deposit-margin` |
+| [getMarginMode()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L499) | :closed_lock_with_key:  | GET | `api/v2/position/getMarginMode` |
+| [updateMarginMode()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L508) | :closed_lock_with_key:  | POST | `api/v2/position/changeMarginMode` |
+| [getCrossMarginLeverage()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L520) | :closed_lock_with_key:  | GET | `api/v2/getCrossUserLeverage` |
+| [changeCrossMarginLeverage()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L529) | :closed_lock_with_key:  | POST | `api/v2/changeCrossUserLeverage` |
+| [getRiskLimitLevel()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L547) | :closed_lock_with_key:  | GET | `api/v1/contracts/risk-limit/{symbol}` |
+| [updateRiskLimitLevel()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L553) | :closed_lock_with_key:  | POST | `api/v1/position/risk-limit-level/change` |
+| [getFundingRate()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L566) |  | GET | `api/v1/funding-rate/{symbol}/current` |
+| [getFundingRates()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L572) |  | GET | `api/v1/contract/funding-rates` |
+| [getFundingHistory()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L578) | :closed_lock_with_key:  | GET | `api/v1/funding-history` |
+| [getBrokerRebateOrderDownloadLink()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L592) | :closed_lock_with_key:  | GET | `api/v1/broker/api/rebase/download` |
+| [getPublicWSConnectionToken()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L606) |  | POST | `api/v1/bullet-public` |
+| [getPrivateWSConnectionToken()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L610) | :closed_lock_with_key:  | POST | `api/v1/bullet-private` |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kucoin-api",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kucoin-api",
-      "version": "1.0.16",
+      "version": "1.0.17",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kucoin-api",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "description": "Complete & robust Node.js SDK for Kucoin's REST APIs and WebSockets, with TypeScript & strong end to end tests.",
   "scripts": {
     "clean": "rm -rf dist",

--- a/src/types/request/spot-funding.ts
+++ b/src/types/request/spot-funding.ts
@@ -87,7 +87,7 @@ export interface SubmitWithdrawV3Request {
 
 export interface GetTransferableRequest {
   currency: string;
-  type: 'MAIN' | 'TRADE' | 'TRADE_HF' | 'MARGIN' | 'ISOLATED';
+  type: 'MAIN' | 'TRADE' | 'TRADE_HF' | 'MARGIN' | 'ISOLATED' | 'OPTION';
   tag?: string;
 }
 
@@ -104,7 +104,8 @@ export interface FlexTransferRequest {
     | 'ISOLATED'
     | 'TRADE_HF'
     | 'MARGIN_V2'
-    | 'ISOLATED_V2';
+    | 'ISOLATED_V2'
+    | 'OPTION';
   fromAccountTag?: string;
   type: 'INTERNAL' | 'PARENT_TO_SUB' | 'SUB_TO_PARENT';
   toUserId?: string;
@@ -116,7 +117,8 @@ export interface FlexTransferRequest {
     | 'ISOLATED'
     | 'TRADE_HF'
     | 'MARGIN_V2'
-    | 'ISOLATED_V2';
+    | 'ISOLATED_V2'
+    | 'OPTION';
   toAccountTag?: string;
 }
 
@@ -125,8 +127,20 @@ export interface submitTransferMasterSubRequest {
   currency: string;
   amount: string;
   direction: 'OUT' | 'IN';
-  accountType?: 'MAIN' | 'TRADE' | 'TRADE_HF' | 'MARGIN' | 'CONTRACT';
-  subAccountType?: 'MAIN' | 'TRADE' | 'TRADE_HF' | 'MARGIN' | 'CONTRACT';
+  accountType?:
+    | 'MAIN'
+    | 'TRADE'
+    | 'TRADE_HF'
+    | 'MARGIN'
+    | 'CONTRACT'
+    | 'OPTION';
+  subAccountType?:
+    | 'MAIN'
+    | 'TRADE'
+    | 'TRADE_HF'
+    | 'MARGIN'
+    | 'CONTRACT'
+    | 'OPTION';
   subUserId: string;
 }
 
@@ -141,7 +155,8 @@ export interface InnerTransferRequest {
     | 'isolated'
     | 'margin_v2'
     | 'isolated_v2'
-    | 'contract';
+    | 'contract'
+    | 'option';
   to:
     | 'main'
     | 'trade'
@@ -150,7 +165,8 @@ export interface InnerTransferRequest {
     | 'isolated'
     | 'margin_v2'
     | 'isolated_v2'
-    | 'contract';
+    | 'contract'
+    | 'option';
   amount: string;
   fromTag?: string;
   toTag?: string;

--- a/src/types/response/futures.types.ts
+++ b/src/types/response/futures.types.ts
@@ -53,6 +53,7 @@ export interface AccountBalance {
   frozenFunds: number; // Frozen funds for withdrawal and out-transfer
   availableBalance: number; // Available balance
   currency: string; // currency code
+  riskRatio: number; // Cross margin risk ratio
 }
 
 export interface AccountSummary {
@@ -177,6 +178,7 @@ export interface FuturesSymbolInfo {
   highPrice: number; // 24H High
   priceChgPct: number; // 24H Change%
   priceChg: number; // 24H Change
+  supportCross: boolean; // Support cross margin or not
 }
 
 export interface TickerDetail {


### PR DESCRIPTION
1. Spot Modify: The limit on the number of websocket connections that can be established simultaneously per user ID: expanded from 50 to 150
2. Spot Modify: GET /v1/accounts/transferable endpoint，request param type add OPTION enums
3. Spot Modify: POST /v2/accounts/inner-transfer endpoint，request param from、to add option enums
4. Spot Modify POST /v2/accounts/sub-transfer endpoint，request param accountType、subAccountType add OPTION enums
5. Spot Modify: POST /v3/accounts/universal-transfer endpoint，request param fromAccountType、toAccountType add OPTION enums
6. Futures Modify: GET /api/v1/contracts/{symbol} endpoint, add supportCross response param
7. Futures Modify: GET /api/v1/contracts/active endpoint, add supportCross response param
8. Futures Modify: GET /api/v1/account-overview endpoint, add riskRatio response param