### PR TITLE
fix(): adjusted type definitions for getSymbol and getSymbols (spot)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kucoin-api",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "description": "Complete & robust Node.js SDK for Kucoin's REST APIs and WebSockets, with TypeScript & strong end to end tests.",
   "scripts": {
     "clean": "rm -rf dist",

--- a/src/types/response/spot-trading.ts
+++ b/src/types/response/spot-trading.ts
@@ -45,7 +45,9 @@ export interface SymbolInfo {
   name: string;
   baseCurrency: string;
   quoteCurrency: string;
+  feeCategory: number;
   feeCurrency: string;
+  makerFeeCoefficient: string;
   market: string;
   baseMinSize: string;
   quoteMinSize: string;
@@ -56,6 +58,8 @@ export interface SymbolInfo {
   priceIncrement: string;
   priceLimitRate: string;
   minFunds: string;
+  st: boolean;
+  takerFeeCoefficient: string;
   isMarginEnabled: boolean;
   enableTrading: boolean;
 }


### PR DESCRIPTION
## Summary
Adjusted type definitions for `SymbolInfo` to align with the official documentation. Added missing.

## Additional Information
- No breaking changes introduced.
- Fields added to match the official API documentation:
  - `feeCategory`, `makerFeeCoefficient`, `st` and `takerFeeCoefficient`

Endpoint doc.: https://www.kucoin.com/docs-new/rest/spot-trading/market-data/get-symbol