### PR TITLE
feat(v2.1.4): added new endpoints, updated types for submitting spot order

### DIFF
--- a/docs/endpointFunctionList.md
+++ b/docs/endpointFunctionList.md
@@ -49,164 +49,166 @@ This table includes all endpoints from the official Exchange API docs and corres
 
 | Function | AUTH | HTTP Method | Endpoint |
 | -------- | :------: | :------: | -------- |
-| [getMyIp()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L262) |  | GET | `api/v1/ip` |
-| [getServiceStatus()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L270) |  | GET | `api/v1/status` |
-| [getAccountSummary()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L285) | :closed_lock_with_key:  | GET | `api/v2/user-info` |
-| [getApikeyInfo()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L294) | :closed_lock_with_key:  | GET | `api/v1/user/api-key` |
-| [getUserType()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L314) | :closed_lock_with_key:  | GET | `api/v1/hf/accounts/opened` |
-| [getBalances()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L323) | :closed_lock_with_key:  | GET | `api/v1/accounts` |
-| [getAccountDetail()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L334) | :closed_lock_with_key:  | GET | `api/v1/accounts/{accountId}` |
-| [getMarginBalance()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L345) | :closed_lock_with_key:  | GET | `api/v3/margin/accounts` |
-| [getIsolatedMarginBalance()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L356) | :closed_lock_with_key:  | GET | `api/v3/isolated/accounts` |
-| [getTransactions()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L369) | :closed_lock_with_key:  | GET | `api/v1/accounts/ledgers` |
-| [getHFTransactions()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L381) | :closed_lock_with_key:  | GET | `api/v1/hf/accounts/ledgers` |
-| [getHFMarginTransactions()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L393) | :closed_lock_with_key:  | GET | `api/v3/hf/margin/account/ledgers` |
-| [createSubAccount()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L410) | :closed_lock_with_key:  | POST | `api/v2/sub/user/created` |
-| [enableSubAccountMargin()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L421) | :closed_lock_with_key:  | POST | `api/v3/sub/user/margin/enable` |
-| [enableSubAccountFutures()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L431) | :closed_lock_with_key:  | POST | `api/v3/sub/user/futures/enable` |
-| [getSubAccountsV2()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L440) | :closed_lock_with_key:  | GET | `api/v2/sub/user` |
-| [getSubAccountBalance()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L451) | :closed_lock_with_key:  | GET | `api/v1/sub-accounts/{subUserId}` |
-| [getSubAccountBalancesV2()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L464) | :closed_lock_with_key:  | GET | `api/v2/sub-accounts` |
-| [createSubAPI()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L482) | :closed_lock_with_key:  | POST | `api/v1/sub/api-key` |
-| [updateSubAPI()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L493) | :closed_lock_with_key:  | POST | `api/v1/sub/api-key/update` |
-| [getSubAPIs()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L505) | :closed_lock_with_key:  | GET | `api/v1/sub/api-key` |
-| [deleteSubAPI()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L517) | :closed_lock_with_key:  | DELETE | `api/v1/sub/api-key` |
-| [createDepositAddressV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L534) | :closed_lock_with_key:  | POST | `api/v3/deposit-address/create` |
-| [getDepositAddressesV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L546) | :closed_lock_with_key:  | GET | `api/v3/deposit-addresses` |
-| [getDeposits()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L560) | :closed_lock_with_key:  | GET | `api/v1/deposits` |
-| [getWithdrawalQuotas()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L577) | :closed_lock_with_key:  | GET | `api/v1/withdrawals/quotas` |
-| [submitWithdrawV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L589) | :closed_lock_with_key:  | POST | `api/v3/withdrawals` |
-| [cancelWithdrawal()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L602) | :closed_lock_with_key:  | DELETE | `api/v1/withdrawals/{withdrawalId}` |
-| [getWithdrawals()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L614) | :closed_lock_with_key:  | GET | `api/v1/withdrawals` |
-| [getTransferable()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L631) | :closed_lock_with_key:  | GET | `api/v1/accounts/transferable` |
-| [submitFlexTransfer()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L642) | :closed_lock_with_key:  | POST | `api/v3/accounts/universal-transfer` |
-| [getBasicUserFee()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L661) | :closed_lock_with_key:  | GET | `api/v1/base-fee` |
-| [getTradingPairFee()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L677) | :closed_lock_with_key:  | GET | `api/v1/trade-fees` |
-| [getAnnouncements()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L700) |  | GET | `api/v3/announcements` |
-| [getCurrency()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L711) |  | GET | `api/v3/currencies/{currency}` |
-| [getCurrencies()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L723) |  | GET | `api/v3/currencies` |
-| [getSymbol()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L733) |  | GET | `api/v2/symbols/{symbol}` |
-| [getSymbols()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L745) |  | GET | `api/v2/symbols` |
-| [getTicker()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L758) |  | GET | `api/v1/market/orderbook/level1` |
-| [getTickers()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L767) |  | GET | `api/v1/market/allTickers` |
-| [getTradeHistories()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L778) |  | GET | `api/v1/market/histories` |
-| [getKlines()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L790) |  | GET | `api/v1/market/candles` |
-| [getOrderBookLevel20()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L801) |  | GET | `api/v1/market/orderbook/level2_20` |
-| [getOrderBookLevel100()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L812) |  | GET | `api/v1/market/orderbook/level2_100` |
-| [getFullOrderBook()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L823) | :closed_lock_with_key:  | GET | `api/v3/market/orderbook/level2` |
-| [getFiatPrice()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L834) |  | GET | `api/v1/prices` |
-| [get24hrStats()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L843) |  | GET | `api/v1/market/stats` |
-| [getMarkets()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L854) |  | GET | `api/v1/markets` |
-| [submitHFOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L871) | :closed_lock_with_key:  | POST | `api/v1/hf/orders` |
-| [submitHFOrderSync()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L887) | :closed_lock_with_key:  | POST | `api/v1/hf/orders/sync` |
-| [submitHFOrderTest()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L899) | :closed_lock_with_key:  | POST | `api/v1/hf/orders/test` |
-| [submitHFMultipleOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L908) | :closed_lock_with_key:  | POST | `api/v1/hf/orders/multi` |
-| [submitHFMultipleOrdersSync()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L920) | :closed_lock_with_key:  | POST | `api/v1/hf/orders/multi/sync` |
-| [cancelHFOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L932) | :closed_lock_with_key:  | DELETE | `api/v1/hf/orders/{orderId}` |
-| [cancelHFOrderSync()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L946) | :closed_lock_with_key:  | DELETE | `api/v1/hf/orders/sync/{orderId}` |
-| [cancelHFOrderByClientOId()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L962) | :closed_lock_with_key:  | DELETE | `api/v1/hf/orders/client-order/{clientOid}` |
-| [cancelHFOrderSyncByClientOId()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L982) | :closed_lock_with_key:  | DELETE | `api/v1/hf/orders/sync/client-order/{clientOid}` |
-| [cancelHFOrdersNumber()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L997) | :closed_lock_with_key:  | DELETE | `api/v1/hf/orders/cancel/{orderId}` |
-| [cancelHFAllOrdersBySymbol()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1012) | :closed_lock_with_key:  | DELETE | `api/v1/hf/orders` |
-| [cancelHFAllOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1023) | :closed_lock_with_key:  | DELETE | `api/v1/hf/orders/cancelAll` |
-| [updateHFOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1032) | :closed_lock_with_key:  | POST | `api/v1/hf/orders/alter` |
-| [getHFOrderDetailsByOrderId()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1046) | :closed_lock_with_key:  | GET | `api/v1/hf/orders/{orderId}` |
-| [getHFOrderDetailsByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1058) | :closed_lock_with_key:  | GET | `api/v1/hf/orders/client-order/{clientOid}` |
-| [getHFActiveSymbols()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1073) | :closed_lock_with_key:  | GET | `api/v1/hf/orders/active/symbols` |
-| [getHFActiveOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1087) | :closed_lock_with_key:  | GET | `api/v1/hf/orders/active` |
-| [getHFCompletedOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1098) | :closed_lock_with_key:  | GET | `api/v1/hf/orders/done` |
-| [getHFFilledOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1112) | :closed_lock_with_key:  | GET | `api/v1/hf/fills` |
-| [cancelHFOrderAutoSettingQuery()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1127) | :closed_lock_with_key:  | GET | `api/v1/hf/orders/dead-cancel-all/query` |
-| [cancelHFOrderAutoSetting()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1140) | :closed_lock_with_key:  | POST | `api/v1/hf/orders/dead-cancel-all` |
-| [submitStopOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1157) | :closed_lock_with_key:  | POST | `api/v1/stop-order` |
-| [cancelStopOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1168) | :closed_lock_with_key:  | DELETE | `api/v1/stop-order/cancelOrderByClientOid` |
-| [cancelStopOrderById()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1188) | :closed_lock_with_key:  | DELETE | `api/v1/stop-order/{orderId}` |
-| [cancelStopOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1201) | :closed_lock_with_key:  | DELETE | `api/v1/stop-order/cancel` |
-| [getStopOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1214) | :closed_lock_with_key:  | GET | `api/v1/stop-order` |
-| [getStopOrderByOrderId()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1227) | :closed_lock_with_key:  | GET | `api/v1/stop-order/{orderId}` |
-| [getStopOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1238) | :closed_lock_with_key:  | GET | `api/v1/stop-order/queryOrderByClientOid` |
-| [submitOCOOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1249) | :closed_lock_with_key:  | POST | `api/v3/oco/order` |
-| [cancelOCOOrderById()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1261) | :closed_lock_with_key:  | DELETE | `api/v3/oco/order/{orderId}` |
-| [cancelOCOOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1274) | :closed_lock_with_key:  | DELETE | `api/v3/oco/client-order/{clientOid}` |
-| [cancelMultipleOCOOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1287) | :closed_lock_with_key:  | DELETE | `api/v3/oco/orders` |
-| [getOCOOrderByOrderId()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1303) | :closed_lock_with_key:  | GET | `api/v3/oco/order/{orderId}` |
-| [getOCOOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1314) | :closed_lock_with_key:  | GET | `api/v3/oco/client-order/{clientOid}` |
-| [getOCOOrderDetails()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1325) | :closed_lock_with_key:  | GET | `api/v3/oco/order/details/{orderId}` |
-| [getOCOOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1336) | :closed_lock_with_key:  | GET | `api/v3/oco/orders` |
-| [getMarginActivePairsV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1353) | :closed_lock_with_key:  | GET | `api/v3/margin/symbols` |
-| [getMarginConfigInfo()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1365) |  | GET | `api/v1/margin/config` |
-| [getMarginLeveragedToken()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1374) | :closed_lock_with_key:  | GET | `api/v3/etf/info` |
-| [getMarginMarkPrices()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1385) |  | GET | `api/v3/mark-price/all-symbols` |
-| [getMarginMarkPrice()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1394) |  | GET | `api/v1/mark-price/{symbol}/current` |
-| [getIsolatedMarginSymbolsConfig()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1404) | :closed_lock_with_key:  | GET | `api/v1/isolated/symbols` |
-| [submitHFMarginOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1421) | :closed_lock_with_key:  | POST | `api/v3/hf/margin/order` |
-| [submitHFMarginOrderTest()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1431) | :closed_lock_with_key:  | POST | `api/v3/hf/margin/order/test` |
-| [cancelHFMarginOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1441) | :closed_lock_with_key:  | DELETE | `api/v3/hf/margin/orders/{orderId}` |
-| [cancelHFMarginOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1457) | :closed_lock_with_key:  | DELETE | `api/v3/hf/margin/orders/client-order/{clientOid}` |
-| [cancelHFAllMarginOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1475) | :closed_lock_with_key:  | DELETE | `api/v3/hf/margin/orders` |
-| [getHFMarginOpenSymbols()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1487) | :closed_lock_with_key:  | GET | `api/v3/hf/margin/order/active/symbols` |
-| [getHFActiveMarginOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1498) | :closed_lock_with_key:  | GET | `api/v3/hf/margin/orders/active` |
-| [getHFMarginFilledOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1509) | :closed_lock_with_key:  | GET | `api/v3/hf/margin/orders/done` |
-| [getHFMarginFills()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1523) | :closed_lock_with_key:  | GET | `api/v3/hf/margin/fills` |
-| [getHFMarginOrderByOrderId()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1537) | :closed_lock_with_key:  | GET | `api/v3/hf/margin/orders/{orderId}` |
-| [getHFMarginOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1548) | :closed_lock_with_key:  | GET | `api/v3/hf/margin/orders/client-order/{clientOid}?symbol={symbol}` |
-| [marginBorrowV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1568) | :closed_lock_with_key:  | POST | `api/v3/margin/borrow` |
-| [getMarginBorrowHistoryV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1579) | :closed_lock_with_key:  | GET | `api/v3/margin/borrow` |
-| [marginRepayV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1590) | :closed_lock_with_key:  | POST | `api/v3/margin/repay` |
-| [getMarginRepayHistoryV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1601) | :closed_lock_with_key:  | GET | `api/v3/margin/repay` |
-| [getMarginInterestRecordsV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1612) | :closed_lock_with_key:  | GET | `api/v3/margin/interest` |
-| [updateMarginLeverageV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1623) | :closed_lock_with_key:  | POST | `api/v3/position/update-user-leverage` |
-| [getLendingCurrencyV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1642) |  | GET | `api/v3/project/list` |
-| [getLendingInterestRateV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1653) |  | GET | `api/v3/project/marketInterestRate` |
-| [submitLendingSubscriptionV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1669) | :closed_lock_with_key:  | POST | `api/v3/purchase` |
-| [updateLendingSubscriptionOrdersV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1686) | :closed_lock_with_key:  | POST | `api/v3/lend/purchase/update` |
-| [getLendingSubscriptionOrdersV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1697) | :closed_lock_with_key:  | GET | `api/v3/purchase/orders` |
-| [submitLendingRedemptionV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1708) | :closed_lock_with_key:  | POST | `api/v3/redeem` |
-| [getLendingRedemptionOrdersV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1725) | :closed_lock_with_key:  | GET | `api/v3/redeem/orders` |
-| [getMarginRiskLimitConfig()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1742) | :closed_lock_with_key:  | GET | `api/v3/margin/currencies` |
-| [subscribeEarnFixedIncome()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1766) | :closed_lock_with_key:  | POST | `api/v1/earn/orders` |
-| [getEarnRedeemPreview()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1777) | :closed_lock_with_key:  | GET | `api/v1/earn/redeem-preview` |
-| [submitRedemption()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1788) | :closed_lock_with_key:  | DELETE | `api/v1/earn/orders` |
-| [getEarnSavingsProducts()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1799) | :closed_lock_with_key:  | GET | `api/v1/earn/saving/products` |
-| [getEarnPromotionProducts()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1810) | :closed_lock_with_key:  | GET | `api/v1/earn/promotion/products` |
-| [getEarnFixedIncomeHoldAssets()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1821) | :closed_lock_with_key:  | GET | `api/v1/earn/hold-assets` |
-| [getEarnStakingProducts()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1832) | :closed_lock_with_key:  | GET | `api/v1/earn/staking/products` |
-| [getEarnKcsStakingProducts()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1844) | :closed_lock_with_key:  | GET | `api/v1/earn/kcs-staking/products` |
-| [getEarnEthStakingProducts()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1856) | :closed_lock_with_key:  | GET | `api/v1/earn/eth-staking/products` |
-| [getDiscountRateConfigs()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1874) | :closed_lock_with_key:  | GET | `api/v1/otc-loan/discount-rate-configs` |
-| [getOtcLoan()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1885) | :closed_lock_with_key:  | GET | `api/v1/otc-loan/loan` |
-| [getOtcLoanAccounts()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1894) | :closed_lock_with_key:  | GET | `api/v1/otc-loan/accounts` |
-| [getAffiliateUserRebateInfo()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1909) | :closed_lock_with_key:  | GET | `api/v2/affiliate/inviter/statistics` |
-| [getBrokerRebateOrderDownloadLink()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1924) | :closed_lock_with_key:  | GET | `api/v1/broker/api/rebase/download` |
-| [getPublicWSConnectionToken()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1938) |  | POST | `api/v1/bullet-public` |
-| [getPrivateWSConnectionToken()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1942) | :closed_lock_with_key:  | POST | `api/v1/bullet-private` |
-| [getSubAccountsV1()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1962) | :closed_lock_with_key:  | GET | `api/v1/sub/user` |
-| [getSubAccountBalancesV1()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1970) | :closed_lock_with_key:  | GET | `api/v1/sub-accounts` |
-| [getMarginBalances()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1984) | :closed_lock_with_key:  | GET | `api/v1/margin/account` |
-| [createDepositAddress()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2002) | :closed_lock_with_key:  | POST | `api/v1/deposit-addresses` |
-| [getDepositAddressesV2()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2012) | :closed_lock_with_key:  | GET | `api/v2/deposit-addresses` |
-| [getDepositAddressV1()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2021) | :closed_lock_with_key:  | GET | `api/v1/deposit-addresses` |
-| [getHistoricalDepositsV1()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2032) | :closed_lock_with_key:  | GET | `api/v1/hist-deposits` |
-| [getHistoricalWithdrawalsV1()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2048) | :closed_lock_with_key:  | GET | `api/v1/hist-withdrawals` |
-| [submitWithdraw()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2057) | :closed_lock_with_key:  | POST | `api/v1/withdrawals` |
-| [submitTransferMasterSub()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2073) | :closed_lock_with_key:  | POST | `api/v2/accounts/sub-transfer` |
-| [submitInnerTransfer()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2085) | :closed_lock_with_key:  | POST | `api/v2/accounts/inner-transfer` |
-| [submitOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2103) | :closed_lock_with_key:  | POST | `api/v1/orders` |
-| [submitOrderTest()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2115) | :closed_lock_with_key:  | POST | `api/v1/orders/test` |
-| [submitMultipleOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2123) | :closed_lock_with_key:  | POST | `api/v1/orders/multi` |
-| [cancelOrderById()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2134) | :closed_lock_with_key:  | DELETE | `api/v1/orders/{orderId}` |
-| [cancelOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2146) | :closed_lock_with_key:  | DELETE | `api/v1/order/client-order/{clientOid}` |
-| [cancelAllOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2159) | :closed_lock_with_key:  | DELETE | `api/v1/orders` |
-| [getOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2171) | :closed_lock_with_key:  | GET | `api/v1/orders` |
-| [getRecentOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2181) | :closed_lock_with_key:  | GET | `api/v1/limit/orders` |
-| [getOrderByOrderId()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2192) | :closed_lock_with_key:  | GET | `api/v1/orders/{orderId}` |
-| [getOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2202) | :closed_lock_with_key:  | GET | `api/v1/order/client-order/{clientOid}` |
-| [getFills()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2218) | :closed_lock_with_key:  | GET | `api/v1/fills` |
-| [getRecentFills()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2228) | :closed_lock_with_key:  | GET | `api/v1/limit/fills` |
-| [submitMarginOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2242) | :closed_lock_with_key:  | POST | `api/v1/margin/order` |
-| [submitMarginOrderTest()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2252) | :closed_lock_with_key:  | POST | `api/v1/margin/order/test` |
-| [getIsolatedMarginAccounts()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2266) | :closed_lock_with_key:  | GET | `api/v1/isolated/accounts` |
-| [getIsolatedMarginAccount()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2276) | :closed_lock_with_key:  | GET | `api/v1/isolated/account/{symbol}` |
+| [getMyIp()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L263) |  | GET | `api/v1/ip` |
+| [getServiceStatus()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L271) |  | GET | `api/v1/status` |
+| [getAccountSummary()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L286) | :closed_lock_with_key:  | GET | `api/v2/user-info` |
+| [getApikeyInfo()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L295) | :closed_lock_with_key:  | GET | `api/v1/user/api-key` |
+| [getUserType()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L315) | :closed_lock_with_key:  | GET | `api/v1/hf/accounts/opened` |
+| [getBalances()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L324) | :closed_lock_with_key:  | GET | `api/v1/accounts` |
+| [getAccountDetail()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L335) | :closed_lock_with_key:  | GET | `api/v1/accounts/{accountId}` |
+| [getMarginBalance()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L346) | :closed_lock_with_key:  | GET | `api/v3/margin/accounts` |
+| [getIsolatedMarginBalance()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L357) | :closed_lock_with_key:  | GET | `api/v3/isolated/accounts` |
+| [getTransactions()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L370) | :closed_lock_with_key:  | GET | `api/v1/accounts/ledgers` |
+| [getHFTransactions()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L382) | :closed_lock_with_key:  | GET | `api/v1/hf/accounts/ledgers` |
+| [getHFMarginTransactions()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L394) | :closed_lock_with_key:  | GET | `api/v3/hf/margin/account/ledgers` |
+| [createSubAccount()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L411) | :closed_lock_with_key:  | POST | `api/v2/sub/user/created` |
+| [enableSubAccountMargin()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L422) | :closed_lock_with_key:  | POST | `api/v3/sub/user/margin/enable` |
+| [enableSubAccountFutures()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L432) | :closed_lock_with_key:  | POST | `api/v3/sub/user/futures/enable` |
+| [getSubAccountsV2()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L441) | :closed_lock_with_key:  | GET | `api/v2/sub/user` |
+| [getSubAccountBalance()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L452) | :closed_lock_with_key:  | GET | `api/v1/sub-accounts/{subUserId}` |
+| [getSubAccountBalancesV2()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L465) | :closed_lock_with_key:  | GET | `api/v2/sub-accounts` |
+| [createSubAPI()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L483) | :closed_lock_with_key:  | POST | `api/v1/sub/api-key` |
+| [updateSubAPI()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L494) | :closed_lock_with_key:  | POST | `api/v1/sub/api-key/update` |
+| [getSubAPIs()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L506) | :closed_lock_with_key:  | GET | `api/v1/sub/api-key` |
+| [deleteSubAPI()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L518) | :closed_lock_with_key:  | DELETE | `api/v1/sub/api-key` |
+| [createDepositAddressV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L535) | :closed_lock_with_key:  | POST | `api/v3/deposit-address/create` |
+| [getDepositAddressesV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L547) | :closed_lock_with_key:  | GET | `api/v3/deposit-addresses` |
+| [getDeposits()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L561) | :closed_lock_with_key:  | GET | `api/v1/deposits` |
+| [getWithdrawalQuotas()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L578) | :closed_lock_with_key:  | GET | `api/v1/withdrawals/quotas` |
+| [submitWithdrawV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L590) | :closed_lock_with_key:  | POST | `api/v3/withdrawals` |
+| [cancelWithdrawal()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L603) | :closed_lock_with_key:  | DELETE | `api/v1/withdrawals/{withdrawalId}` |
+| [getWithdrawals()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L615) | :closed_lock_with_key:  | GET | `api/v1/withdrawals` |
+| [getTransferable()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L632) | :closed_lock_with_key:  | GET | `api/v1/accounts/transferable` |
+| [submitFlexTransfer()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L643) | :closed_lock_with_key:  | POST | `api/v3/accounts/universal-transfer` |
+| [getBasicUserFee()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L662) | :closed_lock_with_key:  | GET | `api/v1/base-fee` |
+| [getTradingPairFee()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L678) | :closed_lock_with_key:  | GET | `api/v1/trade-fees` |
+| [getAnnouncements()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L701) |  | GET | `api/v3/announcements` |
+| [getCurrency()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L712) |  | GET | `api/v3/currencies/{currency}` |
+| [getCurrencies()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L724) |  | GET | `api/v3/currencies` |
+| [getSymbol()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L734) |  | GET | `api/v2/symbols/{symbol}` |
+| [getSymbols()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L746) |  | GET | `api/v2/symbols` |
+| [getTicker()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L759) |  | GET | `api/v1/market/orderbook/level1` |
+| [getTickers()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L768) |  | GET | `api/v1/market/allTickers` |
+| [getTradeHistories()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L779) |  | GET | `api/v1/market/histories` |
+| [getKlines()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L791) |  | GET | `api/v1/market/candles` |
+| [getOrderBookLevel20()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L802) |  | GET | `api/v1/market/orderbook/level2_20` |
+| [getOrderBookLevel100()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L813) |  | GET | `api/v1/market/orderbook/level2_100` |
+| [getFullOrderBook()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L824) | :closed_lock_with_key:  | GET | `api/v3/market/orderbook/level2` |
+| [getCallAuctionPartOrderBook()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L836) |  | GET | `api/v1/market/orderbook/callauction/level2_{size}` |
+| [getCallAuctionInfo()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L853) |  | GET | `api/v1/market/callauctionData` |
+| [getFiatPrice()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L864) |  | GET | `api/v1/prices` |
+| [get24hrStats()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L873) |  | GET | `api/v1/market/stats` |
+| [getMarkets()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L884) |  | GET | `api/v1/markets` |
+| [submitHFOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L901) | :closed_lock_with_key:  | POST | `api/v1/hf/orders` |
+| [submitHFOrderSync()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L917) | :closed_lock_with_key:  | POST | `api/v1/hf/orders/sync` |
+| [submitHFOrderTest()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L929) | :closed_lock_with_key:  | POST | `api/v1/hf/orders/test` |
+| [submitHFMultipleOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L938) | :closed_lock_with_key:  | POST | `api/v1/hf/orders/multi` |
+| [submitHFMultipleOrdersSync()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L950) | :closed_lock_with_key:  | POST | `api/v1/hf/orders/multi/sync` |
+| [cancelHFOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L962) | :closed_lock_with_key:  | DELETE | `api/v1/hf/orders/{orderId}` |
+| [cancelHFOrderSync()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L976) | :closed_lock_with_key:  | DELETE | `api/v1/hf/orders/sync/{orderId}` |
+| [cancelHFOrderByClientOId()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L992) | :closed_lock_with_key:  | DELETE | `api/v1/hf/orders/client-order/{clientOid}` |
+| [cancelHFOrderSyncByClientOId()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1012) | :closed_lock_with_key:  | DELETE | `api/v1/hf/orders/sync/client-order/{clientOid}` |
+| [cancelHFOrdersNumber()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1027) | :closed_lock_with_key:  | DELETE | `api/v1/hf/orders/cancel/{orderId}` |
+| [cancelHFAllOrdersBySymbol()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1042) | :closed_lock_with_key:  | DELETE | `api/v1/hf/orders` |
+| [cancelHFAllOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1053) | :closed_lock_with_key:  | DELETE | `api/v1/hf/orders/cancelAll` |
+| [updateHFOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1062) | :closed_lock_with_key:  | POST | `api/v1/hf/orders/alter` |
+| [getHFOrderDetailsByOrderId()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1076) | :closed_lock_with_key:  | GET | `api/v1/hf/orders/{orderId}` |
+| [getHFOrderDetailsByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1088) | :closed_lock_with_key:  | GET | `api/v1/hf/orders/client-order/{clientOid}` |
+| [getHFActiveSymbols()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1103) | :closed_lock_with_key:  | GET | `api/v1/hf/orders/active/symbols` |
+| [getHFActiveOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1117) | :closed_lock_with_key:  | GET | `api/v1/hf/orders/active` |
+| [getHFCompletedOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1128) | :closed_lock_with_key:  | GET | `api/v1/hf/orders/done` |
+| [getHFFilledOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1142) | :closed_lock_with_key:  | GET | `api/v1/hf/fills` |
+| [cancelHFOrderAutoSettingQuery()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1157) | :closed_lock_with_key:  | GET | `api/v1/hf/orders/dead-cancel-all/query` |
+| [cancelHFOrderAutoSetting()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1170) | :closed_lock_with_key:  | POST | `api/v1/hf/orders/dead-cancel-all` |
+| [submitStopOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1187) | :closed_lock_with_key:  | POST | `api/v1/stop-order` |
+| [cancelStopOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1198) | :closed_lock_with_key:  | DELETE | `api/v1/stop-order/cancelOrderByClientOid` |
+| [cancelStopOrderById()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1218) | :closed_lock_with_key:  | DELETE | `api/v1/stop-order/{orderId}` |
+| [cancelStopOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1231) | :closed_lock_with_key:  | DELETE | `api/v1/stop-order/cancel` |
+| [getStopOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1244) | :closed_lock_with_key:  | GET | `api/v1/stop-order` |
+| [getStopOrderByOrderId()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1257) | :closed_lock_with_key:  | GET | `api/v1/stop-order/{orderId}` |
+| [getStopOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1268) | :closed_lock_with_key:  | GET | `api/v1/stop-order/queryOrderByClientOid` |
+| [submitOCOOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1279) | :closed_lock_with_key:  | POST | `api/v3/oco/order` |
+| [cancelOCOOrderById()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1291) | :closed_lock_with_key:  | DELETE | `api/v3/oco/order/{orderId}` |
+| [cancelOCOOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1304) | :closed_lock_with_key:  | DELETE | `api/v3/oco/client-order/{clientOid}` |
+| [cancelMultipleOCOOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1317) | :closed_lock_with_key:  | DELETE | `api/v3/oco/orders` |
+| [getOCOOrderByOrderId()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1333) | :closed_lock_with_key:  | GET | `api/v3/oco/order/{orderId}` |
+| [getOCOOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1344) | :closed_lock_with_key:  | GET | `api/v3/oco/client-order/{clientOid}` |
+| [getOCOOrderDetails()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1355) | :closed_lock_with_key:  | GET | `api/v3/oco/order/details/{orderId}` |
+| [getOCOOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1366) | :closed_lock_with_key:  | GET | `api/v3/oco/orders` |
+| [getMarginActivePairsV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1383) | :closed_lock_with_key:  | GET | `api/v3/margin/symbols` |
+| [getMarginConfigInfo()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1395) |  | GET | `api/v1/margin/config` |
+| [getMarginLeveragedToken()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1404) | :closed_lock_with_key:  | GET | `api/v3/etf/info` |
+| [getMarginMarkPrices()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1415) |  | GET | `api/v3/mark-price/all-symbols` |
+| [getMarginMarkPrice()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1424) |  | GET | `api/v1/mark-price/{symbol}/current` |
+| [getIsolatedMarginSymbolsConfig()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1434) | :closed_lock_with_key:  | GET | `api/v1/isolated/symbols` |
+| [submitHFMarginOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1451) | :closed_lock_with_key:  | POST | `api/v3/hf/margin/order` |
+| [submitHFMarginOrderTest()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1461) | :closed_lock_with_key:  | POST | `api/v3/hf/margin/order/test` |
+| [cancelHFMarginOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1471) | :closed_lock_with_key:  | DELETE | `api/v3/hf/margin/orders/{orderId}` |
+| [cancelHFMarginOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1487) | :closed_lock_with_key:  | DELETE | `api/v3/hf/margin/orders/client-order/{clientOid}` |
+| [cancelHFAllMarginOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1505) | :closed_lock_with_key:  | DELETE | `api/v3/hf/margin/orders` |
+| [getHFMarginOpenSymbols()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1517) | :closed_lock_with_key:  | GET | `api/v3/hf/margin/order/active/symbols` |
+| [getHFActiveMarginOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1528) | :closed_lock_with_key:  | GET | `api/v3/hf/margin/orders/active` |
+| [getHFMarginFilledOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1539) | :closed_lock_with_key:  | GET | `api/v3/hf/margin/orders/done` |
+| [getHFMarginFills()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1553) | :closed_lock_with_key:  | GET | `api/v3/hf/margin/fills` |
+| [getHFMarginOrderByOrderId()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1567) | :closed_lock_with_key:  | GET | `api/v3/hf/margin/orders/{orderId}` |
+| [getHFMarginOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1578) | :closed_lock_with_key:  | GET | `api/v3/hf/margin/orders/client-order/{clientOid}?symbol={symbol}` |
+| [marginBorrowV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1598) | :closed_lock_with_key:  | POST | `api/v3/margin/borrow` |
+| [getMarginBorrowHistoryV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1609) | :closed_lock_with_key:  | GET | `api/v3/margin/borrow` |
+| [marginRepayV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1620) | :closed_lock_with_key:  | POST | `api/v3/margin/repay` |
+| [getMarginRepayHistoryV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1631) | :closed_lock_with_key:  | GET | `api/v3/margin/repay` |
+| [getMarginInterestRecordsV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1642) | :closed_lock_with_key:  | GET | `api/v3/margin/interest` |
+| [updateMarginLeverageV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1653) | :closed_lock_with_key:  | POST | `api/v3/position/update-user-leverage` |
+| [getLendingCurrencyV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1672) |  | GET | `api/v3/project/list` |
+| [getLendingInterestRateV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1683) |  | GET | `api/v3/project/marketInterestRate` |
+| [submitLendingSubscriptionV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1699) | :closed_lock_with_key:  | POST | `api/v3/purchase` |
+| [updateLendingSubscriptionOrdersV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1716) | :closed_lock_with_key:  | POST | `api/v3/lend/purchase/update` |
+| [getLendingSubscriptionOrdersV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1727) | :closed_lock_with_key:  | GET | `api/v3/purchase/orders` |
+| [submitLendingRedemptionV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1738) | :closed_lock_with_key:  | POST | `api/v3/redeem` |
+| [getLendingRedemptionOrdersV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1755) | :closed_lock_with_key:  | GET | `api/v3/redeem/orders` |
+| [getMarginRiskLimitConfig()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1772) | :closed_lock_with_key:  | GET | `api/v3/margin/currencies` |
+| [subscribeEarnFixedIncome()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1796) | :closed_lock_with_key:  | POST | `api/v1/earn/orders` |
+| [getEarnRedeemPreview()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1807) | :closed_lock_with_key:  | GET | `api/v1/earn/redeem-preview` |
+| [submitRedemption()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1818) | :closed_lock_with_key:  | DELETE | `api/v1/earn/orders` |
+| [getEarnSavingsProducts()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1829) | :closed_lock_with_key:  | GET | `api/v1/earn/saving/products` |
+| [getEarnPromotionProducts()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1840) | :closed_lock_with_key:  | GET | `api/v1/earn/promotion/products` |
+| [getEarnFixedIncomeHoldAssets()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1851) | :closed_lock_with_key:  | GET | `api/v1/earn/hold-assets` |
+| [getEarnStakingProducts()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1862) | :closed_lock_with_key:  | GET | `api/v1/earn/staking/products` |
+| [getEarnKcsStakingProducts()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1874) | :closed_lock_with_key:  | GET | `api/v1/earn/kcs-staking/products` |
+| [getEarnEthStakingProducts()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1886) | :closed_lock_with_key:  | GET | `api/v1/earn/eth-staking/products` |
+| [getDiscountRateConfigs()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1904) | :closed_lock_with_key:  | GET | `api/v1/otc-loan/discount-rate-configs` |
+| [getOtcLoan()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1915) | :closed_lock_with_key:  | GET | `api/v1/otc-loan/loan` |
+| [getOtcLoanAccounts()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1924) | :closed_lock_with_key:  | GET | `api/v1/otc-loan/accounts` |
+| [getAffiliateUserRebateInfo()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1939) | :closed_lock_with_key:  | GET | `api/v2/affiliate/inviter/statistics` |
+| [getBrokerRebateOrderDownloadLink()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1954) | :closed_lock_with_key:  | GET | `api/v1/broker/api/rebase/download` |
+| [getPublicWSConnectionToken()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1968) |  | POST | `api/v1/bullet-public` |
+| [getPrivateWSConnectionToken()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1972) | :closed_lock_with_key:  | POST | `api/v1/bullet-private` |
+| [getSubAccountsV1()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1992) | :closed_lock_with_key:  | GET | `api/v1/sub/user` |
+| [getSubAccountBalancesV1()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2000) | :closed_lock_with_key:  | GET | `api/v1/sub-accounts` |
+| [getMarginBalances()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2014) | :closed_lock_with_key:  | GET | `api/v1/margin/account` |
+| [createDepositAddress()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2032) | :closed_lock_with_key:  | POST | `api/v1/deposit-addresses` |
+| [getDepositAddressesV2()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2042) | :closed_lock_with_key:  | GET | `api/v2/deposit-addresses` |
+| [getDepositAddressV1()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2051) | :closed_lock_with_key:  | GET | `api/v1/deposit-addresses` |
+| [getHistoricalDepositsV1()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2062) | :closed_lock_with_key:  | GET | `api/v1/hist-deposits` |
+| [getHistoricalWithdrawalsV1()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2078) | :closed_lock_with_key:  | GET | `api/v1/hist-withdrawals` |
+| [submitWithdraw()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2087) | :closed_lock_with_key:  | POST | `api/v1/withdrawals` |
+| [submitTransferMasterSub()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2103) | :closed_lock_with_key:  | POST | `api/v2/accounts/sub-transfer` |
+| [submitInnerTransfer()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2115) | :closed_lock_with_key:  | POST | `api/v2/accounts/inner-transfer` |
+| [submitOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2133) | :closed_lock_with_key:  | POST | `api/v1/orders` |
+| [submitOrderTest()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2145) | :closed_lock_with_key:  | POST | `api/v1/orders/test` |
+| [submitMultipleOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2153) | :closed_lock_with_key:  | POST | `api/v1/orders/multi` |
+| [cancelOrderById()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2164) | :closed_lock_with_key:  | DELETE | `api/v1/orders/{orderId}` |
+| [cancelOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2176) | :closed_lock_with_key:  | DELETE | `api/v1/order/client-order/{clientOid}` |
+| [cancelAllOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2189) | :closed_lock_with_key:  | DELETE | `api/v1/orders` |
+| [getOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2201) | :closed_lock_with_key:  | GET | `api/v1/orders` |
+| [getRecentOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2211) | :closed_lock_with_key:  | GET | `api/v1/limit/orders` |
+| [getOrderByOrderId()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2222) | :closed_lock_with_key:  | GET | `api/v1/orders/{orderId}` |
+| [getOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2232) | :closed_lock_with_key:  | GET | `api/v1/order/client-order/{clientOid}` |
+| [getFills()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2248) | :closed_lock_with_key:  | GET | `api/v1/fills` |
+| [getRecentFills()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2258) | :closed_lock_with_key:  | GET | `api/v1/limit/fills` |
+| [submitMarginOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2272) | :closed_lock_with_key:  | POST | `api/v1/margin/order` |
+| [submitMarginOrderTest()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2282) | :closed_lock_with_key:  | POST | `api/v1/margin/order/test` |
+| [getIsolatedMarginAccounts()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2296) | :closed_lock_with_key:  | GET | `api/v1/isolated/accounts` |
+| [getIsolatedMarginAccount()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2306) | :closed_lock_with_key:  | GET | `api/v1/isolated/account/{symbol}` |
 
 # FuturesClient.ts
 

