### PR TITLE
Ensures WebSocket connections respect configured proxy or custom agents

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kucoin-api",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kucoin-api",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kucoin-api",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Complete & robust Node.js SDK for Kucoin's REST APIs and WebSockets, with TypeScript & strong end to end tests.",
   "scripts": {
     "clean": "rm -rf dist",

--- a/src/WebsocketClient.ts
+++ b/src/WebsocketClient.ts
@@ -1,4 +1,4 @@
-import { RestClientOptions } from 'lib/requestUtils.js';
+import { RestClientOptions } from './lib/requestUtils.js';
 
 import { FuturesClient } from './FuturesClient.js';
 import { BaseWebsocketClient, EmittableEvent } from './lib/BaseWSClient.js';

--- a/src/WebsocketClient.ts
+++ b/src/WebsocketClient.ts
@@ -1,3 +1,5 @@
+import { RestClientOptions } from 'lib/requestUtils.js';
+
 import { FuturesClient } from './FuturesClient.js';
 import { BaseWebsocketClient, EmittableEvent } from './lib/BaseWSClient.js';
 import { neverGuard } from './lib/misc-util.js';
@@ -61,11 +63,10 @@ export class WebsocketClient extends BaseWebsocketClient<WsKey> {
         return this.RESTClientCache[clientType];
       }
 
-      this.RESTClientCache[clientType] = new SpotClient({
-        apiKey: this.options.apiKey,
-        apiSecret: this.options.apiSecret,
-        apiPassphrase: this.options.apiPassphrase,
-      });
+      this.RESTClientCache[clientType] = new SpotClient(
+        this.getRestClientOptions(),
+        this.options.requestOptions,
+      );
       return this.RESTClientCache[clientType];
     }
 
@@ -75,17 +76,24 @@ export class WebsocketClient extends BaseWebsocketClient<WsKey> {
         return this.RESTClientCache[clientType];
       }
 
-      this.RESTClientCache[clientType] = new FuturesClient({
-        apiKey: this.options.apiKey,
-        apiSecret: this.options.apiSecret,
-        apiPassphrase: this.options.apiPassphrase,
-      });
+      this.RESTClientCache[clientType] = new FuturesClient(
+        this.getRestClientOptions(),
+        this.options.requestOptions,
+      );
       return this.RESTClientCache[clientType];
     }
 
     throw new Error(`Unhandled WsKey: "${wsKey}"`);
   }
 
+  private getRestClientOptions(): RestClientOptions {
+    return {
+      apiKey: this.options.apiKey,
+      apiSecret: this.options.apiSecret,
+      ...this.options,
+      ...this.options.restOptions,
+    };
+  }
   private async getWSConnectionInfo(
     wsKey: WsKey,
   ): Promise<APISuccessResponse<WsConnectionInfo>> {

--- a/src/lib/BaseRestClient.ts
+++ b/src/lib/BaseRestClient.ts
@@ -135,9 +135,16 @@ export abstract class BaseRestClient {
   }
 
   /**
-   * Timestamp used to sign the request. Override this method to implement your own timestamp/sync mechanism
+   * Generates a timestamp for signing API requests.
+   *
+   * This method can be overridden or customized using `customTimestampFn`
+   * to implement a custom timestamp synchronization mechanism.
+   * If no custom function is provided, it defaults to the current system time.
    */
-  getSignTimestampMs(): number {
+  private getSignTimestampMs(): number {
+    if (typeof this.options.customTimestampFn === 'function') {
+      return this.options.customTimestampFn();
+    }
     return Date.now();
   }
 

--- a/src/lib/requestUtils.ts
+++ b/src/lib/requestUtils.ts
@@ -40,6 +40,8 @@ export interface RestClientOptions {
 
   /** Default: true. whether to try and post-process request exceptions (and throw them). */
   parseExceptions?: boolean;
+
+  customTimestampFn?: () => number;
 }
 
 export function serializeParams<T extends Record<string, any> | undefined = {}>(

--- a/src/types/websockets/client.ts
+++ b/src/types/websockets/client.ts
@@ -1,3 +1,6 @@
+import { AxiosRequestConfig } from 'axios';
+import { RestClientOptions } from 'lib/requestUtils';
+
 /** General configuration for the WebsocketClient */
 export interface WSClientConfigurableOptions {
   /** Your API key */
@@ -20,6 +23,9 @@ export interface WSClientConfigurableOptions {
 
   /** Delay in milliseconds before respawning the connection */
   reconnectTimeout?: number;
+
+  restOptions?: RestClientOptions;
+  requestOptions?: AxiosRequestConfig;
 
   wsOptions?: {
     protocols?: string[];

--- a/src/types/websockets/client.ts
+++ b/src/types/websockets/client.ts
@@ -1,5 +1,5 @@
 import { AxiosRequestConfig } from 'axios';
-import { RestClientOptions } from 'lib/requestUtils';
+import { RestClientOptions } from '../../lib/requestUtils';
 
 /** General configuration for the WebsocketClient */
 export interface WSClientConfigurableOptions {

--- a/src/types/websockets/client.ts
+++ b/src/types/websockets/client.ts
@@ -1,5 +1,6 @@
 import { AxiosRequestConfig } from 'axios';
-import { RestClientOptions } from '../../lib/requestUtils';
+
+import { RestClientOptions } from '../../lib/requestUtils.js';
 
 /** General configuration for the WebsocketClient */
 export interface WSClientConfigurableOptions {


### PR DESCRIPTION
- Updated `getRESTClient` to pass `httpAgent` and `httpsAgent` during `SpotClient` and `FuturesClient` initialization.
- Ensures WebSocket connections respect configured proxy or custom agents.
- Improves network request handling and potential performance with agent reuse.