### PR TITLE
chore(2.1.10): make param leverage optional in Order and SLTPOrder interfaces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kucoin-api",
-  "version": "2.1.9",
+  "version": "2.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kucoin-api",
-      "version": "2.1.9",
+      "version": "2.1.10",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kucoin-api",
-  "version": "2.1.9",
+  "version": "2.1.10",
   "description": "Complete & robust Node.js SDK for Kucoin's REST APIs and WebSockets, with TypeScript & strong end to end tests.",
   "scripts": {
     "clean": "rm -rf dist",

--- a/src/types/request/futures.types.ts
+++ b/src/types/request/futures.types.ts
@@ -116,7 +116,7 @@ export interface Order {
   clientOid: string;
   side: 'buy' | 'sell';
   symbol: string;
-  leverage: number;
+  leverage?: number;
   type?: 'limit' | 'market';
   remark?: string;
   stop?: 'down' | 'up';
@@ -142,7 +142,7 @@ export interface SLTPOrder {
   clientOid: string;
   side: 'buy' | 'sell';
   symbol: string;
-  leverage: number;
+  leverage?: number;
   type: 'limit' | 'market';
   remark?: string;
   triggerStopUpPrice?: string;


### PR DESCRIPTION
## Summary
<!-- Add a brief description of the pr: -->

## Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

## PR Checklist

As part of the PR, make sure you have:
- [ ] No breaking changes / documented all breaking changes clearly.
- [ ] Updated & checked that all tests pass.
- [ ] Updated the endpoint map (optional, if you know how).
- [ ] Increased the version number in the package.json <!-- Only if your changes need to be published to npm -->
- [ ] Checked `npm install` runs without issue.
- [ ] Included the package-lock.json, if it changed after npm install <!-- The version number should update, if you also updated the package.json version number -->
- [ ] Checked `npm run build` runs without issue.
