### PR TITLE
feat(ws): add support for custom agent in WebSocket connection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kucoin-api",
-  "version": "1.0.18",
+  "version": "1.0.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kucoin-api",
-      "version": "1.0.18",
+      "version": "1.0.20",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kucoin-api",
-  "version": "1.0.18",
+  "version": "1.0.20",
   "description": "Complete & robust Node.js SDK for Kucoin's REST APIs and WebSockets, with TypeScript & strong end to end tests.",
   "scripts": {
     "clean": "rm -rf dist",

--- a/src/lib/BaseWSClient.ts
+++ b/src/lib/BaseWSClient.ts
@@ -411,7 +411,9 @@ export abstract class BaseWebsocketClient<
       wsKey,
     });
 
-    const ws = new WebSocket(url, undefined);
+    const { protocols = [], ...wsOptions } = this.options.wsOptions || {};
+
+    const ws = new WebSocket(url, protocols, wsOptions);
 
     ws.onopen = (event: any) => this.onWsOpen(event, wsKey);
     ws.onmessage = (event: any) => this.onWsMessage(event, wsKey, ws);

--- a/src/types/websockets/client.ts
+++ b/src/types/websockets/client.ts
@@ -21,8 +21,12 @@ export interface WSClientConfigurableOptions {
   /** Delay in milliseconds before respawning the connection */
   reconnectTimeout?: number;
 
-  wsUrl?: string;
+  wsOptions?: {
+    protocols?: string[];
+    agent?: any;
+  };
 
+  wsUrl?: string;
   /**
    * Allows you to provide a custom "signMessage" function, e.g. to use node's much faster createHmac method
    *


### PR DESCRIPTION
- Updated WebSocket initialization to use a custom  if provided in options.
- Ensures that users can pass an HTTP or HTTPS agent for advanced connection configurations.

## Summary
<!-- Add a brief description of the pr: -->

## Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