--- a/examples/apidoc/SpotClient/getCallAuctionInfo.js
+++ b/examples/apidoc/SpotClient/getCallAuctionInfo.js
@@ -1,0 +1,21 @@
+const { SpotClient } = require('kucoin-api');
+
+  // This example shows how to call this kucoin API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "kucoin-api" for kucoin exchange
+  // This kucoin API SDK is available on npm via "npm install kucoin-api"
+  // ENDPOINT: api/v1/market/callauctionData
+  // METHOD: GET
+  // PUBLIC: YES
+
+const client = new SpotClient({
+  apiKey: 'apiKeyHere',
+  apiSecret: 'apiSecretHere',
+  apiPassphrase: 'apiPassPhraseHere',
+});
+
+client.getCallAuctionInfo(params)
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/SpotClient/getCallAuctionPartOrderBook.js
+++ b/examples/apidoc/SpotClient/getCallAuctionPartOrderBook.js
@@ -1,0 +1,21 @@
+const { SpotClient } = require('kucoin-api');
+
+  // This example shows how to call this kucoin API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "kucoin-api" for kucoin exchange
+  // This kucoin API SDK is available on npm via "npm install kucoin-api"
+  // ENDPOINT: api/v1/market/orderbook/callauction/level2_{size}
+  // METHOD: GET
+  // PUBLIC: YES
+
+const client = new SpotClient({
+  apiKey: 'apiKeyHere',
+  apiSecret: 'apiSecretHere',
+  apiPassphrase: 'apiPassPhraseHere',
+});
+
+client.getCallAuctionPartOrderBook(params)
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kucoin-api",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kucoin-api",
-      "version": "2.1.3",
+      "version": "2.1.4",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kucoin-api",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Complete & robust Node.js SDK for Kucoin's REST APIs and WebSockets, with TypeScript & strong end to end tests.",
   "scripts": {
     "clean": "rm -rf dist",

--- a/src/SpotClient.ts
+++ b/src/SpotClient.ts
@@ -139,6 +139,7 @@ import { Announcements } from './types/response/spot-misc.js';
 import {
   AllTickers,
   AutoCancelHFOrderSettingQueryResponse,
+  CallAuctionInfo,
   CancelAllHFOrdersResponse,
   CurrencyInfo,
   HFFilledOrder,
@@ -824,6 +825,35 @@ export class SpotClient extends BaseRestClient {
     symbol: string;
   }): Promise<APISuccessResponse<OrderBookLevel>> {
     return this.getPrivate('api/v3/market/orderbook/level2', params);
+  }
+
+  /**
+   * Get Call Auction Part OrderBook
+   *
+   * Query for call auction part orderbook depth data (aggregated by price).
+   * It is recommended that you submit requests via this endpoint as the system response will be faster and consume less traffic.
+   */
+  getCallAuctionPartOrderBook(params: {
+    symbol: string;
+    size: 20 | 100;
+  }): Promise<APISuccessResponse<OrderBookLevel>> {
+    const { symbol, size } = params;
+    return this.get(`api/v1/market/orderbook/callauction/level2_${size}`, {
+      symbol,
+    });
+  }
+
+  /**
+   * Get Call Auction Info
+   *
+   * Get call auction data. This endpoint will return the following information for the specified symbol
+   * during the call auction phase: estimated transaction price, estimated transaction quantity,
+   * bid price range, and ask price range.
+   */
+  getCallAuctionInfo(params: {
+    symbol: string;
+  }): Promise<APISuccessResponse<CallAuctionInfo>> {
+    return this.get('api/v1/market/callauctionData', params);
   }
 
   /**

--- a/src/types/request/spot-trading.ts
+++ b/src/types/request/spot-trading.ts
@@ -63,6 +63,9 @@ export interface SubmitHFOrderRequest {
 
   // Market order fields
   funds?: string; // Required for market orders if size is not provided
+
+  allowMaxTimeWindow?: number; // Order failed after timeout of specified milliseconds, If clientTimestamp + allowMaxTimeWindow < the server reaches time, this order will fail.
+  clientTimestamp?: number; // Equal to KC-API-TIMESTAMP, Need to be defined if iceberg is specified.
 }
 
 export interface ModifyHFOrderRequest {

--- a/src/types/response/spot-trading.ts
+++ b/src/types/response/spot-trading.ts
@@ -64,6 +64,13 @@ export interface SymbolInfo {
   makerFeeCoefficient: string;
   takerFeeCoefficient: string;
   st: boolean;
+  callauctionIsEnabled: boolean;
+  callauctionPriceFloor: string | null;
+  callauctionPriceCeiling: string | null;
+  callauctionFirstStageStartTime: number | null;
+  callauctionSecondStageStartTime: number | null;
+  callauctionThirdStageStartTime: number | null;
+  tradingStartTime: number | null;
 }
 
 export interface Ticker {
@@ -128,6 +135,17 @@ export interface OrderBookLevel {
   time: number;
   bids: [string, string][];
   asks: [string, string][];
+}
+
+export interface CallAuctionInfo {
+  symbol: string; // Symbol (e.g. "BTC-USDT")
+  estimatedPrice: string; // Estimated price
+  estimatedSize: string; // Estimated size
+  sellOrderRangeLowPrice: string; // Sell order minimum price
+  sellOrderRangeHighPrice: string; // Sell order maximum price
+  buyOrderRangeLowPrice: string; // Buy order minimum price
+  buyOrderRangeHighPrice: string; // Buy order maximum price
+  time: number; // Timestamp (ms)
 }
 
 export interface TradeHistory {


### PR DESCRIPTION
Change Log
2025.02.28
[Spot Modify] Add Order, Add Order Sync, Add Order Test, Batch Add Orders, Batch Add Orders Sync endpoint: Added allowMaxTimeWindow, clientTimestamp request parameter.

2025.02.27
[Add] API documentation now includes a Debug Function.

2025.02.26
[Add] Nodejs SDK

[Spot Add] Get Call Auction Part OrderBook, GET /api/v1/market/orderbook/callauction/level2_{size}

[Spot Add] Get Call Auction Info, GET /api/v1/market/callauctionData

[Spot Add] Call Auction Orderbook - Level50, Topic:/callauction/level2Depth50:{symbol}

[Spot Add] Call Auction Data, Topic: /callauction/callauctionData:{symbol}

[Spot Modify] GET /api/v2/symbols/{symbol} endpoint: Added callauctionIsEnabled, callauctionPriceFloor, callauctionPriceCeiling, callauctionFirstStageStartTime, callauctionSecondStageStartTime, callauctionThirdStageStartTime, tradingStartTime response parameter.

[Spot Modify] GET /api/v2/symbols endpoint: Added callauctionIsEnabled, callauctionPriceFloor, callauctionPriceCeiling, callauctionFirstStageStartTime, callauctionSecondStageStartTime, callauctionThirdStageStartTime, tradingStartTime response parameter.