### PR TITLE
feat(v2.5.1): update API documentation and examples for Unified Trading Account

### DIFF
--- a/docs/endpointFunctionList.md
+++ b/docs/endpointFunctionList.md
@@ -51,206 +51,206 @@ This table includes all endpoints from the official Exchange API docs and corres
 
 | Function | AUTH | HTTP Method | Endpoint |
 | -------- | :------: | :------: | -------- |
-| [getMyIp()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L334) |  | GET | `api/v1/ip` |
-| [getServiceStatus()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L342) |  | GET | `api/v1/status` |
-| [getAccountSummary()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L357) | :closed_lock_with_key:  | GET | `api/v2/user-info` |
-| [getKYCRegions()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L366) | :closed_lock_with_key:  | GET | `api/kyc/regions/v4` |
-| [getApikeyInfo()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L376) | :closed_lock_with_key:  | GET | `api/v1/user/api-key` |
-| [getUserType()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L385) | :closed_lock_with_key:  | GET | `api/v1/hf/accounts/opened` |
-| [getBalances()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L394) | :closed_lock_with_key:  | GET | `api/v1/accounts` |
-| [getAccountDetail()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L405) | :closed_lock_with_key:  | GET | `api/v1/accounts/{accountId}` |
-| [getMarginBalance()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L416) | :closed_lock_with_key:  | GET | `api/v3/margin/accounts` |
-| [getIsolatedMarginBalance()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L427) | :closed_lock_with_key:  | GET | `api/v3/isolated/accounts` |
-| [getTransactions()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L440) | :closed_lock_with_key:  | GET | `api/v1/accounts/ledgers` |
-| [getHFTransactions()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L452) | :closed_lock_with_key:  | GET | `api/v1/hf/accounts/ledgers` |
-| [getHFMarginTransactions()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L464) | :closed_lock_with_key:  | GET | `api/v3/hf/margin/account/ledgers` |
-| [createSubAccount()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L481) | :closed_lock_with_key:  | POST | `api/v2/sub/user/created` |
-| [enableSubAccountMargin()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L493) | :closed_lock_with_key:  | POST | `api/v3/sub/user/margin/enable` |
-| [enableSubAccountFutures()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L503) | :closed_lock_with_key:  | POST | `api/v3/sub/user/futures/enable` |
-| [getSubAccountsV2()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L512) | :closed_lock_with_key:  | GET | `api/v2/sub/user` |
-| [getSubAccountBalance()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L524) | :closed_lock_with_key:  | GET | `api/v1/sub-accounts/{subUserId}` |
-| [getSubAccountBalancesV2()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L539) | :closed_lock_with_key:  | GET | `api/v2/sub-accounts` |
-| [createSubAPI()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L557) | :closed_lock_with_key:  | POST | `api/v1/sub/api-key` |
-| [updateSubAPI()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L568) | :closed_lock_with_key:  | POST | `api/v1/sub/api-key/update` |
-| [getSubAPIs()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L580) | :closed_lock_with_key:  | GET | `api/v1/sub/api-key` |
-| [deleteSubAPI()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L592) | :closed_lock_with_key:  | DELETE | `api/v1/sub/api-key` |
-| [createDepositAddressV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L609) | :closed_lock_with_key:  | POST | `api/v3/deposit-address/create` |
-| [getDepositAddressesV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L621) | :closed_lock_with_key:  | GET | `api/v3/deposit-addresses` |
-| [getDeposits()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L635) | :closed_lock_with_key:  | GET | `api/v1/deposits` |
-| [getWithdrawalQuotas()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L652) | :closed_lock_with_key:  | GET | `api/v1/withdrawals/quotas` |
-| [submitWithdrawV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L664) | :closed_lock_with_key:  | POST | `api/v3/withdrawals` |
-| [cancelWithdrawal()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L677) | :closed_lock_with_key:  | DELETE | `api/v1/withdrawals/{withdrawalId}` |
-| [getWithdrawals()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L689) | :closed_lock_with_key:  | GET | `api/v1/withdrawals` |
-| [getWithdrawalById()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L700) | :closed_lock_with_key:  | GET | `api/v1/withdrawals/{withdrawalId}` |
-| [getTransferable()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L717) | :closed_lock_with_key:  | GET | `api/v1/accounts/transferable` |
-| [submitFlexTransfer()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L728) | :closed_lock_with_key:  | POST | `api/v3/accounts/universal-transfer` |
-| [getBasicUserFee()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L747) | :closed_lock_with_key:  | GET | `api/v1/base-fee` |
-| [getTradingPairFee()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L763) | :closed_lock_with_key:  | GET | `api/v1/trade-fees` |
-| [getAnnouncements()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L786) |  | GET | `api/v3/announcements` |
-| [getCurrency()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L797) |  | GET | `api/v3/currencies/{currency}` |
-| [getCurrencies()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L809) |  | GET | `api/v3/currencies` |
-| [getSymbol()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L819) |  | GET | `api/v2/symbols/{symbol}` |
-| [getSymbols()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L831) |  | GET | `api/v2/symbols` |
-| [getTicker()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L844) |  | GET | `api/v1/market/orderbook/level1` |
-| [getTickers()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L853) |  | GET | `api/v1/market/allTickers` |
-| [getTradeHistories()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L864) |  | GET | `api/v1/market/histories` |
-| [getKlines()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L876) |  | GET | `api/v1/market/candles` |
-| [getOrderBookLevel20()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L887) |  | GET | `api/v1/market/orderbook/level2_20` |
-| [getOrderBookLevel100()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L898) |  | GET | `api/v1/market/orderbook/level2_100` |
-| [getFullOrderBook()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L909) | :closed_lock_with_key:  | GET | `api/v3/market/orderbook/level2` |
-| [getCallAuctionPartOrderBook()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L921) |  | GET | `api/v1/market/orderbook/callauction/level2_{size}` |
-| [getCallAuctionInfo()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L938) |  | GET | `api/v1/market/callauctionData` |
-| [getFiatPrice()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L949) |  | GET | `api/v1/prices` |
-| [get24hrStats()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L958) |  | GET | `api/v1/market/stats` |
-| [getMarkets()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L969) |  | GET | `api/v1/markets` |
-| [submitHFOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L986) | :closed_lock_with_key:  | POST | `api/v1/hf/orders` |
-| [submitHFOrderSync()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1002) | :closed_lock_with_key:  | POST | `api/v1/hf/orders/sync` |
-| [submitHFOrderTest()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1014) | :closed_lock_with_key:  | POST | `api/v1/hf/orders/test` |
-| [submitHFMultipleOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1023) | :closed_lock_with_key:  | POST | `api/v1/hf/orders/multi` |
-| [submitHFMultipleOrdersSync()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1035) | :closed_lock_with_key:  | POST | `api/v1/hf/orders/multi/sync` |
-| [cancelHFOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1047) | :closed_lock_with_key:  | DELETE | `api/v1/hf/orders/{orderId}` |
-| [cancelHFOrderSync()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1061) | :closed_lock_with_key:  | DELETE | `api/v1/hf/orders/sync/{orderId}` |
-| [cancelHFOrderByClientOId()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1077) | :closed_lock_with_key:  | DELETE | `api/v1/hf/orders/client-order/{clientOid}` |
-| [cancelHFOrderSyncByClientOId()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1097) | :closed_lock_with_key:  | DELETE | `api/v1/hf/orders/sync/client-order/{clientOid}` |
-| [cancelHFOrdersNumber()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1112) | :closed_lock_with_key:  | DELETE | `api/v1/hf/orders/cancel/{orderId}` |
-| [cancelHFAllOrdersBySymbol()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1127) | :closed_lock_with_key:  | DELETE | `api/v1/hf/orders` |
-| [cancelHFAllOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1138) | :closed_lock_with_key:  | DELETE | `api/v1/hf/orders/cancelAll` |
-| [updateHFOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1147) | :closed_lock_with_key:  | POST | `api/v1/hf/orders/alter` |
-| [getHFOrderDetailsByOrderId()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1161) | :closed_lock_with_key:  | GET | `api/v1/hf/orders/{orderId}` |
-| [getHFOrderDetailsByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1173) | :closed_lock_with_key:  | GET | `api/v1/hf/orders/client-order/{clientOid}` |
-| [getHFActiveSymbols()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1188) | :closed_lock_with_key:  | GET | `api/v1/hf/orders/active/symbols` |
-| [getHFActiveOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1203) | :closed_lock_with_key:  | GET | `api/v1/hf/orders/active` |
-| [getHFActiveOrdersPaginated()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1215) | :closed_lock_with_key:  | GET | `api/v1/hf/orders/active/page` |
-| [getHFCompletedOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1237) | :closed_lock_with_key:  | GET | `api/v1/hf/orders/done` |
-| [getHFFilledOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1251) | :closed_lock_with_key:  | GET | `api/v1/hf/fills` |
-| [cancelHFOrderAutoSettingQuery()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1266) | :closed_lock_with_key:  | GET | `api/v1/hf/orders/dead-cancel-all/query` |
-| [cancelHFOrderAutoSetting()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1279) | :closed_lock_with_key:  | POST | `api/v1/hf/orders/dead-cancel-all` |
-| [submitStopOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1296) | :closed_lock_with_key:  | POST | `api/v1/stop-order` |
-| [cancelStopOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1307) | :closed_lock_with_key:  | DELETE | `api/v1/stop-order/cancelOrderByClientOid` |
-| [cancelStopOrderById()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1327) | :closed_lock_with_key:  | DELETE | `api/v1/stop-order/{orderId}` |
-| [cancelStopOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1340) | :closed_lock_with_key:  | DELETE | `api/v1/stop-order/cancel` |
-| [getStopOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1353) | :closed_lock_with_key:  | GET | `api/v1/stop-order` |
-| [getStopOrderByOrderId()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1366) | :closed_lock_with_key:  | GET | `api/v1/stop-order/{orderId}` |
-| [getStopOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1377) | :closed_lock_with_key:  | GET | `api/v1/stop-order/queryOrderByClientOid` |
-| [submitOCOOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1389) | :closed_lock_with_key:  | POST | `api/v3/oco/order` |
-| [cancelOCOOrderById()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1402) | :closed_lock_with_key:  | DELETE | `api/v3/oco/order/{orderId}` |
-| [cancelOCOOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1415) | :closed_lock_with_key:  | DELETE | `api/v3/oco/client-order/{clientOid}` |
-| [cancelMultipleOCOOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1428) | :closed_lock_with_key:  | DELETE | `api/v3/oco/orders` |
-| [getOCOOrderByOrderId()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1444) | :closed_lock_with_key:  | GET | `api/v3/oco/order/{orderId}` |
-| [getOCOOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1455) | :closed_lock_with_key:  | GET | `api/v3/oco/client-order/{clientOid}` |
-| [getOCOOrderDetails()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1466) | :closed_lock_with_key:  | GET | `api/v3/oco/order/details/{orderId}` |
-| [getOCOOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1477) | :closed_lock_with_key:  | GET | `api/v3/oco/orders` |
-| [getMarginActivePairsV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1494) | :closed_lock_with_key:  | GET | `api/v3/margin/symbols` |
-| [getMarginConfigInfo()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1507) |  | GET | `api/v1/margin/config` |
-| [getMarginLeveragedToken()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1516) | :closed_lock_with_key:  | GET | `api/v3/etf/info` |
-| [getMarginMarkPrices()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1527) |  | GET | `api/v3/mark-price/all-symbols` |
-| [getMarginMarkPrice()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1536) |  | GET | `api/v1/mark-price/{symbol}/current` |
-| [getIsolatedMarginSymbolsConfig()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1547) | :closed_lock_with_key:  | GET | `api/v1/isolated/symbols` |
-| [getMarginCollateralRatio()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1558) |  | GET | `api/v3/margin/collateralRatio` |
-| [getMarketAvailableInventory()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1569) |  | GET | `api/v3/margin/available-inventory` |
-| [submitHFMarginOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1586) | :closed_lock_with_key:  | POST | `api/v3/hf/margin/order` |
-| [submitHFMarginOrderTest()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1597) | :closed_lock_with_key:  | POST | `api/v3/hf/margin/order/test` |
-| [cancelHFMarginOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1608) | :closed_lock_with_key:  | DELETE | `api/v3/hf/margin/orders/{orderId}` |
-| [cancelHFMarginOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1624) | :closed_lock_with_key:  | DELETE | `api/v3/hf/margin/orders/client-order/{clientOid}` |
-| [cancelHFAllMarginOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1643) | :closed_lock_with_key:  | DELETE | `api/v3/hf/margin/orders` |
-| [getHFMarginOpenSymbols()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1655) | :closed_lock_with_key:  | GET | `api/v3/hf/margin/order/active/symbols` |
-| [getHFActiveMarginOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1666) | :closed_lock_with_key:  | GET | `api/v3/hf/margin/orders/active` |
-| [getHFMarginFilledOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1677) | :closed_lock_with_key:  | GET | `api/v3/hf/margin/orders/done` |
-| [getHFMarginFills()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1691) | :closed_lock_with_key:  | GET | `api/v3/hf/margin/fills` |
-| [getHFMarginOrderByOrderId()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1705) | :closed_lock_with_key:  | GET | `api/v3/hf/margin/orders/{orderId}` |
-| [getHFMarginOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1717) | :closed_lock_with_key:  | GET | `api/v3/hf/margin/orders/client-order/{clientOid}?symbol={symbol}` |
-| [addMarginStopOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1731) | :closed_lock_with_key:  | POST | `api/v3/hf/margin/stop-order` |
-| [cancelMarginStopOrderByOrderId()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1742) | :closed_lock_with_key:  | DELETE | `api/v3/hf/margin/stop-order/cancel-by-id?orderId={orderId}` |
-| [cancelMarginStopOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1755) | :closed_lock_with_key:  | DELETE | `api/v3/hf/margin/stop-order/cancel-by-clientOid` |
-| [batchCancelMarginStopOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1769) | :closed_lock_with_key:  | DELETE | `api/v3/hf/margin/stop-order/cancel` |
-| [getMarginStopOrdersList()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1780) | :closed_lock_with_key:  | GET | `api/v3/hf/margin/stop-orders` |
-| [getMarginStopOrderByOrderId()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1791) | :closed_lock_with_key:  | GET | `api/v3/hf/margin/stop-order/orderId?orderId={orderId}` |
-| [getMarginStopOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1804) | :closed_lock_with_key:  | GET | `api/v3/hf/margin/stop-order/clientOid` |
-| [addMarginOcoOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1815) | :closed_lock_with_key:  | POST | `api/v3/hf/margin/oco-order` |
-| [cancelMarginOcoOrderByOrderId()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1826) | :closed_lock_with_key:  | DELETE | `api/v3/hf/margin/oco-order/cancel-by-id?orderId={orderId}` |
-| [cancelMarginOcoOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1839) | :closed_lock_with_key:  | DELETE | `api/v3/hf/margin/oco-order/cancel-by-clientOid` |
-| [batchCancelMarginOcoOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1853) | :closed_lock_with_key:  | DELETE | `api/v3/hf/margin/oco-order/cancel` |
-| [getMarginOcoOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1864) | :closed_lock_with_key:  | GET | `api/v3/hf/margin/oco-order/clientOid` |
-| [getMarginOcoOrderDetailByOrderId()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1875) | :closed_lock_with_key:  | GET | `api/v3/hf/margin/oco-order/detail/orderId?orderId={orderId}` |
-| [getBorrowInterestRate()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1894) | :closed_lock_with_key:  | GET | `api/v3/margin/borrowRate` |
-| [marginBorrowV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1905) | :closed_lock_with_key:  | POST | `api/v3/margin/borrow` |
-| [getMarginBorrowHistoryV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1916) | :closed_lock_with_key:  | GET | `api/v3/margin/borrow` |
-| [marginRepayV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1927) | :closed_lock_with_key:  | POST | `api/v3/margin/repay` |
-| [getMarginRepayHistoryV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1938) | :closed_lock_with_key:  | GET | `api/v3/margin/repay` |
-| [getMarginInterestRecordsV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1949) | :closed_lock_with_key:  | GET | `api/v3/margin/interest` |
-| [updateMarginLeverageV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1960) | :closed_lock_with_key:  | POST | `api/v3/position/update-user-leverage` |
-| [getLendingCurrencyV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1979) |  | GET | `api/v3/project/list` |
-| [getLendingInterestRateV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1990) |  | GET | `api/v3/project/marketInterestRate` |
-| [submitLendingSubscriptionV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2006) | :closed_lock_with_key:  | POST | `api/v3/purchase` |
-| [updateLendingSubscriptionOrdersV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2023) | :closed_lock_with_key:  | POST | `api/v3/lend/purchase/update` |
-| [getLendingSubscriptionOrdersV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2034) | :closed_lock_with_key:  | GET | `api/v3/purchase/orders` |
-| [submitLendingRedemptionV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2045) | :closed_lock_with_key:  | POST | `api/v3/redeem` |
-| [getLendingRedemptionOrdersV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2062) | :closed_lock_with_key:  | GET | `api/v3/redeem/orders` |
-| [getMarginRiskLimitConfig()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2079) | :closed_lock_with_key:  | GET | `api/v3/margin/currencies` |
-| [getConvertSymbol()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2096) |  | GET | `api/v1/convert/symbol` |
-| [getConvertCurrencies()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2107) |  | GET | `api/v1/convert/currencies` |
-| [submitConvertOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2116) | :closed_lock_with_key:  | POST | `api/v1/convert/order` |
-| [getConvertQuote()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2127) | :closed_lock_with_key:  | GET | `api/v1/convert/quote` |
-| [getConvertOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2138) | :closed_lock_with_key:  | GET | `api/v1/convert/order/detail` |
-| [getConvertOrderHistory()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2149) | :closed_lock_with_key:  | GET | `api/v1/convert/order/history` |
-| [submitConvertLimitOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2160) | :closed_lock_with_key:  | POST | `api/v1/convert/limit/order` |
-| [getConvertLimitQuote()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2171) | :closed_lock_with_key:  | GET | `api/v1/convert/limit/quote` |
-| [getConvertLimitOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2182) | :closed_lock_with_key:  | GET | `api/v1/convert/limit/order/detail` |
-| [getConvertLimitOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2193) | :closed_lock_with_key:  | GET | `api/v1/convert/limit/orders` |
-| [cancelConvertLimitOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2204) | :closed_lock_with_key:  | DELETE | `api/v1/convert/limit/order/cancel` |
-| [subscribeEarnFixedIncome()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2222) | :closed_lock_with_key:  | POST | `api/v1/earn/orders` |
-| [getEarnRedeemPreview()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2233) | :closed_lock_with_key:  | GET | `api/v1/earn/redeem-preview` |
-| [submitRedemption()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2244) | :closed_lock_with_key:  | DELETE | `api/v1/earn/orders` |
-| [getEarnSavingsProducts()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2255) | :closed_lock_with_key:  | GET | `api/v1/earn/saving/products` |
-| [getEarnPromotionProducts()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2266) | :closed_lock_with_key:  | GET | `api/v1/earn/promotion/products` |
-| [getEarnFixedIncomeHoldAssets()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2277) | :closed_lock_with_key:  | GET | `api/v1/earn/hold-assets` |
-| [getEarnStakingProducts()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2288) | :closed_lock_with_key:  | GET | `api/v1/earn/staking/products` |
-| [getEarnKcsStakingProducts()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2300) | :closed_lock_with_key:  | GET | `api/v1/earn/kcs-staking/products` |
-| [getEarnEthStakingProducts()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2312) | :closed_lock_with_key:  | GET | `api/v1/earn/eth-staking/products` |
-| [submitStructuredProductPurchase()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2329) | :closed_lock_with_key:  | POST | `api/v1/struct-earn/orders` |
-| [getDualInvestmentProducts()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2340) |  | GET | `api/v1/struct-earn/dual/products` |
-| [getStructuredProductOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2351) | :closed_lock_with_key:  | GET | `api/v1/struct-earn/orders` |
-| [getDiscountRateConfigs()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2369) | :closed_lock_with_key:  | GET | `api/v1/otc-loan/discount-rate-configs` |
-| [getOtcLoan()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2380) | :closed_lock_with_key:  | GET | `api/v1/otc-loan/loan` |
-| [getOtcLoanAccounts()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2389) | :closed_lock_with_key:  | GET | `api/v1/otc-loan/accounts` |
-| [getAffiliateUserRebateInfo()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2405) | :closed_lock_with_key:  | GET | `api/v2/affiliate/inviter/statistics` |
-| [getAffiliateInvitees()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2414) | :closed_lock_with_key:  | GET | `api/v2/affiliate/queryInvitees` |
-| [getAffiliateCommission()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2425) | :closed_lock_with_key:  | GET | `api/v2/affiliate/queryMyCommission` |
-| [getAffiliateTradeHistory()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2436) | :closed_lock_with_key:  | GET | `api/v2/affiliate/queryTransactionByUid` |
-| [getAffiliateTransaction()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2447) | :closed_lock_with_key:  | GET | `api/v2/affiliate/queryTransactionByTime` |
-| [getKumining()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2458) | :closed_lock_with_key:  | GET | `api/v2/affiliate/queryKumining` |
-| [getBrokerRebateOrderDownloadLink()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2476) | :closed_lock_with_key:  | GET | `api/v1/broker/api/rebase/download` |
-| [getBrokerRebateOrderDownloadLinkV2()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2489) | :closed_lock_with_key:  | GET | `api/v2/broker/api/rebase/download` |
-| [getPublicWSConnectionToken()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2506) |  | POST | `api/v1/bullet-public` |
-| [getPrivateWSConnectionToken()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2513) | :closed_lock_with_key:  | POST | `api/v1/bullet-private` |
-| [getPrivateWSConnectionTokenV2()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2521) | :closed_lock_with_key:  | POST | `api/v2/bullet-private` |
-| [getSubAccountsV1()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2543) | :closed_lock_with_key:  | GET | `api/v1/sub/user` |
-| [getSubAccountBalancesV1()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2551) | :closed_lock_with_key:  | GET | `api/v1/sub-accounts` |
-| [getMarginBalances()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2565) | :closed_lock_with_key:  | GET | `api/v1/margin/account` |
-| [createDepositAddress()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2583) | :closed_lock_with_key:  | POST | `api/v1/deposit-addresses` |
-| [getDepositAddressesV2()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2593) | :closed_lock_with_key:  | GET | `api/v2/deposit-addresses` |
-| [getDepositAddressV1()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2602) | :closed_lock_with_key:  | GET | `api/v1/deposit-addresses` |
-| [getHistoricalDepositsV1()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2613) | :closed_lock_with_key:  | GET | `api/v1/hist-deposits` |
-| [getHistoricalWithdrawalsV1()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2629) | :closed_lock_with_key:  | GET | `api/v1/hist-withdrawals` |
-| [submitWithdraw()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2638) | :closed_lock_with_key:  | POST | `api/v1/withdrawals` |
-| [submitTransferMasterSub()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2654) | :closed_lock_with_key:  | POST | `api/v2/accounts/sub-transfer` |
-| [submitInnerTransfer()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2666) | :closed_lock_with_key:  | POST | `api/v2/accounts/inner-transfer` |
-| [submitOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2684) | :closed_lock_with_key:  | POST | `api/v1/orders` |
-| [submitOrderTest()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2696) | :closed_lock_with_key:  | POST | `api/v1/orders/test` |
-| [submitMultipleOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2704) | :closed_lock_with_key:  | POST | `api/v1/orders/multi` |
-| [cancelOrderById()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2715) | :closed_lock_with_key:  | DELETE | `api/v1/orders/{orderId}` |
-| [cancelOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2727) | :closed_lock_with_key:  | DELETE | `api/v1/order/client-order/{clientOid}` |
-| [cancelAllOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2740) | :closed_lock_with_key:  | DELETE | `api/v1/orders` |
-| [getOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2752) | :closed_lock_with_key:  | GET | `api/v1/orders` |
-| [getRecentOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2762) | :closed_lock_with_key:  | GET | `api/v1/limit/orders` |
-| [getOrderByOrderId()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2773) | :closed_lock_with_key:  | GET | `api/v1/orders/{orderId}` |
-| [getOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2783) | :closed_lock_with_key:  | GET | `api/v1/order/client-order/{clientOid}` |
-| [getFills()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2799) | :closed_lock_with_key:  | GET | `api/v1/fills` |
-| [getRecentFills()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2809) | :closed_lock_with_key:  | GET | `api/v1/limit/fills` |
-| [submitMarginOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2823) | :closed_lock_with_key:  | POST | `api/v1/margin/order` |
-| [submitMarginOrderTest()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2833) | :closed_lock_with_key:  | POST | `api/v1/margin/order/test` |
-| [getIsolatedMarginAccounts()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2847) | :closed_lock_with_key:  | GET | `api/v1/isolated/accounts` |
-| [getIsolatedMarginAccount()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2857) | :closed_lock_with_key:  | GET | `api/v1/isolated/account/{symbol}` |
+| [getMyIp()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L321) |  | GET | `api/v1/ip` |
+| [getServiceStatus()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L329) |  | GET | `api/v1/status` |
+| [getAccountSummary()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L344) | :closed_lock_with_key:  | GET | `api/v2/user-info` |
+| [getKYCRegions()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L353) | :closed_lock_with_key:  | GET | `api/kyc/regions/v4` |
+| [getApikeyInfo()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L363) | :closed_lock_with_key:  | GET | `api/v1/user/api-key` |
+| [getUserType()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L372) | :closed_lock_with_key:  | GET | `api/v1/hf/accounts/opened` |
+| [getBalances()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L381) | :closed_lock_with_key:  | GET | `api/v1/accounts` |
+| [getAccountDetail()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L392) | :closed_lock_with_key:  | GET | `api/v1/accounts/{accountId}` |
+| [getMarginBalance()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L403) | :closed_lock_with_key:  | GET | `api/v3/margin/accounts` |
+| [getIsolatedMarginBalance()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L414) | :closed_lock_with_key:  | GET | `api/v3/isolated/accounts` |
+| [getTransactions()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L427) | :closed_lock_with_key:  | GET | `api/v1/accounts/ledgers` |
+| [getHFTransactions()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L439) | :closed_lock_with_key:  | GET | `api/v1/hf/accounts/ledgers` |
+| [getHFMarginTransactions()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L451) | :closed_lock_with_key:  | GET | `api/v3/hf/margin/account/ledgers` |
+| [createSubAccount()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L468) | :closed_lock_with_key:  | POST | `api/v2/sub/user/created` |
+| [enableSubAccountMargin()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L480) | :closed_lock_with_key:  | POST | `api/v3/sub/user/margin/enable` |
+| [enableSubAccountFutures()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L490) | :closed_lock_with_key:  | POST | `api/v3/sub/user/futures/enable` |
+| [getSubAccountsV2()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L499) | :closed_lock_with_key:  | GET | `api/v2/sub/user` |
+| [getSubAccountBalance()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L511) | :closed_lock_with_key:  | GET | `api/v1/sub-accounts/{subUserId}` |
+| [getSubAccountBalancesV2()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L526) | :closed_lock_with_key:  | GET | `api/v2/sub-accounts` |
+| [createSubAPI()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L544) | :closed_lock_with_key:  | POST | `api/v1/sub/api-key` |
+| [updateSubAPI()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L555) | :closed_lock_with_key:  | POST | `api/v1/sub/api-key/update` |
+| [getSubAPIs()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L567) | :closed_lock_with_key:  | GET | `api/v1/sub/api-key` |
+| [deleteSubAPI()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L579) | :closed_lock_with_key:  | DELETE | `api/v1/sub/api-key` |
+| [createDepositAddressV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L596) | :closed_lock_with_key:  | POST | `api/v3/deposit-address/create` |
+| [getDepositAddressesV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L608) | :closed_lock_with_key:  | GET | `api/v3/deposit-addresses` |
+| [getDeposits()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L622) | :closed_lock_with_key:  | GET | `api/v1/deposits` |
+| [getWithdrawalQuotas()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L639) | :closed_lock_with_key:  | GET | `api/v1/withdrawals/quotas` |
+| [submitWithdrawV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L651) | :closed_lock_with_key:  | POST | `api/v3/withdrawals` |
+| [cancelWithdrawal()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L664) | :closed_lock_with_key:  | DELETE | `api/v1/withdrawals/{withdrawalId}` |
+| [getWithdrawals()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L676) | :closed_lock_with_key:  | GET | `api/v1/withdrawals` |
+| [getWithdrawalById()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L687) | :closed_lock_with_key:  | GET | `api/v1/withdrawals/{withdrawalId}` |
+| [getTransferable()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L705) | :closed_lock_with_key:  | GET | `api/v1/accounts/transferable` |
+| [submitFlexTransfer()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L717) | :closed_lock_with_key:  | POST | `api/v3/accounts/universal-transfer` |
+| [getBasicUserFee()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L736) | :closed_lock_with_key:  | GET | `api/v1/base-fee` |
+| [getTradingPairFee()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L752) | :closed_lock_with_key:  | GET | `api/v1/trade-fees` |
+| [getAnnouncements()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L775) |  | GET | `api/v3/announcements` |
+| [getCurrency()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L786) |  | GET | `api/v3/currencies/{currency}` |
+| [getCurrencies()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L798) |  | GET | `api/v3/currencies` |
+| [getSymbol()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L808) |  | GET | `api/v2/symbols/{symbol}` |
+| [getSymbols()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L820) |  | GET | `api/v2/symbols` |
+| [getTicker()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L833) |  | GET | `api/v1/market/orderbook/level1` |
+| [getTickers()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L842) |  | GET | `api/v1/market/allTickers` |
+| [getTradeHistories()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L853) |  | GET | `api/v1/market/histories` |
+| [getKlines()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L865) |  | GET | `api/v1/market/candles` |
+| [getOrderBookLevel20()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L876) |  | GET | `api/v1/market/orderbook/level2_20` |
+| [getOrderBookLevel100()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L887) |  | GET | `api/v1/market/orderbook/level2_100` |
+| [getFullOrderBook()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L898) | :closed_lock_with_key:  | GET | `api/v3/market/orderbook/level2` |
+| [getCallAuctionPartOrderBook()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L910) |  | GET | `api/v1/market/orderbook/callauction/level2_{size}` |
+| [getCallAuctionInfo()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L927) |  | GET | `api/v1/market/callauctionData` |
+| [getFiatPrice()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L938) |  | GET | `api/v1/prices` |
+| [get24hrStats()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L947) |  | GET | `api/v1/market/stats` |
+| [getMarkets()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L958) |  | GET | `api/v1/markets` |
+| [submitHFOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L975) | :closed_lock_with_key:  | POST | `api/v1/hf/orders` |
+| [submitHFOrderSync()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L991) | :closed_lock_with_key:  | POST | `api/v1/hf/orders/sync` |
+| [submitHFOrderTest()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1003) | :closed_lock_with_key:  | POST | `api/v1/hf/orders/test` |
+| [submitHFMultipleOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1012) | :closed_lock_with_key:  | POST | `api/v1/hf/orders/multi` |
+| [submitHFMultipleOrdersSync()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1024) | :closed_lock_with_key:  | POST | `api/v1/hf/orders/multi/sync` |
+| [cancelHFOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1036) | :closed_lock_with_key:  | DELETE | `api/v1/hf/orders/{orderId}` |
+| [cancelHFOrderSync()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1050) | :closed_lock_with_key:  | DELETE | `api/v1/hf/orders/sync/{orderId}` |
+| [cancelHFOrderByClientOId()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1066) | :closed_lock_with_key:  | DELETE | `api/v1/hf/orders/client-order/{clientOid}` |
+| [cancelHFOrderSyncByClientOId()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1086) | :closed_lock_with_key:  | DELETE | `api/v1/hf/orders/sync/client-order/{clientOid}` |
+| [cancelHFOrdersNumber()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1101) | :closed_lock_with_key:  | DELETE | `api/v1/hf/orders/cancel/{orderId}` |
+| [cancelHFAllOrdersBySymbol()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1116) | :closed_lock_with_key:  | DELETE | `api/v1/hf/orders` |
+| [cancelHFAllOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1127) | :closed_lock_with_key:  | DELETE | `api/v1/hf/orders/cancelAll` |
+| [updateHFOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1136) | :closed_lock_with_key:  | POST | `api/v1/hf/orders/alter` |
+| [getHFOrderDetailsByOrderId()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1150) | :closed_lock_with_key:  | GET | `api/v1/hf/orders/{orderId}` |
+| [getHFOrderDetailsByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1162) | :closed_lock_with_key:  | GET | `api/v1/hf/orders/client-order/{clientOid}` |
+| [getHFActiveSymbols()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1177) | :closed_lock_with_key:  | GET | `api/v1/hf/orders/active/symbols` |
+| [getHFActiveOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1192) | :closed_lock_with_key:  | GET | `api/v1/hf/orders/active` |
+| [getHFActiveOrdersPaginated()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1204) | :closed_lock_with_key:  | GET | `api/v1/hf/orders/active/page` |
+| [getHFCompletedOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1226) | :closed_lock_with_key:  | GET | `api/v1/hf/orders/done` |
+| [getHFFilledOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1240) | :closed_lock_with_key:  | GET | `api/v1/hf/fills` |
+| [cancelHFOrderAutoSettingQuery()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1255) | :closed_lock_with_key:  | GET | `api/v1/hf/orders/dead-cancel-all/query` |
+| [cancelHFOrderAutoSetting()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1268) | :closed_lock_with_key:  | POST | `api/v1/hf/orders/dead-cancel-all` |
+| [submitStopOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1285) | :closed_lock_with_key:  | POST | `api/v1/stop-order` |
+| [cancelStopOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1296) | :closed_lock_with_key:  | DELETE | `api/v1/stop-order/cancelOrderByClientOid` |
+| [cancelStopOrderById()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1316) | :closed_lock_with_key:  | DELETE | `api/v1/stop-order/{orderId}` |
+| [cancelStopOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1329) | :closed_lock_with_key:  | DELETE | `api/v1/stop-order/cancel` |
+| [getStopOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1342) | :closed_lock_with_key:  | GET | `api/v1/stop-order` |
+| [getStopOrderByOrderId()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1355) | :closed_lock_with_key:  | GET | `api/v1/stop-order/{orderId}` |
+| [getStopOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1366) | :closed_lock_with_key:  | GET | `api/v1/stop-order/queryOrderByClientOid` |
+| [submitOCOOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1378) | :closed_lock_with_key:  | POST | `api/v3/oco/order` |
+| [cancelOCOOrderById()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1391) | :closed_lock_with_key:  | DELETE | `api/v3/oco/order/{orderId}` |
+| [cancelOCOOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1404) | :closed_lock_with_key:  | DELETE | `api/v3/oco/client-order/{clientOid}` |
+| [cancelMultipleOCOOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1417) | :closed_lock_with_key:  | DELETE | `api/v3/oco/orders` |
+| [getOCOOrderByOrderId()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1433) | :closed_lock_with_key:  | GET | `api/v3/oco/order/{orderId}` |
+| [getOCOOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1444) | :closed_lock_with_key:  | GET | `api/v3/oco/client-order/{clientOid}` |
+| [getOCOOrderDetails()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1455) | :closed_lock_with_key:  | GET | `api/v3/oco/order/details/{orderId}` |
+| [getOCOOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1466) | :closed_lock_with_key:  | GET | `api/v3/oco/orders` |
+| [getMarginActivePairsV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1483) | :closed_lock_with_key:  | GET | `api/v3/margin/symbols` |
+| [getMarginConfigInfo()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1496) |  | GET | `api/v1/margin/config` |
+| [getMarginLeveragedToken()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1505) | :closed_lock_with_key:  | GET | `api/v3/etf/info` |
+| [getMarginMarkPrices()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1516) |  | GET | `api/v3/mark-price/all-symbols` |
+| [getMarginMarkPrice()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1525) |  | GET | `api/v1/mark-price/{symbol}/current` |
+| [getIsolatedMarginSymbolsConfig()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1536) | :closed_lock_with_key:  | GET | `api/v1/isolated/symbols` |
+| [getMarginCollateralRatio()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1547) |  | GET | `api/v3/margin/collateralRatio` |
+| [getMarketAvailableInventory()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1558) |  | GET | `api/v3/margin/available-inventory` |
+| [submitHFMarginOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1575) | :closed_lock_with_key:  | POST | `api/v3/hf/margin/order` |
+| [submitHFMarginOrderTest()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1586) | :closed_lock_with_key:  | POST | `api/v3/hf/margin/order/test` |
+| [cancelHFMarginOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1597) | :closed_lock_with_key:  | DELETE | `api/v3/hf/margin/orders/{orderId}` |
+| [cancelHFMarginOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1613) | :closed_lock_with_key:  | DELETE | `api/v3/hf/margin/orders/client-order/{clientOid}` |
+| [cancelHFAllMarginOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1632) | :closed_lock_with_key:  | DELETE | `api/v3/hf/margin/orders` |
+| [getHFMarginOpenSymbols()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1644) | :closed_lock_with_key:  | GET | `api/v3/hf/margin/order/active/symbols` |
+| [getHFActiveMarginOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1655) | :closed_lock_with_key:  | GET | `api/v3/hf/margin/orders/active` |
+| [getHFMarginFilledOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1666) | :closed_lock_with_key:  | GET | `api/v3/hf/margin/orders/done` |
+| [getHFMarginFills()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1680) | :closed_lock_with_key:  | GET | `api/v3/hf/margin/fills` |
+| [getHFMarginOrderByOrderId()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1694) | :closed_lock_with_key:  | GET | `api/v3/hf/margin/orders/{orderId}` |
+| [getHFMarginOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1706) | :closed_lock_with_key:  | GET | `api/v3/hf/margin/orders/client-order/{clientOid}?symbol={symbol}` |
+| [addMarginStopOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1720) | :closed_lock_with_key:  | POST | `api/v3/hf/margin/stop-order` |
+| [cancelMarginStopOrderByOrderId()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1731) | :closed_lock_with_key:  | DELETE | `api/v3/hf/margin/stop-order/cancel-by-id?orderId={orderId}` |
+| [cancelMarginStopOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1744) | :closed_lock_with_key:  | DELETE | `api/v3/hf/margin/stop-order/cancel-by-clientOid` |
+| [batchCancelMarginStopOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1758) | :closed_lock_with_key:  | DELETE | `api/v3/hf/margin/stop-order/cancel` |
+| [getMarginStopOrdersList()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1769) | :closed_lock_with_key:  | GET | `api/v3/hf/margin/stop-orders` |
+| [getMarginStopOrderByOrderId()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1780) | :closed_lock_with_key:  | GET | `api/v3/hf/margin/stop-order/orderId?orderId={orderId}` |
+| [getMarginStopOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1793) | :closed_lock_with_key:  | GET | `api/v3/hf/margin/stop-order/clientOid` |
+| [addMarginOcoOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1804) | :closed_lock_with_key:  | POST | `api/v3/hf/margin/oco-order` |
+| [cancelMarginOcoOrderByOrderId()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1815) | :closed_lock_with_key:  | DELETE | `api/v3/hf/margin/oco-order/cancel-by-id?orderId={orderId}` |
+| [cancelMarginOcoOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1828) | :closed_lock_with_key:  | DELETE | `api/v3/hf/margin/oco-order/cancel-by-clientOid` |
+| [batchCancelMarginOcoOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1842) | :closed_lock_with_key:  | DELETE | `api/v3/hf/margin/oco-order/cancel` |
+| [getMarginOcoOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1853) | :closed_lock_with_key:  | GET | `api/v3/hf/margin/oco-order/clientOid` |
+| [getMarginOcoOrderDetailByOrderId()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1864) | :closed_lock_with_key:  | GET | `api/v3/hf/margin/oco-order/detail/orderId?orderId={orderId}` |
+| [getBorrowInterestRate()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1883) | :closed_lock_with_key:  | GET | `api/v3/margin/borrowRate` |
+| [marginBorrowV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1894) | :closed_lock_with_key:  | POST | `api/v3/margin/borrow` |
+| [getMarginBorrowHistoryV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1905) | :closed_lock_with_key:  | GET | `api/v3/margin/borrow` |
+| [marginRepayV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1916) | :closed_lock_with_key:  | POST | `api/v3/margin/repay` |
+| [getMarginRepayHistoryV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1927) | :closed_lock_with_key:  | GET | `api/v3/margin/repay` |
+| [getMarginInterestRecordsV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1938) | :closed_lock_with_key:  | GET | `api/v3/margin/interest` |
+| [updateMarginLeverageV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1949) | :closed_lock_with_key:  | POST | `api/v3/position/update-user-leverage` |
+| [getLendingCurrencyV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1968) |  | GET | `api/v3/project/list` |
+| [getLendingInterestRateV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1979) |  | GET | `api/v3/project/marketInterestRate` |
+| [submitLendingSubscriptionV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L1995) | :closed_lock_with_key:  | POST | `api/v3/purchase` |
+| [updateLendingSubscriptionOrdersV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2012) | :closed_lock_with_key:  | POST | `api/v3/lend/purchase/update` |
+| [getLendingSubscriptionOrdersV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2023) | :closed_lock_with_key:  | GET | `api/v3/purchase/orders` |
+| [submitLendingRedemptionV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2034) | :closed_lock_with_key:  | POST | `api/v3/redeem` |
+| [getLendingRedemptionOrdersV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2051) | :closed_lock_with_key:  | GET | `api/v3/redeem/orders` |
+| [getMarginRiskLimitConfig()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2068) | :closed_lock_with_key:  | GET | `api/v3/margin/currencies` |
+| [getConvertSymbol()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2085) |  | GET | `api/v1/convert/symbol` |
+| [getConvertCurrencies()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2096) |  | GET | `api/v1/convert/currencies` |
+| [submitConvertOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2105) | :closed_lock_with_key:  | POST | `api/v1/convert/order` |
+| [getConvertQuote()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2116) | :closed_lock_with_key:  | GET | `api/v1/convert/quote` |
+| [getConvertOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2127) | :closed_lock_with_key:  | GET | `api/v1/convert/order/detail` |
+| [getConvertOrderHistory()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2138) | :closed_lock_with_key:  | GET | `api/v1/convert/order/history` |
+| [submitConvertLimitOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2149) | :closed_lock_with_key:  | POST | `api/v1/convert/limit/order` |
+| [getConvertLimitQuote()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2160) | :closed_lock_with_key:  | GET | `api/v1/convert/limit/quote` |
+| [getConvertLimitOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2171) | :closed_lock_with_key:  | GET | `api/v1/convert/limit/order/detail` |
+| [getConvertLimitOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2182) | :closed_lock_with_key:  | GET | `api/v1/convert/limit/orders` |
+| [cancelConvertLimitOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2193) | :closed_lock_with_key:  | DELETE | `api/v1/convert/limit/order/cancel` |
+| [subscribeEarnFixedIncome()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2211) | :closed_lock_with_key:  | POST | `api/v1/earn/orders` |
+| [getEarnRedeemPreview()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2222) | :closed_lock_with_key:  | GET | `api/v1/earn/redeem-preview` |
+| [submitRedemption()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2233) | :closed_lock_with_key:  | DELETE | `api/v1/earn/orders` |
+| [getEarnSavingsProducts()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2244) | :closed_lock_with_key:  | GET | `api/v1/earn/saving/products` |
+| [getEarnPromotionProducts()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2255) | :closed_lock_with_key:  | GET | `api/v1/earn/promotion/products` |
+| [getEarnFixedIncomeHoldAssets()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2266) | :closed_lock_with_key:  | GET | `api/v1/earn/hold-assets` |
+| [getEarnStakingProducts()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2277) | :closed_lock_with_key:  | GET | `api/v1/earn/staking/products` |
+| [getEarnKcsStakingProducts()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2289) | :closed_lock_with_key:  | GET | `api/v1/earn/kcs-staking/products` |
+| [getEarnEthStakingProducts()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2301) | :closed_lock_with_key:  | GET | `api/v1/earn/eth-staking/products` |
+| [submitStructuredProductPurchase()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2318) | :closed_lock_with_key:  | POST | `api/v1/struct-earn/orders` |
+| [getDualInvestmentProducts()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2329) |  | GET | `api/v1/struct-earn/dual/products` |
+| [getStructuredProductOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2340) | :closed_lock_with_key:  | GET | `api/v1/struct-earn/orders` |
+| [getDiscountRateConfigs()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2358) | :closed_lock_with_key:  | GET | `api/v1/otc-loan/discount-rate-configs` |
+| [getOtcLoan()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2369) | :closed_lock_with_key:  | GET | `api/v1/otc-loan/loan` |
+| [getOtcLoanAccounts()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2378) | :closed_lock_with_key:  | GET | `api/v1/otc-loan/accounts` |
+| [getAffiliateUserRebateInfo()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2394) | :closed_lock_with_key:  | GET | `api/v2/affiliate/inviter/statistics` |
+| [getAffiliateInvitees()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2403) | :closed_lock_with_key:  | GET | `api/v2/affiliate/queryInvitees` |
+| [getAffiliateCommission()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2414) | :closed_lock_with_key:  | GET | `api/v2/affiliate/queryMyCommission` |
+| [getAffiliateTradeHistory()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2425) | :closed_lock_with_key:  | GET | `api/v2/affiliate/queryTransactionByUid` |
+| [getAffiliateTransaction()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2436) | :closed_lock_with_key:  | GET | `api/v2/affiliate/queryTransactionByTime` |
+| [getKumining()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2447) | :closed_lock_with_key:  | GET | `api/v2/affiliate/queryKumining` |
+| [getBrokerRebateOrderDownloadLink()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2465) | :closed_lock_with_key:  | GET | `api/v1/broker/api/rebase/download` |
+| [getBrokerRebateOrderDownloadLinkV2()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2478) | :closed_lock_with_key:  | GET | `api/v2/broker/api/rebase/download` |
+| [getPublicWSConnectionToken()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2495) |  | POST | `api/v1/bullet-public` |
+| [getPrivateWSConnectionToken()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2502) | :closed_lock_with_key:  | POST | `api/v1/bullet-private` |
+| [getPrivateWSConnectionTokenV2()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2510) | :closed_lock_with_key:  | POST | `api/v2/bullet-private` |
+| [getSubAccountsV1()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2532) | :closed_lock_with_key:  | GET | `api/v1/sub/user` |
+| [getSubAccountBalancesV1()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2540) | :closed_lock_with_key:  | GET | `api/v1/sub-accounts` |
+| [getMarginBalances()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2555) | :closed_lock_with_key:  | GET | `api/v1/margin/account` |
+| [createDepositAddress()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2573) | :closed_lock_with_key:  | POST | `api/v1/deposit-addresses` |
+| [getDepositAddressesV2()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2583) | :closed_lock_with_key:  | GET | `api/v2/deposit-addresses` |
+| [getDepositAddressV1()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2592) | :closed_lock_with_key:  | GET | `api/v1/deposit-addresses` |
+| [getHistoricalDepositsV1()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2603) | :closed_lock_with_key:  | GET | `api/v1/hist-deposits` |
+| [getHistoricalWithdrawalsV1()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2619) | :closed_lock_with_key:  | GET | `api/v1/hist-withdrawals` |
+| [submitWithdraw()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2628) | :closed_lock_with_key:  | POST | `api/v1/withdrawals` |
+| [submitTransferMasterSub()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2644) | :closed_lock_with_key:  | POST | `api/v2/accounts/sub-transfer` |
+| [submitInnerTransfer()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2656) | :closed_lock_with_key:  | POST | `api/v2/accounts/inner-transfer` |
+| [submitOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2674) | :closed_lock_with_key:  | POST | `api/v1/orders` |
+| [submitOrderTest()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2686) | :closed_lock_with_key:  | POST | `api/v1/orders/test` |
+| [submitMultipleOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2694) | :closed_lock_with_key:  | POST | `api/v1/orders/multi` |
+| [cancelOrderById()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2705) | :closed_lock_with_key:  | DELETE | `api/v1/orders/{orderId}` |
+| [cancelOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2717) | :closed_lock_with_key:  | DELETE | `api/v1/order/client-order/{clientOid}` |
+| [cancelAllOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2730) | :closed_lock_with_key:  | DELETE | `api/v1/orders` |
+| [getOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2742) | :closed_lock_with_key:  | GET | `api/v1/orders` |
+| [getRecentOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2752) | :closed_lock_with_key:  | GET | `api/v1/limit/orders` |
+| [getOrderByOrderId()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2763) | :closed_lock_with_key:  | GET | `api/v1/orders/{orderId}` |
+| [getOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2773) | :closed_lock_with_key:  | GET | `api/v1/order/client-order/{clientOid}` |
+| [getFills()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2789) | :closed_lock_with_key:  | GET | `api/v1/fills` |
+| [getRecentFills()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2799) | :closed_lock_with_key:  | GET | `api/v1/limit/fills` |
+| [submitMarginOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2814) | :closed_lock_with_key:  | POST | `api/v1/margin/order` |
+| [submitMarginOrderTest()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2825) | :closed_lock_with_key:  | POST | `api/v1/margin/order/test` |
+| [getIsolatedMarginAccounts()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2840) | :closed_lock_with_key:  | GET | `api/v1/isolated/accounts` |
+| [getIsolatedMarginAccount()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts#L2851) | :closed_lock_with_key:  | GET | `api/v1/isolated/account/{symbol}` |
 
 # FuturesClient.ts
 
@@ -258,88 +258,88 @@ This table includes all endpoints from the official Exchange API docs and corres
 
 | Function | AUTH | HTTP Method | Endpoint |
 | -------- | :------: | :------: | -------- |
-| [getBalance()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L110) | :closed_lock_with_key:  | GET | `api/v1/account-overview` |
-| [getTransactions()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L120) | :closed_lock_with_key:  | GET | `api/v1/transaction-history` |
-| [getSubBalances()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L139) | :closed_lock_with_key:  | GET | `api/v1/account-overview-all` |
-| [getTradingPairFee()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L158) | :closed_lock_with_key:  | GET | `api/v1/trade-fees` |
-| [getSymbol()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L179) |  | GET | `api/v1/contracts/{symbol}` |
-| [getSymbols()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L190) |  | GET | `api/v1/contracts/active` |
-| [getTicker()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L198) |  | GET | `api/v1/ticker` |
-| [getTickers()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L208) |  | GET | `api/v1/allTickers` |
-| [getFullOrderBookLevel2()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L216) |  | GET | `api/v1/level2/snapshot` |
-| [getPartOrderBookLevel2Depth20()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L226) |  | GET | `api/v1/level2/depth20` |
-| [getPartOrderBookLevel2Depth100()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L236) |  | GET | `api/v1/level2/depth100` |
-| [getMarketTrades()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L246) |  | GET | `api/v1/trade/history` |
-| [getKlines()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L256) |  | GET | `api/v1/kline/query` |
-| [getMarkPrice()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L266) |  | GET | `api/v1/mark-price/{symbol}/current` |
-| [getIndex()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L276) |  | GET | `api/v1/index/query` |
-| [getInterestRates()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L289) |  | GET | `api/v1/interest/query` |
-| [getPremiumIndex()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L302) |  | GET | `api/v1/premium/query` |
-| [get24HourTransactionVolume()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L315) |  | GET | `api/v1/trade-statistics` |
-| [getServiceStatus()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L335) |  | GET | `api/v1/status` |
-| [submitOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L349) | :closed_lock_with_key:  | POST | `api/v1/orders` |
-| [submitNewOrderTest()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L362) | :closed_lock_with_key:  | POST | `api/v1/orders/test` |
-| [submitMultipleOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L373) | :closed_lock_with_key:  | POST | `api/v1/orders/multi` |
-| [submitSLTPOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L383) | :closed_lock_with_key:  | POST | `api/v1/st-orders` |
-| [cancelOrderById()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L396) | :closed_lock_with_key:  | DELETE | `api/v1/orders/{orderId}` |
-| [cancelOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L406) | :closed_lock_with_key:  | DELETE | `api/v1/orders/client-order/{clientOid}` |
-| [batchCancelOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L420) | :closed_lock_with_key:  | DELETE | `api/v1/orders/multi-cancel` |
-| [cancelAllOrdersV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L430) | :closed_lock_with_key:  | DELETE | `api/v3/orders` |
-| [cancelAllStopOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L440) | :closed_lock_with_key:  | DELETE | `api/v1/stopOrders` |
-| [getOrderByOrderId()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L450) | :closed_lock_with_key:  | GET | `api/v1/orders/{orderId}` |
-| [getOrderByClientOrderId()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L460) | :closed_lock_with_key:  | GET | `api/v1/orders/byClientOid` |
-| [getOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L470) | :closed_lock_with_key:  | GET | `api/v1/orders` |
-| [getRecentOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L480) | :closed_lock_with_key:  | GET | `api/v1/recentDoneOrders` |
-| [getStopOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L490) | :closed_lock_with_key:  | GET | `api/v1/stopOrders` |
-| [getOpenOrderStatistics()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L500) | :closed_lock_with_key:  | GET | `api/v1/openOrderStatistics` |
-| [getRecentFills()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L510) | :closed_lock_with_key:  | GET | `api/v1/recentFills` |
-| [getFills()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L521) | :closed_lock_with_key:  | GET | `api/v1/fills` |
-| [getMarginMode()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L537) | :closed_lock_with_key:  | GET | `api/v2/position/getMarginMode` |
-| [updateMarginMode()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L550) | :closed_lock_with_key:  | POST | `api/v2/position/changeMarginMode` |
-| [batchSwitchMarginMode()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L566) | :closed_lock_with_key:  | POST | `api/v2/position/batchChangeMarginMode` |
-| [getMaxOpenSize()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L577) | :closed_lock_with_key:  | GET | `api/v2/getMaxOpenSize` |
-| [getPosition()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L588) | :closed_lock_with_key:  | GET | `api/v1/position` |
-| [getPositionV2()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L598) | :closed_lock_with_key:  | GET | `api/v2/position` |
-| [getPositions()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L608) | :closed_lock_with_key:  | GET | `api/v1/positions` |
-| [getHistoryPositions()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L618) | :closed_lock_with_key:  | GET | `api/v1/history-positions` |
-| [getMaxWithdrawMargin()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L632) | :closed_lock_with_key:  | GET | `api/v1/margin/maxWithdrawMargin` |
-| [getCrossMarginLeverage()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L642) | :closed_lock_with_key:  | GET | `api/v2/getCrossUserLeverage` |
-| [changeCrossMarginLeverage()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L655) | :closed_lock_with_key:  | POST | `api/v2/changeCrossUserLeverage` |
-| [depositMargin()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L671) | :closed_lock_with_key:  | POST | `api/v1/position/margin/deposit-margin` |
-| [getCrossMarginRiskLimit()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L683) | :closed_lock_with_key:  | GET | `api/v2/batchGetCrossOrderLimit` |
-| [withdrawMargin()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L695) | :closed_lock_with_key:  | POST | `api/v1/margin/withdrawMargin` |
-| [getCrossMarginRequirement()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L706) | :closed_lock_with_key:  | GET | `api/v2/getCrossModeMarginRequirement` |
-| [getRiskLimitLevel()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L718) | :closed_lock_with_key:  | GET | `api/v1/contracts/risk-limit/{symbol}` |
-| [updateRiskLimitLevel()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L728) | :closed_lock_with_key:  | POST | `api/v1/position/risk-limit-level/change` |
-| [getPositionMode()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L739) | :closed_lock_with_key:  | GET | `api/v2/position/getPositionMode` |
-| [updatePositionMode()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L747) | :closed_lock_with_key:  | POST | `api/v2/position/switchPositionMode` |
-| [getFundingRate()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L765) | :closed_lock_with_key:  | GET | `api/v1/funding-rate/{symbol}/current` |
-| [getFundingRates()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L775) | :closed_lock_with_key:  | GET | `api/v1/contract/funding-rates` |
-| [getFundingHistory()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L785) | :closed_lock_with_key:  | GET | `api/v1/funding-history` |
-| [submitCopyTradeOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L805) | :closed_lock_with_key:  | POST | `api/v1/copy-trade/futures/orders` |
-| [submitCopyTradeOrderTest()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L820) | :closed_lock_with_key:  | POST | `api/v1/copy-trade/futures/orders/test` |
-| [submitCopyTradeSLTPOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L834) | :closed_lock_with_key:  | POST | `api/v1/copy-trade/futures/st-orders` |
-| [cancelCopyTradeOrderById()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L847) | :closed_lock_with_key:  | DELETE | `api/v1/copy-trade/futures/orders` |
-| [cancelCopyTradeOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L857) | :closed_lock_with_key:  | DELETE | `api/v1/copy-trade/futures/orders/client-order` |
-| [getCopyTradeMaxOpenSize()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L871) | :closed_lock_with_key:  | GET | `api/v1/copy-trade/futures/get-max-open-size` |
-| [getCopyTradeMaxWithdrawMargin()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L892) | :closed_lock_with_key:  | GET | `api/v1/copy-trade/futures/position/margin/max-withdraw-margin` |
-| [addCopyTradeIsolatedMargin()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L906) | :closed_lock_with_key:  | POST | `api/v1/copy-trade/futures/position/margin/deposit-margin` |
-| [removeCopyTradeIsolatedMargin()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L922) | :closed_lock_with_key:  | POST | `api/v1/copy-trade/futures/position/margin/withdraw-margin` |
-| [modifyCopyTradeRiskLimitLevel()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L938) | :closed_lock_with_key:  | POST | `api/v1/copy-trade/futures/position/risk-limit-level/change` |
-| [updateCopyTradeAutoDepositStatus()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L953) | :closed_lock_with_key:  | POST | `api/v1/copy-trade/futures/position/margin/auto-deposit-status` |
-| [switchCopyTradeMarginMode()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L968) | :closed_lock_with_key:  | POST | `api/v1/copy-trade/futures/position/changeMarginMode` |
-| [updateCopyTradeCrossMarginLeverage()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L981) | :closed_lock_with_key:  | POST | `api/v2/copy-trade/futures/changeCrossUserLeverage` |
-| [getCopyTradeCrossMarginRequirement()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L994) | :closed_lock_with_key:  | POST | `api/v2/copy-trade/getCrossModeMarginRequirement` |
-| [switchCopyTradePositionMode()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L1008) | :closed_lock_with_key:  | POST | `api/v2/copy-trade/position/switchPositionMode` |
-| [getBrokerRebateOrderDownloadLink()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L1028) | :closed_lock_with_key:  | GET | `api/v1/broker/api/rebase/download` |
-| [getBrokerRebateOrderDownloadLinkV2()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L1041) | :closed_lock_with_key:  | GET | `api/v2/broker/api/rebase/download` |
-| [getPublicWSConnectionToken()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L1058) |  | POST | `api/v1/bullet-public` |
-| [getPrivateWSConnectionToken()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L1065) | :closed_lock_with_key:  | POST | `api/v1/bullet-private` |
-| [getPrivateWSConnectionTokenV2()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L1073) | :closed_lock_with_key:  | POST | `api/v2/bullet-private` |
-| [submitTransferOut()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L1088) | :closed_lock_with_key:  | POST | `api/v3/transfer-out` |
-| [submitTransferIn()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L1099) | :closed_lock_with_key:  | POST | `api/v1/transfer-in` |
-| [getTransfers()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L1110) | :closed_lock_with_key:  | GET | `api/v1/transfer-list` |
-| [updateAutoDepositStatus()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L1125) | :closed_lock_with_key:  | POST | `api/v1/position/margin/auto-deposit-status` |
+| [getBalance()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L97) | :closed_lock_with_key:  | GET | `api/v1/account-overview` |
+| [getTransactions()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L107) | :closed_lock_with_key:  | GET | `api/v1/transaction-history` |
+| [getSubBalances()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L126) | :closed_lock_with_key:  | GET | `api/v1/account-overview-all` |
+| [getTradingPairFee()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L145) | :closed_lock_with_key:  | GET | `api/v1/trade-fees` |
+| [getSymbol()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L166) |  | GET | `api/v1/contracts/{symbol}` |
+| [getSymbols()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L177) |  | GET | `api/v1/contracts/active` |
+| [getTicker()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L185) |  | GET | `api/v1/ticker` |
+| [getTickers()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L195) |  | GET | `api/v1/allTickers` |
+| [getFullOrderBookLevel2()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L203) |  | GET | `api/v1/level2/snapshot` |
+| [getPartOrderBookLevel2Depth20()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L213) |  | GET | `api/v1/level2/depth20` |
+| [getPartOrderBookLevel2Depth100()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L223) |  | GET | `api/v1/level2/depth100` |
+| [getMarketTrades()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L233) |  | GET | `api/v1/trade/history` |
+| [getKlines()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L243) |  | GET | `api/v1/kline/query` |
+| [getMarkPrice()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L253) |  | GET | `api/v1/mark-price/{symbol}/current` |
+| [getIndex()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L263) |  | GET | `api/v1/index/query` |
+| [getInterestRates()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L276) |  | GET | `api/v1/interest/query` |
+| [getPremiumIndex()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L289) |  | GET | `api/v1/premium/query` |
+| [get24HourTransactionVolume()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L302) |  | GET | `api/v1/trade-statistics` |
+| [getServiceStatus()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L322) |  | GET | `api/v1/status` |
+| [submitOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L336) | :closed_lock_with_key:  | POST | `api/v1/orders` |
+| [submitNewOrderTest()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L349) | :closed_lock_with_key:  | POST | `api/v1/orders/test` |
+| [submitMultipleOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L360) | :closed_lock_with_key:  | POST | `api/v1/orders/multi` |
+| [submitSLTPOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L370) | :closed_lock_with_key:  | POST | `api/v1/st-orders` |
+| [cancelOrderById()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L383) | :closed_lock_with_key:  | DELETE | `api/v1/orders/{orderId}` |
+| [cancelOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L393) | :closed_lock_with_key:  | DELETE | `api/v1/orders/client-order/{clientOid}` |
+| [batchCancelOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L407) | :closed_lock_with_key:  | DELETE | `api/v1/orders/multi-cancel` |
+| [cancelAllOrdersV3()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L417) | :closed_lock_with_key:  | DELETE | `api/v3/orders` |
+| [cancelAllStopOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L427) | :closed_lock_with_key:  | DELETE | `api/v1/stopOrders` |
+| [getOrderByOrderId()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L437) | :closed_lock_with_key:  | GET | `api/v1/orders/{orderId}` |
+| [getOrderByClientOrderId()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L447) | :closed_lock_with_key:  | GET | `api/v1/orders/byClientOid` |
+| [getOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L457) | :closed_lock_with_key:  | GET | `api/v1/orders` |
+| [getRecentOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L467) | :closed_lock_with_key:  | GET | `api/v1/recentDoneOrders` |
+| [getStopOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L477) | :closed_lock_with_key:  | GET | `api/v1/stopOrders` |
+| [getOpenOrderStatistics()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L487) | :closed_lock_with_key:  | GET | `api/v1/openOrderStatistics` |
+| [getRecentFills()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L497) | :closed_lock_with_key:  | GET | `api/v1/recentFills` |
+| [getFills()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L508) | :closed_lock_with_key:  | GET | `api/v1/fills` |
+| [getMarginMode()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L524) | :closed_lock_with_key:  | GET | `api/v2/position/getMarginMode` |
+| [updateMarginMode()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L537) | :closed_lock_with_key:  | POST | `api/v2/position/changeMarginMode` |
+| [batchSwitchMarginMode()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L553) | :closed_lock_with_key:  | POST | `api/v2/position/batchChangeMarginMode` |
+| [getMaxOpenSize()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L564) | :closed_lock_with_key:  | GET | `api/v2/getMaxOpenSize` |
+| [getPosition()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L575) | :closed_lock_with_key:  | GET | `api/v1/position` |
+| [getPositionV2()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L585) | :closed_lock_with_key:  | GET | `api/v2/position` |
+| [getPositions()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L595) | :closed_lock_with_key:  | GET | `api/v1/positions` |
+| [getHistoryPositions()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L605) | :closed_lock_with_key:  | GET | `api/v1/history-positions` |
+| [getMaxWithdrawMargin()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L619) | :closed_lock_with_key:  | GET | `api/v1/margin/maxWithdrawMargin` |
+| [getCrossMarginLeverage()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L629) | :closed_lock_with_key:  | GET | `api/v2/getCrossUserLeverage` |
+| [changeCrossMarginLeverage()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L642) | :closed_lock_with_key:  | POST | `api/v2/changeCrossUserLeverage` |
+| [depositMargin()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L658) | :closed_lock_with_key:  | POST | `api/v1/position/margin/deposit-margin` |
+| [getCrossMarginRiskLimit()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L670) | :closed_lock_with_key:  | GET | `api/v2/batchGetCrossOrderLimit` |
+| [withdrawMargin()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L682) | :closed_lock_with_key:  | POST | `api/v1/margin/withdrawMargin` |
+| [getCrossMarginRequirement()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L693) | :closed_lock_with_key:  | GET | `api/v2/getCrossModeMarginRequirement` |
+| [getRiskLimitLevel()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L705) | :closed_lock_with_key:  | GET | `api/v1/contracts/risk-limit/{symbol}` |
+| [updateRiskLimitLevel()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L715) | :closed_lock_with_key:  | POST | `api/v1/position/risk-limit-level/change` |
+| [getPositionMode()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L726) | :closed_lock_with_key:  | GET | `api/v2/position/getPositionMode` |
+| [updatePositionMode()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L734) | :closed_lock_with_key:  | POST | `api/v2/position/switchPositionMode` |
+| [getFundingRate()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L752) | :closed_lock_with_key:  | GET | `api/v1/funding-rate/{symbol}/current` |
+| [getFundingRates()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L762) | :closed_lock_with_key:  | GET | `api/v1/contract/funding-rates` |
+| [getFundingHistory()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L772) | :closed_lock_with_key:  | GET | `api/v1/funding-history` |
+| [submitCopyTradeOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L792) | :closed_lock_with_key:  | POST | `api/v1/copy-trade/futures/orders` |
+| [submitCopyTradeOrderTest()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L807) | :closed_lock_with_key:  | POST | `api/v1/copy-trade/futures/orders/test` |
+| [submitCopyTradeSLTPOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L821) | :closed_lock_with_key:  | POST | `api/v1/copy-trade/futures/st-orders` |
+| [cancelCopyTradeOrderById()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L834) | :closed_lock_with_key:  | DELETE | `api/v1/copy-trade/futures/orders` |
+| [cancelCopyTradeOrderByClientOid()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L844) | :closed_lock_with_key:  | DELETE | `api/v1/copy-trade/futures/orders/client-order` |
+| [getCopyTradeMaxOpenSize()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L858) | :closed_lock_with_key:  | GET | `api/v1/copy-trade/futures/get-max-open-size` |
+| [getCopyTradeMaxWithdrawMargin()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L879) | :closed_lock_with_key:  | GET | `api/v1/copy-trade/futures/position/margin/max-withdraw-margin` |
+| [addCopyTradeIsolatedMargin()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L893) | :closed_lock_with_key:  | POST | `api/v1/copy-trade/futures/position/margin/deposit-margin` |
+| [removeCopyTradeIsolatedMargin()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L909) | :closed_lock_with_key:  | POST | `api/v1/copy-trade/futures/position/margin/withdraw-margin` |
+| [modifyCopyTradeRiskLimitLevel()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L925) | :closed_lock_with_key:  | POST | `api/v1/copy-trade/futures/position/risk-limit-level/change` |
+| [updateCopyTradeAutoDepositStatus()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L940) | :closed_lock_with_key:  | POST | `api/v1/copy-trade/futures/position/margin/auto-deposit-status` |
+| [switchCopyTradeMarginMode()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L955) | :closed_lock_with_key:  | POST | `api/v1/copy-trade/futures/position/changeMarginMode` |
+| [updateCopyTradeCrossMarginLeverage()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L968) | :closed_lock_with_key:  | POST | `api/v2/copy-trade/futures/changeCrossUserLeverage` |
+| [getCopyTradeCrossMarginRequirement()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L981) | :closed_lock_with_key:  | POST | `api/v2/copy-trade/getCrossModeMarginRequirement` |
+| [switchCopyTradePositionMode()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L995) | :closed_lock_with_key:  | POST | `api/v2/copy-trade/position/switchPositionMode` |
+| [getBrokerRebateOrderDownloadLink()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L1015) | :closed_lock_with_key:  | GET | `api/v1/broker/api/rebase/download` |
+| [getBrokerRebateOrderDownloadLinkV2()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L1028) | :closed_lock_with_key:  | GET | `api/v2/broker/api/rebase/download` |
+| [getPublicWSConnectionToken()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L1045) |  | POST | `api/v1/bullet-public` |
+| [getPrivateWSConnectionToken()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L1052) | :closed_lock_with_key:  | POST | `api/v1/bullet-private` |
+| [getPrivateWSConnectionTokenV2()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L1060) | :closed_lock_with_key:  | POST | `api/v2/bullet-private` |
+| [submitTransferOut()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L1075) | :closed_lock_with_key:  | POST | `api/v3/transfer-out` |
+| [submitTransferIn()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L1086) | :closed_lock_with_key:  | POST | `api/v1/transfer-in` |
+| [getTransfers()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L1097) | :closed_lock_with_key:  | GET | `api/v1/transfer-list` |
+| [updateAutoDepositStatus()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts#L1112) | :closed_lock_with_key:  | POST | `api/v1/position/margin/auto-deposit-status` |
 
 # WebsocketAPIClient.ts
 
@@ -365,41 +365,42 @@ This table includes all endpoints from the official Exchange API docs and corres
 
 | Function | AUTH | HTTP Method | Endpoint |
 | -------- | :------: | :------: | -------- |
-| [getAnnouncements()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L114) |  | GET | `api/ua/v1/market/announcement` |
-| [getCurrency()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L124) |  | GET | `api/ua/v1/market/currency` |
-| [getSymbols()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L134) |  | GET | `api/ua/v1/market/instrument` |
-| [getTickers()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L144) |  | GET | `api/ua/v1/market/ticker` |
-| [getTrades()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L154) |  | GET | `api/ua/v1/market/trade` |
-| [getOrderBook()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L164) |  | GET | `api/ua/v1/market/orderbook` |
-| [getKlines()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L174) |  | GET | `api/ua/v1/market/kline` |
-| [getCurrentFundingRate()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L184) |  | GET | `api/ua/v1/market/funding-rate` |
-| [getHistoryFundingRate()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L194) |  | GET | `api/ua/v1/market/funding-rate-history` |
-| [getCrossMarginConfig()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L204) |  | GET | `api/ua/v1/market/cross-config` |
-| [getServiceStatus()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L214) |  | GET | `api/ua/v1/server/status` |
-| [getClassicAccount()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L231) | :closed_lock_with_key:  | GET | `api/ua/v1/account/balance` |
-| [getAccount()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L241) | :closed_lock_with_key:  | GET | `api/ua/v1/unified/account/balance` |
-| [getAccountOverview()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L249) | :closed_lock_with_key:  | GET | `api/ua/v1/unified/account/overview` |
-| [getSubAccount()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L259) | :closed_lock_with_key:  | GET | `api/ua/v1/sub-account/balance` |
-| [getTransferQuotas()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L270) | :closed_lock_with_key:  | GET | `api/ua/v1/account/transfer-quota` |
-| [flexTransfer()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L281) | :closed_lock_with_key:  | POST | `api/ua/v1/account/transfer` |
-| [setSubAccountTransferPermission()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L291) | :closed_lock_with_key:  | POST | `api/ua/v1/sub-account/canTransferOut` |
-| [getAccountMode()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L301) | :closed_lock_with_key:  | GET | `api/ua/v1/account/mode` |
-| [setAccountMode()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L309) | :closed_lock_with_key:  | POST | `api/ua/v1/account/mode` |
-| [getFeeRate()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L321) | :closed_lock_with_key:  | GET | `api/ua/v1/user/fee-rate` |
-| [getAccountLedger()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L336) | :closed_lock_with_key:  | GET | `api/ua/v1/account/ledger` |
-| [getInterestHistory()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L350) | :closed_lock_with_key:  | GET | `api/ua/v1/account/interest-history` |
-| [modifyLeverage()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L360) | :closed_lock_with_key:  | POST | `api/ua/v1/unified/account/modify-leverage` |
-| [getDepositAddress()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L375) | :closed_lock_with_key:  | GET | `api/ua/v1/asset/deposit/address` |
-| [placeOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L395) | :closed_lock_with_key:  | GET | `api/ua/v1/{accountMode}/order/detail` |
-| [batchPlaceOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L413) | :closed_lock_with_key:  | GET | `api/ua/v1/{accountMode}/order/detail` |
-| [getOrderDetails()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L431) | :closed_lock_with_key:  | GET | `api/ua/v1/{accountMode}/order/detail` |
-| [getOpenOrderList()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L445) | :closed_lock_with_key:  | GET | `api/ua/v1/{accountMode}/order/open-list` |
-| [getOrderHistory()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L459) | :closed_lock_with_key:  | GET | `api/ua/v1/{accountMode}/order/history` |
-| [getTradeHistory()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L472) | :closed_lock_with_key:  | GET | `api/ua/v1/{accountMode}/order/execution` |
-| [cancelOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L484) | :closed_lock_with_key:  | POST | `api/ua/v1/dcp/set` |
-| [batchCancelOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L501) | :closed_lock_with_key:  | POST | `api/ua/v1/dcp/set` |
-| [setDCP()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L519) | :closed_lock_with_key:  | POST | `api/ua/v1/dcp/set` |
-| [getDCP()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L530) | :closed_lock_with_key:  | GET | `api/ua/v1/dcp/query` |
-| [getPositionList()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L547) | :closed_lock_with_key:  | GET | `api/ua/v1/unified/position/open-list` |
-| [getPositionsHistory()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L560) | :closed_lock_with_key:  | GET | `api/ua/v1/position/history` |
-| [getAccountPositionTiers()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L571) | :closed_lock_with_key:  | GET | `api/ua/v1/{accountMode}/position/tiers` |
+| [getAnnouncements()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L102) |  | GET | `api/ua/v1/market/announcement` |
+| [getCurrency()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L112) |  | GET | `api/ua/v1/market/currency` |
+| [getSymbols()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L122) |  | GET | `api/ua/v1/market/instrument` |
+| [getTickers()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L132) |  | GET | `api/ua/v1/market/ticker` |
+| [getTrades()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L142) |  | GET | `api/ua/v1/market/trade` |
+| [getOrderBook()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L152) |  | GET | `api/ua/v1/market/orderbook` |
+| [getKlines()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L162) |  | GET | `api/ua/v1/market/kline` |
+| [getCurrentFundingRate()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L172) |  | GET | `api/ua/v1/market/funding-rate` |
+| [getHistoryFundingRate()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L182) |  | GET | `api/ua/v1/market/funding-rate-history` |
+| [getCrossMarginConfig()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L192) |  | GET | `api/ua/v1/market/cross-config` |
+| [getServiceStatus()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L202) |  | GET | `api/ua/v1/server/status` |
+| [getClassicAccount()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L219) | :closed_lock_with_key:  | GET | `api/ua/v1/account/balance` |
+| [getAccount()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L229) | :closed_lock_with_key:  | GET | `api/ua/v1/unified/account/balance` |
+| [getAccountOverview()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L237) | :closed_lock_with_key:  | GET | `api/ua/v1/unified/account/overview` |
+| [getSubAccount()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L247) | :closed_lock_with_key:  | GET | `api/ua/v1/sub-account/balance` |
+| [getTransferQuotas()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L258) | :closed_lock_with_key:  | GET | `api/ua/v1/account/transfer-quota` |
+| [flexTransfer()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L269) | :closed_lock_with_key:  | POST | `api/ua/v1/account/transfer` |
+| [setSubAccountTransferPermission()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L279) | :closed_lock_with_key:  | POST | `api/ua/v1/sub-account/canTransferOut` |
+| [getAccountMode()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L289) | :closed_lock_with_key:  | GET | `api/ua/v1/account/mode` |
+| [setAccountMode()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L297) | :closed_lock_with_key:  | POST | `api/ua/v1/account/mode` |
+| [getFeeRate()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L309) | :closed_lock_with_key:  | GET | `api/ua/v1/user/fee-rate` |
+| [getAccountLedger()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L324) | :closed_lock_with_key:  | GET | `api/ua/v1/account/ledger` |
+| [getInterestHistory()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L338) | :closed_lock_with_key:  | GET | `api/ua/v1/account/interest-history` |
+| [modifyLeverage()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L348) | :closed_lock_with_key:  | POST | `api/ua/v1/unified/account/modify-leverage` |
+| [getDepositAddress()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L363) | :closed_lock_with_key:  | GET | `api/ua/v1/asset/deposit/address` |
+| [placeOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L383) | :closed_lock_with_key:  | GET | `api/ua/v1/{accountMode}/order/detail` |
+| [batchPlaceOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L401) | :closed_lock_with_key:  | GET | `api/ua/v1/{accountMode}/order/detail` |
+| [getOrderDetails()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L419) | :closed_lock_with_key:  | GET | `api/ua/v1/{accountMode}/order/detail` |
+| [getOpenOrderList()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L433) | :closed_lock_with_key:  | GET | `api/ua/v1/{accountMode}/order/open-list` |
+| [getOrderHistory()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L447) | :closed_lock_with_key:  | GET | `api/ua/v1/{accountMode}/order/history` |
+| [getTradeHistory()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L460) | :closed_lock_with_key:  | GET | `api/ua/v1/{accountMode}/order/execution` |
+| [cancelOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L472) | :closed_lock_with_key:  | POST | `api/ua/v1/unified/order/cancel-all` |
+| [batchCancelOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L489) | :closed_lock_with_key:  | POST | `api/ua/v1/unified/order/cancel-all` |
+| [batchCancelOrdersBySymbol()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L504) | :closed_lock_with_key:  | POST | `api/ua/v1/unified/order/cancel-all` |
+| [setDCP()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L517) | :closed_lock_with_key:  | POST | `api/ua/v1/dcp/set` |
+| [getDCP()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L528) | :closed_lock_with_key:  | GET | `api/ua/v1/dcp/query` |
+| [getPositionList()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L545) | :closed_lock_with_key:  | GET | `api/ua/v1/unified/position/open-list` |
+| [getPositionsHistory()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L558) | :closed_lock_with_key:  | GET | `api/ua/v1/position/history` |
+| [getAccountPositionTiers()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L569) | :closed_lock_with_key:  | GET | `api/ua/v1/{accountMode}/position/tiers` |

--- a/examples/apidoc/UnifiedAPIClient/batchCancelOrdersBySymbol.js
+++ b/examples/apidoc/UnifiedAPIClient/batchCancelOrdersBySymbol.js
@@ -12,7 +12,7 @@ const client = new UnifiedAPIClient({
   apiPassphrase: 'apiPassPhraseHere',
 });
 
-client.batchCancelOrders(params)
+client.batchCancelOrdersBySymbol(params)
   .then((response) => {
     console.log(response);
   })

--- a/examples/apidoc/UnifiedAPIClient/cancelOrder.js
+++ b/examples/apidoc/UnifiedAPIClient/cancelOrder.js
@@ -2,7 +2,7 @@ const { UnifiedAPIClient } = require('kucoin-api');
 
   // This example shows how to call this kucoin API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "kucoin-api" for kucoin exchange
   // This kucoin API SDK is available on npm via "npm install kucoin-api"
-  // ENDPOINT: api/ua/v1/dcp/set
+  // ENDPOINT: api/ua/v1/unified/order/cancel-all
   // METHOD: POST
   // PUBLIC: NO
 

--- a/llms.txt
+++ b/llms.txt
@@ -72,6 +72,7 @@ examples/
     ws-public-spot-v1.ts
   kucoin-FUTURES-examples-nodejs.md
   kucoin-SPOT-examples-nodejs.md
+  kucoin-UNIFIED-examples-nodejs.md
   tsconfig.examples.json
 src/
   lib/
@@ -145,6 +146,24 @@ Files
 ================================================================
 
 ================
+File: examples/auth/authorizationHeader.ts
+================
+import { SpotClient } from '../../src/index.js';
+⋮----
+// or
+// import { SpotClient } from 'kucoin-api';
+⋮----
+async function start()
+⋮----
+/**
+   * All REST clients support passing the access token. If available, sign will be skipped for the request and the access token will instead be used via an authorization header.
+   *
+   * More details: https://github.com/tiagosiebler/kucoin-api/issues/2
+   */
+⋮----
+// If you later need to set a new access token (e.g. it expired):
+
+================
 File: examples/tsconfig.examples.json
 ================
 {
@@ -157,6 +176,106 @@ File: examples/tsconfig.examples.json
   },
   "include": ["../src/**/*.*", "../examples/**/*.*"]
 }
+
+================
+File: src/lib/websocket/WsStore.types.ts
+================
+import WebSocket from 'isomorphic-ws';
+⋮----
+export enum WsConnectionStateEnum {
+  INITIAL = 0,
+  CONNECTING = 1,
+  CONNECTED = 2,
+  CLOSING = 3,
+  RECONNECTING = 4,
+  // ERROR_RECONNECTING = 5,
+  ERROR = 5,
+}
+⋮----
+// ERROR_RECONNECTING = 5,
+⋮----
+export interface DeferredPromise<TSuccess = any, TError = any> {
+  resolve?: (value: TSuccess) => TSuccess;
+  reject?: (value: TError) => TError;
+  promise?: Promise<TSuccess>;
+}
+⋮----
+export interface WSConnectedResult {
+  wsKey: string;
+  ws: WebSocket;
+}
+⋮----
+export interface WsStoredState<TWSTopicSubscribeEvent extends string | object> {
+  /** The currently active websocket connection */
+  ws?: WebSocket;
+
+  /** The current lifecycle state of the connection (enum) */
+  connectionState?: WsConnectionStateEnum;
+  connectionStateChangedAt?: Date;
+
+  /** A timer that will send an upstream heartbeat (ping) when it expires */
+  activePingTimer?: ReturnType<typeof setTimeout> | undefined;
+
+  /** A timer tracking that an upstream heartbeat was sent, expecting a reply before it expires */
+  activePongTimer?: ReturnType<typeof setTimeout> | undefined;
+
+  /** If a reconnection is in progress, this will have the timer for the delayed reconnect */
+  activeReconnectTimer?: ReturnType<typeof setTimeout> | undefined;
+  /**
+   * When a connection attempt is in progress (even for reconnect), a promise is stored here.
+   *
+   * This promise will resolve once connected (and will then get removed);
+   */
+  deferredPromiseStore: Record<string, DeferredPromise>;
+
+  /**
+   * All the topics we are expected to be subscribed to on this connection (and we automatically resubscribe to if the connection drops)
+   *
+   * A "Set" and a deep-object-match are used to ensure we only subscribe to a topic once (tracking a list of unique topics we're expected to be connected to)
+   */
+  subscribedTopics: Set<TWSTopicSubscribeEvent>;
+
+  /** Whether this connection has completed authentication (only applies to private connections) */
+  isAuthenticated?: boolean;
+
+  /**
+   * Whether this connection has completed authentication before for the Websocket API, so it knows to automatically reauth if reconnected
+   */
+  didAuthWSAPI?: boolean;
+
+  /** To reauthenticate on the WS API, which channel do we send to? */
+  WSAPIAuthChannel?: string;
+}
+⋮----
+/** The currently active websocket connection */
+⋮----
+/** The current lifecycle state of the connection (enum) */
+⋮----
+/** A timer that will send an upstream heartbeat (ping) when it expires */
+⋮----
+/** A timer tracking that an upstream heartbeat was sent, expecting a reply before it expires */
+⋮----
+/** If a reconnection is in progress, this will have the timer for the delayed reconnect */
+⋮----
+/**
+   * When a connection attempt is in progress (even for reconnect), a promise is stored here.
+   *
+   * This promise will resolve once connected (and will then get removed);
+   */
+⋮----
+/**
+   * All the topics we are expected to be subscribed to on this connection (and we automatically resubscribe to if the connection drops)
+   *
+   * A "Set" and a deep-object-match are used to ensure we only subscribe to a topic once (tracking a list of unique topics we're expected to be connected to)
+   */
+⋮----
+/** Whether this connection has completed authentication (only applies to private connections) */
+⋮----
+/**
+   * Whether this connection has completed authentication before for the Websocket API, so it knows to automatically reauth if reconnected
+   */
+⋮----
+/** To reauthenticate on the WS API, which channel do we send to? */
 
 ================
 File: src/lib/misc-util.ts
@@ -209,7 +328,14 @@ export interface GetBrokerSubAccountsRequest {
   pageSize?: number;
 }
 ⋮----
-export type BrokerSubAccountPermission = 'general' | 'spot' | 'futures';
+export type BrokerSubAccountPermission =
+  | 'General'
+  | 'Spot'
+  | 'Margin'
+  | 'Futures'
+  | 'InnerTransfer'
+  | 'Transfer'
+  | 'Earn';
 ⋮----
 export interface CreateBrokerSubAccountApiRequest {
   uid: string;
@@ -649,6 +775,7 @@ export interface FlexTransferRequest {
     | 'TRADE_HF'
     | 'MARGIN_V2'
     | 'ISOLATED_V2'
+    | 'UNIFIED'
     | 'OPTION';
   fromAccountTag?: string;
   type: 'INTERNAL' | 'PARENT_TO_SUB' | 'SUB_TO_PARENT';
@@ -662,6 +789,7 @@ export interface FlexTransferRequest {
     | 'TRADE_HF'
     | 'MARGIN_V2'
     | 'ISOLATED_V2'
+    | 'UNIFIED'
     | 'OPTION';
   toAccountTag?: string;
 }
@@ -1066,7 +1194,15 @@ export interface BrokerSubAccountApi {
   label: string;
   apiKey: string;
   apiVersion: number;
-  permissions: ('General' | 'Spot' | 'Futures')[];
+  permissions: (
+    | 'General'
+    | 'Spot'
+    | 'Margin'
+    | 'Futures'
+    | 'InnerTransfer'
+    | 'Transfer'
+    | 'Earn'
+  )[];
   ipWhitelist: string[];
   createdAt: number;
 }
@@ -1754,2534 +1890,6 @@ export interface Announcements {
 }
 
 ================
-File: src/types/response/spot-vip.ts
-================
-/**
- *
- ***********
- * VIP LENDING
- ***********
- *
- */
-⋮----
-export interface DiscountRateConfig {
-  currency: string;
-  usdtLevels: {
-    left: number;
-    right: number;
-    discountRate: string;
-  }[];
-}
-⋮----
-export interface OtcLoan {
-  parentUid: string;
-  orders: {
-    orderId: string;
-    currency: string;
-    principal: string;
-    interest: string;
-  }[];
-  ltv: {
-    transferLtv: string;
-    onlyClosePosLtv: string;
-    delayedLiquidationLtv: string;
-    instantLiquidationLtv: string;
-    currentLtv: string;
-  };
-  totalMarginAmount: string;
-  transferMarginAmount: string;
-  margins: {
-    marginCcy: string;
-    marginQty: string;
-    marginFactor: string;
-  }[];
-}
-⋮----
-export interface OtcLoanAccount {
-  uid: string;
-  marginCcy: string;
-  marginQty: string;
-  marginFactor: string;
-  accountType: 'TRADE' | 'TRADE_HF' | 'CONTRACT';
-  isParent: boolean;
-}
-
-================
-File: src/BrokerClient.ts
-================
-import { BaseRestClient } from './lib/BaseRestClient.js';
-import { REST_CLIENT_TYPE_ENUM, RestClientType } from './lib/requestUtils.js';
-import {
-  BrokerTransferRequest,
-  CreateBrokerSubAccountApiRequest,
-  DeleteBrokerSubAccountApiRequest,
-  GetBrokerDepositListRequest,
-  GetBrokerInfoRequest,
-  GetBrokerSubAccountApisRequest,
-  GetBrokerSubAccountsRequest,
-  UpdateBrokerSubAccountApiRequest,
-} from './types/request/broker.types.js';
-import {
-  BrokerDepositRecord,
-  BrokerInfo,
-  BrokerSubAccountApi,
-  BrokerTransferHistory,
-  BrokerWithdrawalRecord,
-  CreateBrokerSubAccountApiResponse,
-  CreateBrokerSubAccountResponse,
-  GetBrokerSubAccountsResponse,
-} from './types/response/broker.types.js';
-import { APISuccessResponse } from './types/response/shared.types.js';
-⋮----
-/**
- *
- */
-export class BrokerClient extends BaseRestClient
-⋮----
-getClientType(): RestClientType
-⋮----
-/**
-   * Get Broker Info
-   *
-   * This endpoint supports querying the basic information of the current Broker
-   */
-getBrokerInfo(
-    params: GetBrokerInfoRequest,
-): Promise<APISuccessResponse<BrokerInfo>>
-⋮----
-/**
-   * Add SubAccount
-   *
-   * This endpoint supports Broker users to create sub-accounts.
-   * Note that the account name is unique across the exchange.
-   * It is recommended to add a special identifier to prevent name duplication.
-   */
-createSubAccount(params: {
-    accountName: string;
-}): Promise<APISuccessResponse<CreateBrokerSubAccountResponse>>
-⋮----
-/**
-   * Get SubAccount
-   *
-   * This interface supports querying sub-accounts created by Broker.
-   * Returns paginated results with default page size of 20 (max 100).
-   */
-getSubAccounts(
-    params: GetBrokerSubAccountsRequest,
-): Promise<APISuccessResponse<GetBrokerSubAccountsResponse>>
-⋮----
-/**
-   * Add SubAccount API
-   *
-   * This interface supports the creation of Broker sub-account APIKEY.
-   * Supports up to 20 IPs in the whitelist.
-   * Only General, Spot, and Futures permissions can be set.
-   * Label must be between 4 and 32 characters.
-   */
-createSubAccountApi(
-    params: CreateBrokerSubAccountApiRequest,
-): Promise<APISuccessResponse<CreateBrokerSubAccountApiResponse>>
-⋮----
-/**
-   * Get SubAccount API
-   *
-   * This interface supports querying the Broker's sub-account APIKEYs.
-   * Can optionally filter by specific apiKey.
-   */
-getSubAccountApis(
-    params: GetBrokerSubAccountApisRequest,
-): Promise<APISuccessResponse<BrokerSubAccountApi[]>>
-⋮----
-/**
-   * Modify SubAccount API
-   *
-   * This interface supports modifying the Broker's sub-account APIKEY.
-   * Supports up to 20 IPs in the whitelist.
-   * Only General, Spot, and Futures permissions can be set.
-   * Label must be between 4 and 32 characters.
-   */
-updateSubAccountApi(
-    params: UpdateBrokerSubAccountApiRequest,
-): Promise<APISuccessResponse<BrokerSubAccountApi>>
-⋮----
-/**
-   * Delete SubAccount API
-   *
-   * This interface supports deleting Broker's sub-account APIKEY.
-   */
-deleteSubAccountApi(
-    params: DeleteBrokerSubAccountApiRequest,
-): Promise<APISuccessResponse<boolean>>
-⋮----
-/**
-   * Transfer
-   *
-   * This endpoint supports fund transfer between Broker account and Broker sub-accounts.
-   * Please be aware that withdrawal from sub-account is not directly supported.
-   * Broker has to transfer funds from broker sub-account to broker account to initiate the withdrawals.
-   *
-   * Direction:
-   * - OUT: Broker account is transferred to Broker sub-account
-   * - IN: Broker sub-account is transferred to Broker account
-   *
-   * Account Types:
-   * - MAIN: Funding account
-   * - TRADE: Spot trading account
-   */
-submitTransfer(params: BrokerTransferRequest): Promise<
-    APISuccessResponse<{
-      orderId: string;
-    }>
-  > {
-    return this.postPrivate('api/v1/broker/nd/transfer', params);
-⋮----
-/**
-   * Get Transfer History
-   *
-   * This endpoint supports querying transfer records of the broker itself and its created sub-accounts.
-   *
-   * Account Types:
-   * - MAIN: Funding account
-   * - TRADE: Spot trading account
-   * - CONTRACT: Contract account
-   * - MARGIN: Margin account
-   * - ISOLATED: Isolated margin account
-   *
-   * Status:
-   * - PROCESSING: Processing
-   * - SUCCESS: Successful
-   * - FAILURE: Failed
-   */
-getTransferHistory(params: {
-    orderId: string;
-}): Promise<APISuccessResponse<BrokerTransferHistory>>
-⋮----
-/**
-   * Get Deposit List
-   *
-   * This endpoint can obtain the deposit records of each sub-account under the ND Broker.
-   * Default limit is 1000 records (max 1000).
-   * Results are sorted in descending order by default.
-   *
-   * Status:
-   * - PROCESSING: Processing
-   * - SUCCESS: Successful
-   * - FAILURE: Failed
-   */
-getDeposits(
-    params?: GetBrokerDepositListRequest,
-): Promise<APISuccessResponse<BrokerDepositRecord[]>>
-⋮----
-/**
-   * Get Deposit Detail
-   *
-   * This endpoint supports querying the deposit record of sub-accounts created by a Broker
-   * (excluding main account of nd broker).
-   *
-   * Status:
-   * - PROCESSING: Processing
-   * - SUCCESS: Successful
-   * - FAILURE: Failed
-   */
-getDeposit(params: {
-    currency: string;
-    hash: string;
-}): Promise<APISuccessResponse<BrokerDepositRecord>>
-⋮----
-/**
-   * Get Withdrawal Detail
-   *
-   * This endpoint supports querying the withdrawal records of sub-accounts created by a Broker
-   * (excluding main account of nd broker).
-   *
-   * Status:
-   * - PROCESSING: Processing
-   * - WALLET_PROCESSING: Wallet Processing
-   * - REVIEW: Under Review
-   * - SUCCESS: Successful
-   * - FAILURE: Failed
-   */
-getWithdrawal(params: {
-    withdrawalId: string;
-}): Promise<APISuccessResponse<BrokerWithdrawalRecord>>
-⋮----
-/**
-   * Get Broker Rebate
-   *
-   * This interface supports downloading Broker rebate orders.
-   * Returns a URL to download a CSV file containing the rebate data.
-   * The URL is valid for 1 day.
-   * Maximum interval between begin and end dates is 6 months.
-   */
-getBrokerRebate(params: {
-    begin: string;
-    end: string;
-    tradeType: '1' | '2';
-  }): Promise<
-    APISuccessResponse<{
-      url: string;
-    }>
-  > {
-    return this.getPrivate('api/v1/broker/nd/rebase/download', params);
-
-================
-File: .prettierrc
-================
-{
-  "tabWidth": 2,
-  "singleQuote": true,
-  "trailingComma": "all"
-}
-
-================
-File: jest.config.ts
-================
-/**
- * For a detailed explanation regarding each configuration property, visit:
- * https://jestjs.io/docs/configuration
- */
-⋮----
-import type { Config } from 'jest';
-⋮----
-// All imported modules in your tests should be mocked automatically
-// automock: false,
-⋮----
-// Stop running tests after `n` failures
-// bail: 0,
-bail: false, // enable to stop test when an error occur,
-⋮----
-// The directory where Jest should store its cached dependency information
-// cacheDirectory: "/private/var/folders/kf/2k3sz4px6c9cbyzj1h_b192h0000gn/T/jest_dx",
-⋮----
-// Automatically clear mock calls, instances, contexts and results before every test
-⋮----
-// Indicates whether the coverage information should be collected while executing the test
-⋮----
-// An array of glob patterns indicating a set of files for which coverage information should be collected
-⋮----
-// The directory where Jest should output its coverage files
-⋮----
-// An array of regexp pattern strings used to skip coverage collection
-// coveragePathIgnorePatterns: [
-//   "/node_modules/"
-// ],
-⋮----
-// Indicates which provider should be used to instrument code for coverage
-⋮----
-// A list of reporter names that Jest uses when writing coverage reports
-// coverageReporters: [
-//   "json",
-//   "text",
-//   "lcov",
-//   "clover"
-// ],
-⋮----
-// An object that configures minimum threshold enforcement for coverage results
-// coverageThreshold: undefined,
-⋮----
-// A path to a custom dependency extractor
-// dependencyExtractor: undefined,
-⋮----
-// Make calling deprecated APIs throw helpful error messages
-// errorOnDeprecated: false,
-⋮----
-// The default configuration for fake timers
-// fakeTimers: {
-//   "enableGlobally": false
-// },
-⋮----
-// Force coverage collection from ignored files using an array of glob patterns
-// forceCoverageMatch: [],
-⋮----
-// A path to a module which exports an async function that is triggered once before all test suites
-// globalSetup: undefined,
-⋮----
-// A path to a module which exports an async function that is triggered once after all test suites
-// globalTeardown: undefined,
-⋮----
-// A set of global variables that need to be available in all test environments
-// globals: {},
-⋮----
-// The maximum amount of workers used to run your tests. Can be specified as % or a number. E.g. maxWorkers: 10% will use 10% of your CPU amount + 1 as the maximum worker number. maxWorkers: 2 will use a maximum of 2 workers.
-// maxWorkers: "50%",
-⋮----
-// An array of directory names to be searched recursively up from the requiring module's location
-// moduleDirectories: [
-//   "node_modules"
-// ],
-⋮----
-// An array of file extensions your modules use
-⋮----
-// modulePaths: ['src'],
-⋮----
-// A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
-// moduleNameMapper: {},
-⋮----
-// An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
-// modulePathIgnorePatterns: [],
-⋮----
-// Activates notifications for test results
-// notify: false,
-⋮----
-// An enum that specifies notification mode. Requires { notify: true }
-// notifyMode: "failure-change",
-⋮----
-// A preset that is used as a base for Jest's configuration
-// preset: undefined,
-⋮----
-// Run tests from one or more projects
-// projects: undefined,
-⋮----
-// Use this configuration option to add custom reporters to Jest
-// reporters: undefined,
-⋮----
-// Automatically reset mock state before every test
-// resetMocks: false,
-⋮----
-// Reset the module registry before running each individual test
-// resetModules: false,
-⋮----
-// A path to a custom resolver
-// resolver: undefined,
-⋮----
-// Automatically restore mock state and implementation before every test
-// restoreMocks: false,
-⋮----
-// The root directory that Jest should scan for tests and modules within
-// rootDir: undefined,
-⋮----
-// A list of paths to directories that Jest should use to search for files in
-// roots: [
-//   "<rootDir>"
-// ],
-⋮----
-// Allows you to use a custom runner instead of Jest's default test runner
-// runner: "jest-runner",
-⋮----
-// The paths to modules that run some code to configure or set up the testing environment before each test
-// setupFiles: [],
-⋮----
-// A list of paths to modules that run some code to configure or set up the testing framework before each test
-// setupFilesAfterEnv: [],
-⋮----
-// The number of seconds after which a test is considered as slow and reported as such in the results.
-// slowTestThreshold: 5,
-⋮----
-// A list of paths to snapshot serializer modules Jest should use for snapshot testing
-// snapshotSerializers: [],
-⋮----
-// The test environment that will be used for testing
-// testEnvironment: "jest-environment-node",
-⋮----
-// Options that will be passed to the testEnvironment
-// testEnvironmentOptions: {},
-⋮----
-// Adds a location field to test results
-// testLocationInResults: false,
-⋮----
-// The glob patterns Jest uses to detect test files
-⋮----
-// "**/__tests__/**/*.[jt]s?(x)",
-⋮----
-// An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
-// testPathIgnorePatterns: [
-//   "/node_modules/"
-// ],
-⋮----
-// The regexp pattern or array of patterns that Jest uses to detect test files
-// testRegex: [],
-⋮----
-// This option allows the use of a custom results processor
-// testResultsProcessor: undefined,
-⋮----
-// This option allows use of a custom test runner
-// testRunner: "jest-circus/runner",
-⋮----
-// A map from regular expressions to paths to transformers
-// transform: undefined,
-⋮----
-// An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
-// transformIgnorePatterns: [
-//   "/node_modules/",
-//   "\\.pnp\\.[^\\/]+$"
-// ],
-⋮----
-// Prevents import esm module error from v1 axios release, issue #5026
-⋮----
-// An array of regexp pattern strings that are matched against all modules before the module loader will automatically return a mock for them
-// unmockedModulePathPatterns: undefined,
-⋮----
-// Indicates whether each individual test should be reported during the run
-// verbose: undefined,
-verbose: true, // report individual test
-⋮----
-// An array of regexp patterns that are matched against all source file paths before re-running tests in watch mode
-// watchPathIgnorePatterns: [],
-⋮----
-// Whether to use watchman for file crawling
-// watchman: true,
-
-================
-File: postBuild.sh
-================
-#!/bin/bash
-#
-#   Add package.json files to cjs/mjs subtrees
-#
-
-cat >dist/cjs/package.json <<!EOF
-{
-    "type": "commonjs"
-}
-!EOF
-
-cat >dist/mjs/package.json <<!EOF
-{
-    "type": "module"
-}
-!EOF
-
-find src -name '*.d.ts' -exec cp {} dist/mjs \;
-find src -name '*.d.ts' -exec cp {} dist/cjs \;
-
-================
-File: tsconfig.cjs.json
-================
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "module": "commonjs",
-    "outDir": "dist/cjs",
-    "target": "esnext"
-  },
-  "include": ["src/**/*.*"]
-}
-
-================
-File: tsconfig.esm.json
-================
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "module": "esnext",
-    "outDir": "dist/mjs",
-    "target": "esnext"
-  },
-  "include": ["src/**/*.*"]
-}
-
-================
-File: examples/auth/authorizationHeader.ts
-================
-import { SpotClient } from '../../src/index.js';
-⋮----
-// or
-// import { SpotClient } from 'kucoin-api';
-⋮----
-async function start()
-⋮----
-/**
-   * All REST clients support passing the access token. If available, sign will be skipped for the request and the access token will instead be used via an authorization header.
-   *
-   * More details: https://github.com/tiagosiebler/kucoin-api/issues/2
-   */
-⋮----
-// If you later need to set a new access token (e.g. it expired):
-
-================
-File: examples/auth/fasterHmacSign.ts
-================
-import { createHmac } from 'crypto';
-⋮----
-import { DefaultLogger, SpotClient, WebsocketClient } from '../../src/index.js';
-⋮----
-// or
-// import { createHmac } from 'crypto';
-// import { DefaultLogger, SpotClient, WebsocketClient } from 'kucoin-api';
-⋮----
-/**
- * Injecting a custom signMessage function.
- *
- * As of version 3.0.0 of the kucoin-api Node.js/TypeScript/JavaScript
- * SDK for Kucoin, the SDK uses the Web Crypto API for signing requests.
- * While it is compatible with Node and Browser environments, it is
- * slightly slower than using Node's native crypto module (only
- * available in backend Node environments).
- *
- * For latency sensitive users, you can inject the previous node crypto sign
- * method (or your own even faster implementation), if this change affects you.
- *
- * This example demonstrates how to inject a custom sign function, to achieve
- * the same peformance as seen before the Web Crypto API was introduced.
- *
- * For context on standard usage, the "signMessage" function is used:
- * - During every single API call
- * - After opening a new private WebSocket connection
- */
-⋮----
-/**
-   * Overkill in almost every case, but if you need any optimisation available,
-   * you can inject a faster sign mechanism such as node's native createHmac:
-   */
-⋮----
-// Optional, uncomment the "trace" override to log a lot more info about what the WS client is doing
-⋮----
-// trace: (...params) => console.log('trace', ...params),
-⋮----
-/**
-     * Overkill in almost every case, but if you need any optimisation available,
-     * you can inject a faster sign mechanism such as node's native createHmac:
-     */
-⋮----
-function setWsClientEventListeners(
-  websocketClient: WebsocketClient,
-  accountRef: string,
-): Promise<void>
-⋮----
-// console.log('raw message received ', JSON.stringify(data, null, 2));
-⋮----
-// Simple promise to ensure we're subscribed before trying anything else
-⋮----
-// Start trading
-
-================
-File: examples/Rest/rest-futures-orders-guide.ts
-================
-import { FuturesClient } from '../../src/index.ts';
-// import { FuturesClient } from 'kucoin-api';
-// normally you should install this module via npm: `npm install kucoin-api`
-⋮----
-async function start()
-⋮----
-/**
-     * =======
-     * Credits for this guide go to user: @DKTradingClient / Code Nerd from the Kucoin API Telegram group!
-     * =======
-
-    /**
-     * Futures are contracts, not currencies. In the futures symbols list you will see a "multiplier" field for each of the symbols. 
-     * Each contract equals to  Multiplier x Size
-     * For example:  https://api-futures.kucoin.com/api/v1/contracts/XRPUSDTM  - see the "multiplier" value.
-     * */
-⋮----
-/**
-     * E.g. if multiplier is 10(what you can see from the endpoint), that means each SIZE is 10 XRP. So if XRP is currently at $0.5,
-     * then each 1 contract (size 10) is going to cost $5.00
-     * size = (Funds x leverage) / (price x multiplier)
-     */
-⋮----
-/**
-     * The trade amount indicates the amount of contract to buy or sell, and contract uses the base currency or lot as the trading unit.
-     * The trade amount must be no less than 1 lot for the contract and no larger than the maxOrderQty.
-     * It should be a multiple number of the lot, or the system will report an error when you place the order.
-     * E.g. 1 lot of XBTUSDTM is 0.001 Bitcoin, while 1 lot of XBTUSDM is 1 USD.
-     * or check the XRPUSDTM example above.
-     *
-     * Here are function examples using the Futures Create Order endpoint:
-     */
-⋮----
-// A MARKET SHORT of 2 contracts of XBT using leverage of 5:
-⋮----
-// A MARKET LONG of 2 contracts of XBT using leverage of 5:
-⋮----
-// A LIMIT SHORT of 2 contracts of XBT using leverage of 5:
-⋮----
-// A LIMIT LONG of 2 contracts of XBT using leverage of 5:
-⋮----
-// On any "close position" action, if you specify a SIZE=0 or leave off the SIZE parameter,
-// then it will close the whole position, regardless of the size.
-// If you specify a SIZE, it will close only the number of contracts you specify.
-⋮----
-// If closeOrder is set to TRUE,
-// the system will close the position and the position size will become 0.
-// Side, Size and Leverage fields can be left empty and the system will determine the side and size automatically.
-⋮----
-// A MARKET CLOSE POSITION example:
-⋮----
-// A LIMIT CLOSE of a LONG example:
-⋮----
-// A LIMIT CLOSE of a SHORT example:
-⋮----
-// A STOP LOSS example for a LONG position:
-⋮----
-// A STOP LOSS example for a SHORT position:
-
-================
-File: examples/Rest/rest-futures-private-trade.ts
-================
-import { FuturesClient } from '../../src/index.ts';
-// import { FuturesClient } from 'kucoin-api';
-// normally you should install this module via npm: `npm install kucoin-api`
-⋮----
-async function start()
-⋮----
-/**
-     * The trade amount indicates the amount of contract to buy or sell, and contract uses the base currency or lot as the trading unit.
-     * The trade amount must be no less than 1 lot for the contract and no larger than the maxOrderQty.
-     * It should be a multiple number of the lot, or the system will report an error when you place the order.
-     * E.g. 1 lot of XBTUSDTM is 0.001 Bitcoin, while 1 lot of XBTUSDM is 1 USD.
-     */
-⋮----
-// Submit a futures entry order for 1 lot of XBTUSDTM (0.001 bitcoin)
-
-================
-File: examples/Rest/rest-futures-public.ts
-================
-import { FuturesClient } from '../../src/index.ts';
-// import { FuturesClient } from 'kucoin-api';
-// normally you should install this module via npm: `npm install kucoin-api`
-⋮----
-async function start()
-⋮----
-// Fetch all symbols
-⋮----
-// Fetch ticker for a specific symbol
-⋮----
-// Fetch klines for a specific symbol
-
-================
-File: examples/Rest/rest-spot-private-trade.ts
-================
-import { SpotClient } from '../../src/index.ts';
-// import { SpotClient } from 'kucoin-api';
-// normally you should install this module via npm: `npm install kucoin-api`
-⋮----
-async function start()
-
-================
-File: examples/Rest/rest-spot-public.ts
-================
-import { SpotClient } from '../../src/index.ts';
-// import { SpotClient } from 'kucoin-api';
-// normally you should install this module via npm: `npm install kucoin-api`
-⋮----
-async function start()
-⋮----
-// Fetch all symbols
-⋮----
-// Fetch ticker for a specific symbol
-⋮----
-// Fetch klines for a specific symbol
-
-================
-File: examples/WebSockets/WS-API/ws-api-client.ts
-================
-/**
- * KuCoin WebSocket API Client - Complete Example
- *
- * This example demonstrates all available WebSocket API operations:
- * - Spot trading: submit, modify, cancel, sync operations
- * - Margin trading: submit and cancel orders
- * - Futures trading: submit, cancel, batch operations
- *
- * Usage:
- * Make sure to set your API credentials in environment variables:
- *    - API_KEY
- *    - API_SECRET
- *    - API_PASSPHRASE
- *
- *  or pass them as arguments to the constructor
- */
-⋮----
-import { DefaultLogger, WebsocketAPIClient } from '../../../src/index.js';
-⋮----
-async function main()
-⋮----
-// For a more detailed view of the WebsocketClient, enable the `trace` level by uncommenting the below line:
-// trace: (...params) => console.log(new Date(), 'trace', ...params),
-⋮----
-passphrase: process.env.API_PASSPHRASE || 'apiPassPhraseHere', // This is NOT your account password
-⋮----
-// If you want your own event handlers instead of the default ones with logs, disable this setting and see the `attachEventHandlers` example below:
-// attachEventListeners: false
-⋮----
-// Example usage for each WebSocket API operation
-⋮----
-// 1. Submit Spot Order
-⋮----
-price: '20000', // Very low price to avoid accidental execution
-⋮----
-// 2. Submit Sync Spot Order
-⋮----
-price: '1000', // Very high price to avoid accidental execution
-⋮----
-// 3. Modify Spot Order (requires existing order ID)
-⋮----
-orderId: '68cc3476693c1c00072ef1d9', // Replace with actual order ID
-⋮----
-// 4. Cancel Spot Order
-⋮----
-orderId: '68cc34c6693c1c0007301929', // Replace with actual order ID
-⋮----
-// 5. Cancel Sync Spot Order
-⋮----
-orderId: '68cc3530b9870a0007670294', // Replace with actual client order ID
-⋮----
-// 6. Submit Margin Order
-⋮----
-price: '19000', // Very low price to avoid accidental execution
-⋮----
-isIsolated: false, // false for cross margin, true for isolated
-⋮----
-// 7. Cancel Margin Order
-⋮----
-orderId: 'your-margin-order-id-here', // Replace with actual order ID
-⋮----
-// 8. Submit Futures Order
-⋮----
-price: '1000', // Very low price to avoid accidental execution
-⋮----
-positionSide: 'LONG', // needed if trading two-way (hedge) position mode
-⋮----
-// 9. Cancel Futures Order
-⋮----
-orderId: '358196976308797441', // Replace with actual order ID
-⋮----
-// 10. Submit Multiple Futures Orders
-⋮----
-price: '1000', // Very low price to avoid accidental execution
-⋮----
-positionSide: 'LONG', // Needed if trading hedge/two-way mode. Optional in one-way mode.
-⋮----
-price: '1010', // Very low price to avoid accidental execution
-⋮----
-// 11. Cancel Multiple Futures Orders
-⋮----
-orderIdsList: ['order-id-1', 'order-id-2'], // Replace with actual order IDs
-⋮----
-// Start executing the example workflow
-
-================
-File: examples/WebSockets/WS-API/ws-api-raw-promises.ts
-================
-/* eslint-disable @typescript-eslint/no-unused-vars */
-import {
-  DefaultLogger,
-  WebsocketClient,
-  WS_KEY_MAP,
-} from '../../../src/index.js';
-// import { DefaultLogger, WebsocketClient, WS_KEY_MAP } from 'kucoin-api';
-// normally you should install this module via npm: `npm install kucoin-api`
-⋮----
-async function start()
-⋮----
-// Optional: inject a custom logger to override internal logging behaviour
-⋮----
-// Uncomment the below callback to introduce filtered trace logging in the WebsocketClient.
-// trace: (...params) => {
-//   if (
-//     [
-//       'Sending ping',
-//       // 'Sending upstream ws message: ',
-//       'Received pong',
-//     ].includes(params[0])
-//   ) {
-//     return;
-//   }
-//   console.log('trace', JSON.stringify(params, null, 2));
-// },
-⋮----
-passphrase: process.env.API_PASSPHRASE || 'apiPassPhraseHere', // This is NOT your account password
-⋮----
-// console.log('connecting with ', account);
-⋮----
-// logger,
-⋮----
-// Data received
-⋮----
-// Something happened, attempting to reconenct
-⋮----
-// Reconnect successful
-⋮----
-// Connection closed. If unexpected, expect reconnect -> reconnected.
-⋮----
-// Reply to a request, e.g. "subscribe"/"unsubscribe"/"authenticate"
-⋮----
-// console.info('response: ', data);
-⋮----
-/**
-   *
-   * Raw events can be routed via the sendWSAPIRequest in the WebsocketClient, as shown below.
-   * However, for a simpler integration, it is recommended to use the WebsocketAPIClient. The
-   * WebsocketAPIClient class is a wrapper around sendWSAPIRequest, with clear functions, typed
-   * requests and typed responses. The simpler WSAPIClient interface behaves much like a REST API
-   * wrapper, but all calls are routed via the WebSocket API.
-   *
-   * For a clearer example, refer to the "ws-api-client.ts" example found in this folder.
-   */
-⋮----
-price: '20000', // Very low price to avoid accidental execution
-
-================
-File: examples/WebSockets/ws-private-futures-v1.ts
-================
-/* eslint-disable @typescript-eslint/no-unused-vars */
-import { DefaultLogger, WebsocketClient } from '../../src/index.js';
-// import { DefaultLogger, WebsocketClient } from 'kucoin-api';
-// normally you should install this module via npm: `npm install kucoin-api`
-⋮----
-async function start()
-⋮----
-// Optional: inject and customise a logger for more control over internal logging
-// const logger: typeof DefaultLogger = {
-//   ...DefaultLogger,
-//   trace: (...params) => {
-//     if (
-//       [
-//         'Sending ping',
-//         // 'Sending upstream ws message: ',
-//         'Received pong',
-//       ].includes(params[0])
-//     ) {
-//       return;
-//     }
-//     console.log('trace', JSON.stringify(params, null, 2));
-//   },
-// };
-⋮----
-passphrase: process.env.API_PASSPHRASE || 'apiPassPhraseHere', // This is NOT your account password
-⋮----
-// logger,
-⋮----
-// Data received
-⋮----
-// Something happened, attempting to reconenct
-⋮----
-// Reconnect successful
-⋮----
-// Connection closed. If unexpected, expect reconnect -> reconnected.
-⋮----
-// Reply to a request, e.g. "subscribe"/"unsubscribe"/"authenticate"
-⋮----
-// throw new Error('res?');
-⋮----
-// Optional: await a connection to be ready before subscribing (this is not necessary)
-// await client.connect('futuresPrivateV1');
-// console.log('connected');
-⋮----
-/**
-     * For more detailed usage info, refer to the ws-spot-public.ts example.
-     *
-     * Below are some examples for subscribing to private futures websockets.
-     * Note: all "private" websocket topics should use the "futuresPrivateV1" wsKey.
-     */
-
-================
-File: examples/WebSockets/ws-private-spot-v1.ts
-================
-/* eslint-disable @typescript-eslint/no-unused-vars */
-import { DefaultLogger, WebsocketClient } from '../../src/index.js';
-// import { DefaultLogger, WebsocketClient } from 'kucoin-api';
-// normally you should install this module via npm: `npm install kucoin-api`
-⋮----
-async function start()
-⋮----
-// Optional: inject a custom logger to override internal logging behaviour
-// const logger: typeof DefaultLogger = {
-//   ...DefaultLogger,
-//   trace: (...params) => {
-//     if (
-//       [
-//         'Sending ping',
-//         // 'Sending upstream ws message: ',
-//         'Received pong',
-//       ].includes(params[0])
-//     ) {
-//       return;
-//     }
-//     console.log('trace', JSON.stringify(params, null, 2));
-//   },
-// };
-⋮----
-passphrase: process.env.API_PASSPHRASE || 'apiPassPhraseHere', // This is NOT your account password
-⋮----
-// logger,
-⋮----
-// Data received
-⋮----
-// Something happened, attempting to reconenct
-⋮----
-// Reconnect successful
-⋮----
-// Connection closed. If unexpected, expect reconnect -> reconnected.
-⋮----
-// Reply to a request, e.g. "subscribe"/"unsubscribe"/"authenticate"
-⋮----
-// throw new Error('res?');
-⋮----
-// Optional: await a connection to be ready before subscribing (this is not necessary)
-// await client.connect('spotPrivateV1');
-// console.log('connected');
-⋮----
-/**
-     * For more detailed usage info, refer to the ws-spot-public.ts example.
-     *
-     * Below are some examples for subscribing to private spot & margin websockets.
-     * Note: all "private" websocket topics should use the "spotPrivateV1" wsKey.
-     */
-⋮----
-/**
-     * Other margin websocket topics, which also use the "spotPrivateV1" WsKey:
-     */
-
-================
-File: examples/WebSockets/ws-public-futures-v1.ts
-================
-/* eslint-disable @typescript-eslint/no-unused-vars */
-import { DefaultLogger, WebsocketClient } from '../../src/index.js';
-// import { DefaultLogger, WebsocketClient } from 'kucoin-api';
-// normally you should install this module via npm: `npm install kucoin-api`
-⋮----
-async function start()
-⋮----
-// Optional: fully customise the logging experience by injecting a custom logger
-// const logger: typeof DefaultLogger = {
-//   ...DefaultLogger,
-//   trace: (...params) => {
-//     if (
-//       [
-//         'Sending ping',
-//         'Sending upstream ws message: ',
-//         'Received pong',
-//       ].includes(params[0])
-//     ) {
-//       return;
-//     }
-//     console.log('trace', params);
-//   },
-// };
-⋮----
-// const client = new WebsocketClient({}, logger);
-⋮----
-// Data received
-⋮----
-// Something happened, attempting to reconenct
-⋮----
-// Reconnect successful
-⋮----
-// Connection closed. If unexpected, expect reconnect -> reconnected.
-⋮----
-// Reply to a request, e.g. "subscribe"/"unsubscribe"/"authenticate"
-⋮----
-// throw new Error('res?');
-⋮----
-// Optional: await a connection to be ready before subscribing (this is not necessary)
-// await client.connect('futuresPublicV1');
-⋮----
-/**
-     * Examples for public futures websocket topics (that don't require authentication).
-     *
-     * These should all subscribe via the "futuresPublicV1" wsKey. For detailed usage, refer to the ws-spot-public.ts example.
-     */
-
-================
-File: examples/WebSockets/ws-public-spot-v1.ts
-================
-/* eslint-disable @typescript-eslint/no-unused-vars */
-import {
-  DefaultLogger,
-  WebsocketClient,
-  WsTopicRequest,
-} from '../../src/index.js';
-// import { DefaultLogger, WebsocketClient, WsTopicRequest } from 'kucoin-api';
-// normally you should install this module via npm: `npm install kucoin-api`
-⋮----
-async function start()
-⋮----
-// Optional: fully customise the logging experience by injecting a custom logger
-// const logger: typeof DefaultLogger = {
-//   ...DefaultLogger,
-//   trace: (...params) => {
-//     if (
-//       [
-//         'Sending ping',
-//         'Sending upstream ws message: ',
-//         'Received pong',
-//       ].includes(params[0])
-//     ) {
-//       return;
-//     }
-//     console.log('trace', params);
-//   },
-// };
-⋮----
-// const client = new WebsocketClient({}, logger);
-⋮----
-// Data received
-⋮----
-// Something happened, attempting to reconenct
-⋮----
-// Reconnect successful
-⋮----
-// Connection closed. If unexpected, expect reconnect -> reconnected.
-⋮----
-// Reply to a request, e.g. "subscribe"/"unsubscribe"/"authenticate"
-⋮----
-// throw new Error('res?');
-⋮----
-/**
-   * The following example demonstrates the ways to consume data from the V1 WebSockets. For the V2 (Pro) WebSockets, see ws-spot-v2-public.ts
-   */
-⋮----
-// Optional: await a connection to be ready before subscribing (this is not necessary)
-// await client.connect('spotPublicV1');
-⋮----
-/**
-     * Use the client subscribe(topic, market) pattern to subscribe to any websocket topic.
-     *
-     * You can subscribe to topics one at a time or many one one request. Topics can be sent as simple strings:
-     *
-     */
-⋮----
-/**
-     * Or, as an array of simple strings
-     *
-     */
-⋮----
-/**
-     * Or send a more structured object with parameters
-     *
-     */
-⋮----
-/** Anything in the payload will be merged into the subscribe "request", allowing you to send misc parameters supported by the exchange.
-       *    For more info on parameters, see: https://www.kucoin.com/docs/websocket/basic-info/subscribe/introduction
-       */
-⋮----
-/**
-     * Or, send an array of structured objects with parameters, if you wanted to send multiple in one request
-     *
-     */
-// client.subscribe([subRequest1, subRequest2, etc], 'spotPublicV1');
-⋮----
-/**
-     * Other spot websocket topics:
-     */
-⋮----
-/**
-     * Other margin websocket topics, which also use the "spotPublicV1" WsKey:
-     */
-
-================
-File: examples/kucoin-FUTURES-examples-nodejs.md
-================
-# **KuCoin FUTURES API Examples** - Node.js, JavaScript & Typescript SDK for KuCoin REST APIs & WebSockets
-
-<p align="center">
-  <a href="https://www.npmjs.com/package/kucoin-api">
-    <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://github.com/tiagosiebler/kucoin-api/blob/master/docs/images/logoDarkMode2.svg?raw=true#gh-dark-mode-only">
-      <img alt="SDK Logo" src="https://github.com/tiagosiebler/kucoin-api/blob/master/docs/images/logoBrightMode2.svg?raw=true#gh-light-mode-only">
-    </picture>
-  </a>
-</p>
-
-This document provides comprehensive examples for using the KuCoin FUTURES API with Node.js and JavaScript. It covers various functionalities including account management, fund transfers, trade execution, order management, and market data retrieval. The examples are designed to help developers quickly integrate KuCoin Futures API into their NodeJS, Javascript and Typscript applications.
-
-If you are here, it means you will be great addition to our [Node.js Traders](https://t.me/nodetraders) community on Telegram where we discuss trading ideas, provide support regarding SDKs and share valuable resources!
-
-- [KuCoin Documentation](https://docs.kucoin.com/futures/#introduction) - official KuCoin API docs
-
-- [Node.js & JavaScript SDK for KuCoin](https://github.com/tiagosiebler/kucoin-api) - Github repo of our SDK
-
-Current file contains only certain most used examples. If you can't find what you need, you can search through [FuturesClient.ts](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts) - all of the endpoints and functions will be there! Otherwise, just ask in [Node.js Traders](https://t.me/nodetraders) Telegram group.
-
-Do you need help with Spot? Check out [Spot Quickstart guide](https://github.com/tiagosiebler/kucoin-api/blob/master/examples/kucoin-SPOT-examples-nodejs.md)
-
-**Table of contents:**
-
-- [Installation](#installation)
-- [Usage](#usage)
-- [REST API](#rest-api)
-
-  - [Account and balance](#account-examples)
-  - [Subaccount API management](#subaccount-api-management)
-  - [Market Data](#market-data)
-    - [Symbol and exchange info](#symbol-and-exchange-info)
-    - [Order Book data](#order-book-data)
-    - [Public Trades and Index data](#public-trades-and-index-data)
-    - [Funding Fees](#funding-fees)
-    - [Kline/Candles](#klinecandles)
-  - [Transfer funds in and out of Futures Account](#transfer-funds-in-and-out-of-futures-account)
-  - [Trade Execution](#trade)
-    - [General info](#general-info)
-    - [Market short](#market-short)
-    - [Market long](#market-long)
-    - [Limit short](#limit-short)
-    - [Limit long](#limit-long)
-    - [Market close](#market-close)
-    - [Limit close](#limit-close)
-    - [Stop loss](#stop-loss)
-    - [Place multiple orders](#place-multiple-orders)
-    - [Cancel order](#cancel-order)
-    - [Cancel all orders for specific symbol](#cancel-all-orders-for-specific-symbol)
-  - [Trade/Order/Positions Management](#tradeorderpositions-management)
-    - [Fetching orders](#fetching-orders)
-    - [Fills](#fills)
-    - [Positions](#positions)
-
-- [WebSocket](#websocket)
-- [Community group](#community-group)
-
-## Installation:
-
-```js
-// Install by npm
-npm install kucoin-api
-
-
-// Install by yarn
-yarn add kucoin-api
-```
-
-## Usage
-
-#### Create API credentials
-
-- [KuCoin API Key Management](https://www.kucoin.com/account/api)
-
-#### Import SDK to your project
-
-```js
-// require
-const { FuturesClient } = require('kucoin-api');
-
-// import
-import { FuturesClient } from 'kucoin-api';
-
-// initialise Futures Client
-const futuresClient = new FuturesClient({
-  // insert your api key, secret and passphrase - use env vars, if not just fill the string values
-  apiKey: process.env.KUCOIN_API_KEY || 'insert-your-api-key',
-  apiSecret: process.env.KUCOIN_API_SECRET || 'insert-your-api-secret',
-  apiPassphrase:
-    process.env.KUCOIN_API_PASSPHRASE || 'insert-your-api-passphrase',
-});
-```
-
-## REST API
-
-### Account examples
-
-#### Get Account Overview
-
-```js
-// Get Account Balance - XBT or USDT, default XBT
-futuresClient.getBalance({ currency: 'XBT' });
-
-// Get All Subaccount Accounts Balance
-futuresClient.getSubBalances({ currency: 'XBT' });
-```
-
-#### Get Transaction History
-
-```js
-futuresClient.getTransactions({
-  type: 'RealisedPNL', // 'RealisedPNL' | 'Deposit' | 'Withdrawal' | 'Transferin' | 'TransferOut'
-  maxCount: 10,
-  currency: 'USDT',
-});
-```
-
-### Subaccount API management
-
-```js
-// Get all subaccount APIs
-
-futuresClient.getSubAPIs({
-  subName: 'my_sub_name',
-});
-
-// Create Futures APIs for Sub-Account
-
-futuresClient.createSubAPI({
-  subName: 'my_sub_name',
-  passphrase: 'my_passphrase',
-  remark: 'my_remark',
-});
-
-// Modify Sub-Account Futures APIs
-
-futuresClient.updateSubAPI({
-  subName: 'my_sub_name',
-  passphrase: 'my_passphrase',
-  apiKey: 'my_api_key',
-});
-
-// Delete Sub-Account Futures APIs
-
-futuresClient.deleteSubAPI({
-  subName: 'my_sub_name',
-  passphrase: 'my_passphrase',
-  apiKey: 'my_api_key',
-});
-```
-
-### Market Data
-
-#### Symbol and exchange info
-
-```js
-// Get All Contract List
-futuresClient.getSymbols();
-
-// Get Order Info of the Contract
-futuresClient.getSymbol({ symbol: 'XBTUSDTM' });
-
-// Get Ticker
-futuresClient.getTicker({ symbol: 'XBTUSDTM' });
-```
-
-#### Order Book data
-
-```js
-// Get Full Order Book - Level 2
-futuresClient.getFullOrderBookLevel2({ symbol: 'XBTUSDTM' });
-
-// Get Level2 depth20
-futuresClient.getPartOrderBookLevel2Depth20({ symbol: 'XBTUSDTM' });
-
-// Get Level2 depth100
-futuresClient.getPartOrderBookLevel2Depth100({ symbol: 'XBTUSDTM' });
-```
-
-#### Public Trades and Index data
-
-```js
-// Get Public Trades
-futuresClient.getMarketTrades({ symbol: 'XBTUSDTM' });
-
-// Get Interest Rate List
-futuresClient.getInterestRates({ symbol: '.XBTINT' });
-
-// Get Index List
-futuresClient.getIndex({ symbol: '.KXBT' });
-
-// Get Current Mark Price
-futuresClient.getMarkPrice({ symbol: 'XBTUSDM' });
-
-// Get Premium Index
-futuresClient.getPremiumIndex({ symbol: '.XBTUSDMPI' });
-
-// Get 24hour futures transaction volume
-futuresClient.get24HourTransactionVolume();
-```
-
-#### Funding Fees
-
-```js
-// Get Current Funding Rate
-futuresClient.getFundingRate({ symbol: 'XBTUSDM' });
-
-// Get Public Funding History
-futuresClient.getFundingRates({
-  symbol: 'XBTUSDTM',
-  from: '1700310700000',
-  to: '1702310700000',
-});
-
-// Get Private Funding History
-futuresClient.getFundingHistory({ symbol: 'ETHUSDTM' });
-```
-
-#### Kline/Candles
-
-```js
-futuresClient.getKlines({
-  symbol: 'XBTUSDTM',
-  granularity: 60,
-  from: new Date().getTime() - 24 * 60 * 60 * 1000, // 24 hours ago
-  to: new Date().getTime(),
-});
-```
-
-### Transfer funds in and out of Futures Account
-
-```js
-// Transfer out of the Futures to main acc
-
-futuresClient.submitTransferOut({
-  amount: 0.01,
-  currency: 'USDT',
-  recAccountType: 'MAIN',
-});
-
-// Transfer to Futures Account
-
-futuresClient.submitTransferIn({
-  amount: 0.01,
-  currency: 'USDT',
-  payAccountType: 'MAIN',
-});
-
-// Get All Transfers
-
-futuresClient.futureTransfers({
-  status: 'SUCCESS', // optional, 'PROCESSING' | 'SUCCESS' | 'FAILURE';
-  currency: 'USDT', // optional
-  startAt: 1723550000, // optional
-  endAt: 1723557472, // optional
-  currentPage: 1, // optional
-  pageSize: 100, // optional
-});
-```
-
----
-
-### Trade
-
-#### General info
-
-Futures are contracts, not currencies. In the futures symbols list you will see a "multiplier" field for each of the symbols. Each contract is equal to Multiplier x Size.
-
-For example click on this endpoint and get a symbol info for XRPUSDTM: https://api-futures.kucoin.com/api/v1/contracts/XRPUSDTM
-
-In the object, find the "multiplier" value.
-
-```js
-// In your code, you can fetch it like this
-const symbolInfo = await client.getSymbol({ symbol: 'XRPUSDTM' });
-const multiplier = symbolInfo.data.multiplier;
-```
-
-E.g. if multiplier is 10(what you can see from the endpoint), that means each SIZE is 10 XRP. So if XRP is currently at $0.5, then each 1 contract (size 10) is going to cost $5.00
-
-size = (Funds x leverage) / (price x multiplier)
-
-```js
-const XRPPriceExample = 0.5;
-const leverage = 5;
-const fundsToTradeUSDT = 100;
-
-const costOfContract = XRPPriceExample * multiplier;
-
-const size = (fundsToTradeUSDT * leverage) / costOfContract;
-console.log(`Size: ${size}`);
-```
-
-The trade amount indicates the amount of contract to buy or sell, and contract uses the base currency(USD contracts e.g. XBTUSDM) or lot( USDT contracts e.g. XBTUSDTM) as the trading unit.
-The trade amount must be no less than 1 lot for the contract and no larger than the maxOrderQty.
-It should be a multiple number of the lot, or the system will report an error when you place the order.
-E.g. 1 lot of XBTUSDTM is 0.001 Bitcoin, while 1 lot of XBTUSDM is 1 USD.
-You can get info about any contract on the link: https://api-futures.kucoin.com/api/v1/contracts/****\_\_**** - just replace the empty space with the symbol of the contract.
-
-Here are function examples using the Futures Create Order endpoint:
-
-#### Market Short
-
-```js
-// A MARKET SHORT of 2 contracts of XBT using leverage of 5:
-const marketShort = futureTransfers.submitOrder({
-  clientOid: '123456789',
-  leverage: '5',
-  side: 'sell',
-  size: 2,
-  symbol: 'XBTUSDTM',
-  timeInForce: 'GTC',
-  type: 'market',
-});
-```
-
-#### Market Long
-
-```js
-// A MARKET LONG of 2 contracts of XBT using leverage of 5:
-const marketLong = futureTransfers.submitOrder({
-  clientOid: '123456789',
-  leverage: '5',
-  side: 'buy',
-  size: 2,
-  symbol: 'XBTUSDTM',
-  timeInForce: 'GTC',
-  type: 'market',
-});
-```
-
-#### Limit Short
-
-```js
-// A LIMIT SHORT of 2 contracts of XBT using leverage of 5:
-const limitShort = futureTransfers.submitOrder({
-  clientOid: '123456789',
-  leverage: '5',
-  price: '70300.31',
-  side: 'sell',
-  size: 2,
-  symbol: 'XBTUSDTM',
-  timeInForce: 'GTC',
-  type: 'limit',
-});
-```
-
-#### Limit Long
-
-```js
-// A LIMIT LONG of 2 contracts of XBT using leverage of 5:
-const limitLong = futureTransfers.submitOrder({
-  clientOid: '123456789',
-  leverage: '5',
-  price: '40300.31',
-  side: 'buy',
-  size: 2,
-  symbol: 'XBTUSDTM',
-  timeInForce: 'GTC',
-  type: 'limit',
-});
-```
-
-On any "close position" action, if you specify a SIZE=0 or leave off the SIZE parameter,
-then it will close the whole position, regardless of the size.
-If you specify a SIZE, it will close only the number of contracts you specify.
-
-If closeOrder is set to TRUE,
-the system will close the position and the position size will become 0.
-Side, Size and Leverage fields can be left empty and the system will determine the side and size automatically.
-
-#### Market close
-
-```js
-// A MARKET CLOSE POSITION example:
-const marketClose = futureTransfers.submitOrder({
-  clientOid: '123456789',
-  closeOrder: true,
-  symbol: 'XBTUSDTM',
-  timeInForce: 'GTC',
-  type: 'market',
-  side: 'sell',
-  size: 0,
-});
-```
-
-#### Limit close
-
-```js
-// A LIMIT CLOSE of a LONG example:
-const limitCloseLong = futureTransfers.submitOrder({
-  clientOid: '123456789',
-  leverage: '5',
-  price: '70300.31',
-  closeOrder: true,
-  side: 'sell',
-  size: 2,
-  symbol: 'XBTUSDTM',
-  timeInForce: 'GTC',
-  type: 'limit',
-});
-
-// A LIMIT CLOSE of a SHORT example:
-const limitCloseShort = futureTransfers.submitOrder({
-  clientOid: '123456789',
-  leverage: '5',
-  price: '40300.31',
-  closeOrder: true,
-  side: 'buy',
-  size: 2,
-  symbol: 'XBTUSDTM',
-  timeInForce: 'GTC',
-  type: 'limit',
-});
-```
-
-#### Stop loss
-
-```js
-// A STOP LOSS example for a LONG position:
-const stopLossLong = futureTransfers.submitOrder({
-  clientOid: '123456789',
-  closeOrder: true,
-  stop: 'down',
-  stopPrice: '40200.31',
-  stopPriceType: 'TP',
-  symbol: 'XBTUSDTM',
-  timeInForce: 'GTC',
-  type: 'market',
-});
-
-// A STOP LOSS example for a SHORT position:
-const stopLossShort = futureTransfers.submitOrder({
-  clientOid: '123456789',
-  closeOrder: true,
-  stop: 'up',
-  stopPrice: '40200.31',
-  stopPriceType: 'TP',
-  symbol: 'XBTUSDTM',
-  timeInForce: 'GTC',
-  type: 'market',
-});
-```
-
-##### Place Multiple Orders
-
-```js
-//request
-
-const orders = [
-  {
-    clientOid: '5c52e11203aa677f33e491',
-    side: 'buy',
-    symbol: 'ETHUSDTM',
-    type: 'limit',
-    price: '2150',
-    leverage: '1',
-    size: 2,
-  },
-  {
-    clientOid: 'je12019ka012ja013099',
-    side: 'buy',
-    symbol: 'XBTUSDTM',
-    type: 'limit',
-    price: '32150',
-    leverage: '1',
-    size: 2,
-  },
-];
-
-futuresClient.submitMultipleOrders(orders);
-```
-
-#### Cancel Order
-
-```js
-futuresClient.cancelOrderById({ orderId: 'orderId' });
-futuresClient.cancelOrderByClientOid({ clientOid: 'clientOid' });
-```
-
-#### Cancel all orders for specific symbol
-
-```js
-futuresClient.cancelAllOrders({ symbol: 'XBTUSDTM' });
-
-futuresClient.cancelAllStopOrders({ symbol: 'XBTUSDTM' });
-```
-
-### Trade/Order/Positions Management
-
-#### Fetching orders
-
-```js
-// Get open orders
-futuresClient.getOrders({ status: 'active' });
-
-// Get closed orders
-futuresClient.getOrders({ status: 'done' });
-
-// Get Untriggered Stop Orders
-futuresClient.getStopOrders({ type: 'limit' });
-
-// Get List of Orders Completed in 24h
-futuresClient.getRecentOrders();
-
-// Get Details of a Single Order by ClientOrderId
-futuresClient.getOrderByClientOrderId({ clientOid: 'clientOid' });
-// Or By OrderId
-futuresClient.getOrderByOrderId({ orderId: 'orderId' });
-```
-
-#### Fills
-
-```js
-// Get Specific Fills
-futuresClient.getFills({ type: 'market' });
-// or search for all
-futuresClient.getFills({});
-
-// Recent Fills from last 24 hours
-futuresClient.futuresRecentFills({ symbol: 'ETHUSDTM' });
-// Or Search All
-futuresClient.futuresRecentFills({});
-
-// Active Order Value Calculation
-futuresClient.getOpenOrderStatistics({ symbol: 'ETHUSDTM' });
-```
-
-#### Positions
-
-```js
-// Get Position Details
-futuresClient.getPosition({ symbol: 'ETHUSDTM' });
-
-// Get Position List
-futuresClient.getPositions({ currency: 'USDT' });
-// Or Search All
-futuresClient.getPositions();
-
-// Get History Positions
-futuresClient.getHistoryPositions({ symbol: 'ETHUSDTM' });
-```
-
-## Websocket
-
-For Websocket examples, please refer to these links:
-
-- [Spot Public Websocket](https://github.com/tiagosiebler/kucoin-api/blob/master/examples/ws-spot-public.ts)
-- [Spot Private Websocket](https://github.com/tiagosiebler/kucoin-api/blob/master/examples/ws-spot-private.ts)
-- [Futures Public Websocket](https://github.com/tiagosiebler/kucoin-api/blob/master/examples/ws-futures-public.ts)
-- [Futures Private Websocket](https://github.com/tiagosiebler/kucoin-api/blob/master/examples/ws-futures-private.ts)
-
-## Community group
-
-If you need help, something is wrong/missing or you have suggestions, please join our [Node.js Traders](https://t.me/nodetraders) community group on Telegram and let us know!
-
-================
-File: examples/kucoin-SPOT-examples-nodejs.md
-================
-# **KuCoin SPOT API Examples** - Node.js, JavaScript & Typescript SDK for KuCoin REST APIs & WebSockets
-
-<p align="center">
-  <a href="https://www.npmjs.com/package/kucoin-api">
-    <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://github.com/tiagosiebler/kucoin-api/blob/master/docs/images/logoDarkMode2.svg?raw=true#gh-dark-mode-only">
-      <img alt="SDK Logo" src="https://github.com/tiagosiebler/kucoin-api/blob/master/docs/images/logoBrightMode2.svg?raw=true#gh-light-mode-only">
-    </picture>
-  </a>
-</p>
-
-This document provides comprehensive examples for using the KuCoin SPOT API with Node.js and JavaScript. It covers various functionalities including account management, fund transfers, trade execution, order management, and market data retrieval. The examples are designed to help developers quickly integrate KuCoin Spot API into their NodeJS, Javascript and Typscript applications.
-
-If you are here, it means you will be great addition to our [Node.js Traders](https://t.me/nodetraders) community on Telegram where we discuss trading ideas, provide support regarding SDKs and share valuable resources!
-
-- [KuCoin Documentation](https://www.kucoin.com/docs/beginners/introduction) - official KuCoin API docs
-
-- [Node.js & JavaScript SDK for KuCoin](https://github.com/tiagosiebler/kucoin-api) - Github repo of our SDK
-
-Current file contains only certain most used examples. If you can't find what you need, you can search through [SpotClient.ts](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts) - all of the endpoints and functions will be there! Otherwise, just ask in [Node.js Traders](https://t.me/nodetraders) Telegram group.
-
-Do you need help with Futures? Check out [Futures Quickstart guide](https://github.com/tiagosiebler/kucoin-api/blob/master/examples/kucoin-FUTURES-examples-nodejs.md)
-
-**Table of contents:**
-
-- [Installation](#installation)
-- [Usage](#usage)
-- [REST API](#rest-api)
-
-  - [Account and balance](#account-examples)
-
-    - [Account overview](#account-overview)
-    - [Transactions](#transactions)
-    - [Deposit and Withdrawal](#deposit-and-withdrawal)
-
-  - [Subaccount](#subaccount)
-    - [Subaccount management](#subaccount-management)
-    - [Subaccount API management](#subaccount-api-management)
-  - [Market Data](#market-data)
-    - [Symbol and exchange info](#symbol-and-exchange-info)
-    - [Order Book data](#order-book-data)
-    - [Kline/Candles](#klinecandles)
-  - [Trade Execution](#trade)
-    - [General info](#general-info)
-    - [Market short](#market-short)
-    - [Market long](#market-long)
-    - [Limit short](#limit-short)
-    - [Limit long](#limit-long)
-    - [Place multiple orders](#place-multiple-orders)
-  - [Trade/Order/Positions Management](#tradeorderpositions-management)
-    - [Fetching orders](#fetching-orders)
-    - [Cancel order](#cancel-order)
-    - [Cancel all orders for specific symbol](#cancel-all-orders-for-specific-symbol)
-    - [Fills](#fills)
-  - [Spot HF trade](#spot-hf-trade)
-  - [Margin trade](#margin-trade--margin-hf-trade)
-
-- [WebSocket](#websocket)
-- [Community group](#community-group)
-
-## Installation:
-
-```js
-// Install by npm
-npm install kucoin-api
-
-
-// Install by yarn
-yarn add kucoin-api
-```
-
-## Usage
-
-#### Create API credentials
-
-- [KuCoin API Key Management](https://www.kucoin.com/account/api)
-
-#### Import SDK to your project
-
-```js
-// require
-const { SpotClient } = require('kucoin-api');
-
-// import
-import { SpotClient } from 'kucoin-api';
-
-// initialise Spot Client
-const spotClient = new SpotClient({
-  // insert your api key, secret and passphrase - use env vars, if not just fill the string values
-  apiKey: process.env.KUCOIN_API_KEY || 'insert-your-api-key',
-  apiSecret: process.env.KUCOIN_API_SECRET || 'insert-your-api-secret',
-  apiPassphrase:
-    process.env.KUCOIN_API_PASSPHRASE || 'insert-your-api-passphrase',
-});
-```
-
-## REST API
-
-### Account examples
-
-#### Account Overview
-
-```js
-// Get Account Summary
-spotClient.getAccountSummary();
-
-// Get all Account Balances
-spotClient.getBalances();
-
-// Get specific Account or Currency Balance
-spotClient.getBalance({
-  currency: 'USDT',
-  type: 'main', // 'trade' | 'margin' | 'trade_hf'
-});
-
-// Example call to get account details by ID
-spotClient.getAccountDetails({ accountId: '5bd6e9286d99522a52e458de' });
-
-// Margin endpoints for balances
-spotClient.getMarginBalances();
-spotClient.getMarginBalance();
-spotClient.getIsolatedMarginBalance();
-```
-
-#### Transactions
-
-```js
-// Example call to get account ledgers with specified parameters
-spotClient.getTransactions({ currency: 'BTC', startAt: 1601395200000 });
-
-// Example call to get high-frequency account ledgers with specified parameters
-spotClient.getHFTransactions({
-  bizType: 'TRADE_EXCHANGE',
-  currency: 'YOP,DAI',
-  startAt: 1601395200000,
-});
-
-// Example call to get high-frequency margin account ledgers with specified parameters
-spotClient.getHFMarginTransactions({
-  bizType: 'MARGIN_EXCHANGE',
-  currency: 'YOP,DAI',
-  startAt: 1601395200000,
-});
-```
-
-#### Deposit and Withdrawal
-
-```js
-// Example call to create a deposit address
-spotClient.createDepositAddress({
-  currency: 'BTC',
-  // Optional parameter
-  chain: 'BTC',
-});
-
-// Example call to get deposit addresses with specified parameters
-spotClient.getDepositAddressesV2({
-  currency: 'BTC',
-});
-
-// Example call to get deposits
-spotClient.getDeposits();
-
-// Example call to get withdrawals with specified parameters
-spotClient.getWithdrawals({
-  currency: 'BTC', // Optional parameter
-});
-
-// Example call to submit a withdrawal
-spotClient.submitWithdraw({
-  currency: 'BTC',
-  address: '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa',
-  amount: 0.01,
-  // Optional parameters
-  memo: 'exampleMemo',
-  chain: 'BTC',
-});
-
-// Example call to cancel a withdrawal by ID
-spotClient.cancelWithdrawal({
-  withdrawalId: '5bffb63303aa675e8bbe18f9',
-});
-```
-
-### Subaccount
-
-#### Subaccount Management
-
-```js
-// Get all subaccounts
-spotClient.getSubAccountsV2({});
-
-// Example call to create a sub-account
-spotClient.createSubAccount({
-  // Fill in the required parameters for creating a sub-account
-  subName: 'exampleSubAccount',
-  password: 'examplePassword',
-  access: 'trade',
-});
-
-// Example call to get sub-account balance with specified parameters
-spotClient.getSubAccountBalance({
-  subUserId: '5caefba7d9575a0688f83c45',
-  includeBaseAmount: false,
-});
-
-// Example call to get sub-account balances
-spotClient.getSubAccountBalancesV2();
-
-// Example call to get transferable funds
-spotClient.getTransferable({
-  currency: 'BTC',
-  type: 'MAIN',
-});
-
-// Example call to submit a transfer from master to sub-account
-spotClient.submitTransferMasterSub({
-  clientOid: client.generateNewOrderID(), // or use your custom UUID
-  amount: 0.01,
-  currency: 'USDT',
-  direction: 'OUT', // 'IN' for transfer to master, 'OUT' for transfer to sub
-  subUserId: 'enter_sub_user_id_here',
-});
-
-// Example call to submit an inner transfer within same account
-spotClient.submitInnerTransfer({
-  clientOid: client.generateNewOrderID(), // or use your custom UUID
-  amount: 0.01,
-  currency: 'USDT',
-  from: 'main', // Source account type
-  to: 'trade', // Destination account type
-});
-```
-
-#### Subaccount API management
-
-```js
-// Get all subaccount APIs
-
-spotClient.getSubAPIs({
-  subName: 'my_sub_name',
-});
-
-// Create APIs for Sub-Account
-
-spotClient.createSubAPI({
-  subName: 'my_sub_name',
-  passphrase: 'my_passphrase',
-  remark: 'my_remark',
-});
-
-// Modify Sub-Account APIs
-
-spotClient.updateSubAPI({
-  subName: 'my_sub_name',
-  passphrase: 'my_passphrase',
-  apiKey: 'my_api_key',
-});
-
-// Delete Sub-Account APIs
-
-spotClient.deleteSubAPI({
-  subName: 'my_sub_name',
-  passphrase: 'my_passphrase',
-  apiKey: 'my_api_key',
-});
-```
-
-### Market Data
-
-#### Symbol and exchange info
-
-```js
-// Get All Currencies List
-spotClient.getCurrencies();
-
-// Get info for a specific currency
-spotClient.getCurrency({
-  currency: 'BTC',
-});
-
-// Get all Symbols
-spotClient.getSymbols();
-
-// Example call to get ticker information for a specific symbol
-spotClient.getTicker({
-  symbol: 'BTC-USDT',
-});
-
-// All tickers
-spotClient.getTickers();
-
-// Get 24h stats for a specific symbol
-spotClient.get24hrStats({
-  symbol: 'BTC-USDT',
-});
-```
-
-#### Order Book data
-
-```js
-// get partial orderbook
-spotClient.getOrderBookLevel20({ symbol: 'BTC-USDT' });
-
-// get partial orderbook
-spotClient.getOrderBookLevel100({ symbol: 'BTC-USDT' });
-
-// get full orderbook
-spotClient.getFullOrderBook({ symbol: 'BTC-USDT' });
-```
-
-#### Kline/Candles
-
-```js
-// Example call to get Klines (candlestick data) with specified parameters
-spotClient.getKlines({
-  type: '1min',
-  symbol: 'BTC-USDT',
-  startAt: 1566703297,
-  endAt: 1566789757,
-});
-```
-
----
-
-### Trade
-
-#### General info
-
-Please, read official [KuCoin API docs](https://www.kucoin.com/docs/rest/spot-trading/orders/place-order) to understand how to place orders, cancel orders, etc. and what is needed for each endpoint. These are just low-end examples to understand how to use it with SDK.
-
-#### Market Short
-
-```js
-// Market short order
-const marketShort = spotClient.submitOrder({
-  clientOid: client.generateNewOrderID(), // or use your custom UUID
-  side: 'sell',
-  symbol: 'ETH-BTC',
-  type: 'market',
-  size: '0.5', // Specify the quantity to sell
-});
-```
-
-#### Market Long
-
-```js
-// Market long order
-const marketLong = spotClient.submitOrder({
-  clientOid: client.generateNewOrderID(), // or use your custom UUID
-  side: 'buy',
-  symbol: 'ETH-BTC',
-  type: 'market',
-  size: '0.5', // Specify the quantity to buy
-});
-```
-
-#### Limit Short
-
-```js
-// Limit short order
-const limitShort = spotClient.submitOrder({
-  clientOid: client.generateNewOrderID(), // or use your custom UUID
-  side: 'sell',
-  symbol: 'ETH-BTC',
-  type: 'limit',
-  price: '0.03', // Specify the price to sell
-  size: '0.5', // Specify the quantity to sell
-  timeInForce: 'GTC', // Good Till Canceled
-});
-```
-
-#### Limit Long
-
-```js
-// Limit long order
-const limitLong = spotClient.submitOrder({
-  clientOid: client.generateNewOrderID(), // or use your custom UUID
-  side: 'buy',
-  symbol: 'ETH-BTC',
-  type: 'limit',
-  price: '0.03', // Specify the price to buy
-  size: '0.5', // Specify the quantity to buy
-  timeInForce: 'GTC', // Good Till Canceled
-});
-```
-
-##### Place Multiple Orders
-
-```js
-//request
-
-const multipleOrders = [
-  {
-    clientOid: '3d07008668054da6b3cb12e432c2b13a',
-    side: 'buy',
-    type: 'limit',
-    price: '0.01',
-    size: '0.01',
-  },
-  {
-    clientOid: '37245dbe6e134b5c97732bfb36cd4a9d',
-    side: 'buy',
-    type: 'limit',
-    price: '0.01',
-    size: '0.01',
-  },
-];
-
-spotClient.submitMultipleOrders({
-  symbol: 'KCS-USDT',
-  orderList: multipleOrders,
-});
-```
-
-### Trade/Order/Positions Management
-
-#### Fetching orders
-
-```js
-// Get open orders
-spotClient.getOrders({ status: 'active' });
-
-// Get closed orders
-spotClient.getOrders({ status: 'done' });
-
-// Get List of Orders Completed in 24h
-spotClient.getRecentOrders();
-
-// Get Details of a Single Order by ClientOrderId
-spotClient.getOrderByClientOid({ clientOid: 'clientOid' });
-// Or By OrderId
-spotClient.getOrderByOrderId({ orderId: 'orderId' });
-```
-
-#### Cancel Order
-
-```js
-spotClient.cancelOrderById({ orderId: 'orderId' });
-spotClient.cancelOrderByClientOid({ clientOid: 'clientOid' });
-```
-
-#### Cancel all orders for specific symbol
-
-```js
-//cancel all orders for symbol
-spotClient.cancelAllOrders({ symbol: 'XBTUSDTM' });
-
-// cancel all orders for all symbols
-spotClient.cancelAllOrders();
-```
-
-#### Fills
-
-```js
-// Get Specific Fills
-spotClient.getFills({ type: 'market' });
-// or search for all
-spotClient.getFills();
-
-// Recent Fills from last 24 hours
-spotClient.getRecentFills();
-```
-
-### Spot HF trade
-
-All of the examples are 99% same as regular spot, but you can follow the [official HF Trade API documentation](https://www.kucoin.com/docs/rest/spot-trading/spot-hf-trade-pro-account/place-hf-order) and list of functions in [SpotClient.ts](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts) to find what you need!
-
-### Margin trade & Margin HF trade
-
-All of the examples are 99% same as regular spot, but you can follow the [official Margin Trade API documentation](https://www.kucoin.com/docs/rest/margin-trading/market-data) and list of functions in [SpotClient.ts](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts) to find what you need!
-
----
-
-## Websocket
-
-For Websocket examples, please refer to these links:
-
-- [Spot Public Websocket](https://github.com/tiagosiebler/kucoin-api/blob/master/examples/ws-spot-public.ts)
-- [Spot Private Websocket](https://github.com/tiagosiebler/kucoin-api/blob/master/examples/ws-spot-private.ts)
-- [Futures Public Websocket](https://github.com/tiagosiebler/kucoin-api/blob/master/examples/ws-futures-public.ts)
-- [Futures Private Websocket](https://github.com/tiagosiebler/kucoin-api/blob/master/examples/ws-futures-private.ts)
-
-## Community group
-
-If you need help, something is wrong/missing or you have suggestions, please join our [Node.js Traders](https://t.me/nodetraders) community group on Telegram and let us know!
-
-================
-File: src/lib/websocket/WsStore.types.ts
-================
-import WebSocket from 'isomorphic-ws';
-⋮----
-export enum WsConnectionStateEnum {
-  INITIAL = 0,
-  CONNECTING = 1,
-  CONNECTED = 2,
-  CLOSING = 3,
-  RECONNECTING = 4,
-  // ERROR_RECONNECTING = 5,
-  ERROR = 5,
-}
-⋮----
-// ERROR_RECONNECTING = 5,
-⋮----
-export interface DeferredPromise<TSuccess = any, TError = any> {
-  resolve?: (value: TSuccess) => TSuccess;
-  reject?: (value: TError) => TError;
-  promise?: Promise<TSuccess>;
-}
-⋮----
-export interface WSConnectedResult {
-  wsKey: string;
-  ws: WebSocket;
-}
-⋮----
-export interface WsStoredState<TWSTopicSubscribeEvent extends string | object> {
-  /** The currently active websocket connection */
-  ws?: WebSocket;
-
-  /** The current lifecycle state of the connection (enum) */
-  connectionState?: WsConnectionStateEnum;
-  connectionStateChangedAt?: Date;
-
-  /** A timer that will send an upstream heartbeat (ping) when it expires */
-  activePingTimer?: ReturnType<typeof setTimeout> | undefined;
-
-  /** A timer tracking that an upstream heartbeat was sent, expecting a reply before it expires */
-  activePongTimer?: ReturnType<typeof setTimeout> | undefined;
-
-  /** If a reconnection is in progress, this will have the timer for the delayed reconnect */
-  activeReconnectTimer?: ReturnType<typeof setTimeout> | undefined;
-  /**
-   * When a connection attempt is in progress (even for reconnect), a promise is stored here.
-   *
-   * This promise will resolve once connected (and will then get removed);
-   */
-  deferredPromiseStore: Record<string, DeferredPromise>;
-
-  /**
-   * All the topics we are expected to be subscribed to on this connection (and we automatically resubscribe to if the connection drops)
-   *
-   * A "Set" and a deep-object-match are used to ensure we only subscribe to a topic once (tracking a list of unique topics we're expected to be connected to)
-   */
-  subscribedTopics: Set<TWSTopicSubscribeEvent>;
-
-  /** Whether this connection has completed authentication (only applies to private connections) */
-  isAuthenticated?: boolean;
-
-  /**
-   * Whether this connection has completed authentication before for the Websocket API, so it knows to automatically reauth if reconnected
-   */
-  didAuthWSAPI?: boolean;
-
-  /** To reauthenticate on the WS API, which channel do we send to? */
-  WSAPIAuthChannel?: string;
-}
-⋮----
-/** The currently active websocket connection */
-⋮----
-/** The current lifecycle state of the connection (enum) */
-⋮----
-/** A timer that will send an upstream heartbeat (ping) when it expires */
-⋮----
-/** A timer tracking that an upstream heartbeat was sent, expecting a reply before it expires */
-⋮----
-/** If a reconnection is in progress, this will have the timer for the delayed reconnect */
-⋮----
-/**
-   * When a connection attempt is in progress (even for reconnect), a promise is stored here.
-   *
-   * This promise will resolve once connected (and will then get removed);
-   */
-⋮----
-/**
-   * All the topics we are expected to be subscribed to on this connection (and we automatically resubscribe to if the connection drops)
-   *
-   * A "Set" and a deep-object-match are used to ensure we only subscribe to a topic once (tracking a list of unique topics we're expected to be connected to)
-   */
-⋮----
-/** Whether this connection has completed authentication (only applies to private connections) */
-⋮----
-/**
-   * Whether this connection has completed authentication before for the Websocket API, so it knows to automatically reauth if reconnected
-   */
-⋮----
-/** To reauthenticate on the WS API, which channel do we send to? */
-
-================
-File: src/types/response/spot-account.ts
-================
-export interface SpotAccountSummary {
-  level: number;
-  subQuantity: number;
-  spotSubQuantity: number;
-  marginSubQuantity: number;
-  futuresSubQuantity: number;
-  optionSubQuantity: number;
-  maxSubQuantity: number;
-  maxDefaultSubQuantity: number;
-  maxSpotSubQuantity: number;
-  maxMarginSubQuantity: number;
-  maxFuturesSubQuantity: number;
-  maxOptionSubQuantity: number;
-}
-⋮----
-export interface Balances {
-  id: string;
-  currency: string;
-  type: 'main' | 'trade';
-  balance: string;
-  available: string;
-  holds: string;
-}
-⋮----
-export interface Account {
-  currency: string;
-  balance: string;
-  available: string;
-  holds: string;
-}
-⋮----
-export interface SpotAccountTransaction {
-  id: string;
-  currency: string;
-  amount: string;
-  fee: string;
-  tax: string;
-  balance: string;
-  accountType: string; // 'TRADE_HF'
-  bizType: string;
-  direction: 'out' | 'in';
-  createdAt: string;
-  context: string;
-}
-⋮----
-accountType: string; // 'TRADE_HF'
-⋮----
-export interface SpotAccountTransactions {
-  currentPage: number;
-  pageSize: number;
-  totalNum: number;
-  totalPage: number;
-  items: SpotAccountTransaction[];
-}
-⋮----
-export interface AccountHFMarginTransactions {
-  id: string;
-  currency: string;
-  amount: string;
-  fee: string;
-  balance: string;
-  accountType: 'MARGIN_V2' | 'ISOLATED_V2';
-  bizType:
-    | 'TRANSFER'
-    | 'MARGIN_EXCHANGE'
-    | 'ISOLATED_EXCHANGE'
-    | 'LIQUIDATION'
-    | 'ASSERT_RETURN';
-  direction: 'out' | 'in';
-  createdAt: string;
-  tax: string;
-  context: string;
-}
-⋮----
-/**
- *
- * Sub-Account
- *
- */
-⋮----
-export interface SubAccountInfo {
-  userId: string;
-  uid: number;
-  subName: string;
-  status: number;
-  type: number;
-  access: string;
-  createdAt: number;
-  remarks: string;
-  tradeTypes: string[];
-  openedTradeTypes: string[];
-  hostedStatus: null | string;
-}
-⋮----
-export interface SubAccountsV2 {
-  currentPage: number;
-  pageSize: number;
-  totalNum: number;
-  totalPage: number;
-  items: SubAccountInfo[];
-}
-⋮----
-export interface SubAccountItem {
-  userId: string;
-  uid: number;
-  subName: string;
-  status: number;
-  type: number;
-  access: string;
-  createdAt: number;
-  remarks: string;
-  tradeTypes: string[];
-  openedTradeTypes: string[];
-  hostedStatus: null | string;
-}
-⋮----
-export interface CreateSubAccount {
-  currentPage: number;
-  pageSize: number;
-  totalNum: number;
-  totalPage: number;
-  items: SubAccountItem[];
-}
-⋮----
-export interface SubAccountBalance {
-  currency: string;
-  balance: string;
-  available: string;
-  holds: string;
-  baseCurrency: string;
-  baseCurrencyPrice: string;
-  baseAmount: string;
-}
-⋮----
-// deprecated
-export interface SubAccountBalances {
-  subUserId: string;
-  subName: string;
-  mainAccounts: SubAccountBalance[];
-  tradeAccounts: SubAccountBalance[];
-  marginAccounts: SubAccountBalance[];
-}
-⋮----
-export interface SubAccountBalancesV2 {
-  currentPage: number;
-  pageSize: number;
-  totalNum: number;
-  totalPage: number;
-  items: {
-    subUserId: string;
-    subName: string;
-    mainAccounts: SubAccountBalance[];
-  }[];
-}
-export interface SubAccountV2Details {
-  currency?: string;
-  balance?: string;
-  available?: string;
-  holds?: string;
-  baseCurrency?: string;
-  baseCurrencyPrice?: string;
-  baseAmount?: string;
-  tag?: string;
-}
-⋮----
-export interface SubAccountBalanceItemV2 {
-  subUserId: string;
-  subName: string;
-  mainAccounts: SubAccountV2Details[]; // Funding Account
-  tradeAccounts: SubAccountV2Details[]; // Spot Account
-  marginAccounts: SubAccountV2Details[]; // Margin Account
-  tradeHFAccounts: string[]; // Deprecated, only for old users
-}
-⋮----
-mainAccounts: SubAccountV2Details[]; // Funding Account
-tradeAccounts: SubAccountV2Details[]; // Spot Account
-marginAccounts: SubAccountV2Details[]; // Margin Account
-tradeHFAccounts: string[]; // Deprecated, only for old users
-⋮----
-/**
- *
- * Sub-Account API
- *
- *
- */
-⋮----
-export interface SubAccountAPIInfo {
-  subName: string;
-  remark: string;
-  apiKey: string;
-  apiVersion: number;
-  permission: string;
-  ipWhitelist: string;
-  createdAt: number;
-  uid: number;
-  isMaster: boolean;
-}
-⋮----
-export interface CreateSubAPI {
-  subName: string;
-  remark: string;
-  apiKey: string;
-  apiSecret: string;
-  apiVersion: number;
-  passphrase: string;
-  permission: string;
-  createdAt: number;
-}
-⋮----
-export interface UpdateSubAPI {
-  apiKey: string;
-  ipWhitelist: string;
-  permission: string;
-  subName: string;
-}
-⋮----
-export interface DeleteSubAccountAPI {
-  subName: string;
-  apiKey: string;
-}
-⋮----
-/**
- * Get KYC Regions Response
- */
-export interface KYCRegion {
-  code: string; // Two-letter country code
-  enName: string; // English name of the region
-}
-⋮----
-code: string; // Two-letter country code
-enName: string; // English name of the region
-⋮----
-/**
- * Get API Key Info Response
- */
-export interface ApiKeyInfo {
-  uid: number; // Account UID
-  parentUid?: number; // Master account UID. Returns empty when called by the master account itself
-  region: string; // KYC region of the account, returns the two-letter country code
-  kycStatus: 0 | 1; // KYC status
-  subName?: string; // Sub-account name (not present for the master account)
-  remark: string; // Remarks
-  apiKey: string; // API key
-  apiVersion: number; // API version
-  permission: string; // Permissions
-  ipWhitelist?: string; // IP whitelist (comma-separated list of allowed IPs)
-  isMaster: boolean; // Indicates whether this is the master account
-  createdAt: number; // API key creation timestamp (Unix milliseconds)
-  expiredAt?: number | null; // API key expiration timestamp (Unix milliseconds). Returns null if no expiration is set
-  thirdPartyApp?: string; // Third-party application name. Returns empty string if not associated with any third-party app
-}
-⋮----
-uid: number; // Account UID
-parentUid?: number; // Master account UID. Returns empty when called by the master account itself
-region: string; // KYC region of the account, returns the two-letter country code
-kycStatus: 0 | 1; // KYC status
-subName?: string; // Sub-account name (not present for the master account)
-remark: string; // Remarks
-apiKey: string; // API key
-apiVersion: number; // API version
-permission: string; // Permissions
-ipWhitelist?: string; // IP whitelist (comma-separated list of allowed IPs)
-isMaster: boolean; // Indicates whether this is the master account
-createdAt: number; // API key creation timestamp (Unix milliseconds)
-expiredAt?: number | null; // API key expiration timestamp (Unix milliseconds). Returns null if no expiration is set
-thirdPartyApp?: string; // Third-party application name. Returns empty string if not associated with any third-party app
-
-================
 File: src/types/response/spot-trading.ts
 ================
 /**
@@ -4844,57 +2452,275 @@ export interface OCOOrders {
 }
 
 ================
-File: src/types/response/ws.ts
+File: src/types/response/spot-vip.ts
 ================
-export interface WsServerInfo {
-  endpoint: string;
-  encrypt: boolean;
-  protocol: string;
-  pingInterval: number;
-  pingTimeout: number;
+/**
+ *
+ ***********
+ * VIP LENDING
+ ***********
+ *
+ */
+⋮----
+export interface DiscountRateConfig {
+  currency: string;
+  usdtLevels: {
+    left: number;
+    right: number;
+    discountRate: string;
+  }[];
 }
 ⋮----
-export interface WsConnectionInfo {
-  token: string;
-  instanceServers: WsServerInfo[];
+export interface OtcLoan {
+  parentUid: string;
+  orders: {
+    orderId: string;
+    currency: string;
+    principal: string;
+    interest: string;
+  }[];
+  ltv: {
+    transferLtv: string;
+    onlyClosePosLtv: string;
+    delayedLiquidationLtv: string;
+    instantLiquidationLtv: string;
+    currentLtv: string;
+  };
+  totalMarginAmount: string;
+  transferMarginAmount: string;
+  margins: {
+    marginCcy: string;
+    marginQty: string;
+    marginFactor: string;
+  }[];
 }
 ⋮----
-export interface WsConnectionInfoV2 {
-  token: string;
-  instanceServers: undefined;
+export interface OtcLoanAccount {
+  uid: string;
+  marginCcy: string;
+  marginQty: string;
+  marginFactor: string;
+  accountType: 'TRADE' | 'TRADE_HF' | 'CONTRACT';
+  isParent: boolean;
 }
 
 ================
-File: webpack/webpack.config.cjs
+File: src/BrokerClient.ts
 ================
-function generateConfig(name)
+import { BaseRestClient } from './lib/BaseRestClient.js';
+import { REST_CLIENT_TYPE_ENUM, RestClientType } from './lib/requestUtils.js';
+import {
+  BrokerTransferRequest,
+  CreateBrokerSubAccountApiRequest,
+  DeleteBrokerSubAccountApiRequest,
+  GetBrokerDepositListRequest,
+  GetBrokerInfoRequest,
+  GetBrokerSubAccountApisRequest,
+  GetBrokerSubAccountsRequest,
+  UpdateBrokerSubAccountApiRequest,
+} from './types/request/broker.types.js';
+import {
+  BrokerDepositRecord,
+  BrokerInfo,
+  BrokerSubAccountApi,
+  BrokerTransferHistory,
+  BrokerWithdrawalRecord,
+  CreateBrokerSubAccountApiResponse,
+  CreateBrokerSubAccountResponse,
+  GetBrokerSubAccountsResponse,
+} from './types/response/broker.types.js';
+import { APISuccessResponse } from './types/response/shared.types.js';
 ⋮----
-// Add '.ts' and '.tsx' as resolvable extensions.
+/**
+ *
+ */
+export class BrokerClient extends BaseRestClient
 ⋮----
-// Node.js core modules not available in browsers
-// The REST client's https.Agent (for keepAlive) is Node.js-only and won't work in browsers
+getClientType(): RestClientType
 ⋮----
-// Code is already transpiled from TypeScript, no additional loaders needed
-
-================
-File: .gitignore
-================
-examples/futures-private-test.ts
-examples/spot-private-test.ts
-node_modules
-
-rest-spot-private-ts-test.ts
-
-localtest.sh
-testfile.ts
-dist
-repomix.sh
-doc
-
-coverage
-
-privaterepotracker
-restClientRegex.ts
+/**
+   * Get Broker Info
+   *
+   * This endpoint supports querying the basic information of the current Broker
+   */
+getBrokerInfo(
+    params: GetBrokerInfoRequest,
+): Promise<APISuccessResponse<BrokerInfo>>
+⋮----
+/**
+   * Add SubAccount
+   *
+   * This endpoint supports Broker users to create sub-accounts.
+   * Note that the account name is unique across the exchange.
+   * It is recommended to add a special identifier to prevent name duplication.
+   */
+createSubAccount(params: {
+    accountName: string;
+}): Promise<APISuccessResponse<CreateBrokerSubAccountResponse>>
+⋮----
+/**
+   * Get SubAccount
+   *
+   * This interface supports querying sub-accounts created by Broker.
+   * Returns paginated results with default page size of 20 (max 100).
+   */
+getSubAccounts(
+    params: GetBrokerSubAccountsRequest,
+): Promise<APISuccessResponse<GetBrokerSubAccountsResponse>>
+⋮----
+/**
+   * Add SubAccount API
+   *
+   * This interface supports the creation of Broker sub-account APIKEY.
+   * Supports up to 20 IPs in the whitelist.
+   * Permissions: General, Spot, Margin, Futures, InnerTransfer, Transfer, Earn.
+   * Label must be between 4 and 32 characters.
+   */
+createSubAccountApi(
+    params: CreateBrokerSubAccountApiRequest,
+): Promise<APISuccessResponse<CreateBrokerSubAccountApiResponse>>
+⋮----
+/**
+   * Get SubAccount API
+   *
+   * This interface supports querying the Broker's sub-account APIKEYs.
+   * Can optionally filter by specific apiKey.
+   */
+getSubAccountApis(
+    params: GetBrokerSubAccountApisRequest,
+): Promise<APISuccessResponse<BrokerSubAccountApi[]>>
+⋮----
+/**
+   * Modify SubAccount API
+   *
+   * This interface supports modifying the Broker's sub-account APIKEY.
+   * Supports up to 20 IPs in the whitelist.
+   * Permissions: General, Spot, Margin, Futures, InnerTransfer, Transfer, Earn.
+   * Label must be between 4 and 32 characters.
+   */
+updateSubAccountApi(
+    params: UpdateBrokerSubAccountApiRequest,
+): Promise<APISuccessResponse<BrokerSubAccountApi>>
+⋮----
+/**
+   * Delete SubAccount API
+   *
+   * This interface supports deleting Broker's sub-account APIKEY.
+   */
+deleteSubAccountApi(
+    params: DeleteBrokerSubAccountApiRequest,
+): Promise<APISuccessResponse<boolean>>
+⋮----
+/**
+   * Transfer
+   *
+   * This endpoint supports fund transfer between Broker account and Broker sub-accounts.
+   * Please be aware that withdrawal from sub-account is not directly supported.
+   * Broker has to transfer funds from broker sub-account to broker account to initiate the withdrawals.
+   *
+   * Direction:
+   * - OUT: Broker account is transferred to Broker sub-account
+   * - IN: Broker sub-account is transferred to Broker account
+   *
+   * Account Types:
+   * - MAIN: Funding account
+   * - TRADE: Spot trading account
+   */
+submitTransfer(params: BrokerTransferRequest): Promise<
+    APISuccessResponse<{
+      orderId: string;
+    }>
+  > {
+    return this.postPrivate('api/v1/broker/nd/transfer', params);
+⋮----
+/**
+   * Get Transfer History
+   *
+   * This endpoint supports querying transfer records of the broker itself and its created sub-accounts.
+   *
+   * Account Types:
+   * - MAIN: Funding account
+   * - TRADE: Spot trading account
+   * - CONTRACT: Contract account
+   * - MARGIN: Margin account
+   * - ISOLATED: Isolated margin account
+   *
+   * Status:
+   * - PROCESSING: Processing
+   * - SUCCESS: Successful
+   * - FAILURE: Failed
+   */
+getTransferHistory(params: {
+    orderId: string;
+}): Promise<APISuccessResponse<BrokerTransferHistory>>
+⋮----
+/**
+   * Get Deposit List
+   *
+   * This endpoint can obtain the deposit records of each sub-account under the ND Broker.
+   * Default limit is 1000 records (max 1000).
+   * Results are sorted in descending order by default.
+   *
+   * Status:
+   * - PROCESSING: Processing
+   * - SUCCESS: Successful
+   * - FAILURE: Failed
+   */
+getDeposits(
+    params?: GetBrokerDepositListRequest,
+): Promise<APISuccessResponse<BrokerDepositRecord[]>>
+⋮----
+/**
+   * Get Deposit Detail
+   *
+   * This endpoint supports querying the deposit record of sub-accounts created by a Broker
+   * (excluding main account of nd broker).
+   *
+   * Status:
+   * - PROCESSING: Processing
+   * - SUCCESS: Successful
+   * - FAILURE: Failed
+   */
+getDeposit(params: {
+    currency: string;
+    hash: string;
+}): Promise<APISuccessResponse<BrokerDepositRecord>>
+⋮----
+/**
+   * Get Withdrawal Detail
+   *
+   * This endpoint supports querying the withdrawal records of sub-accounts created by a Broker
+   * (excluding main account of nd broker).
+   *
+   * Status:
+   * - PROCESSING: Processing
+   * - WALLET_PROCESSING: Wallet Processing
+   * - REVIEW: Under Review
+   * - SUCCESS: Successful
+   * - FAILURE: Failed
+   */
+getWithdrawal(params: {
+    withdrawalId: string;
+}): Promise<APISuccessResponse<BrokerWithdrawalRecord>>
+⋮----
+/**
+   * Get Broker Rebate
+   *
+   * This interface supports downloading Broker rebate orders.
+   * Returns a URL to download a CSV file containing the rebate data.
+   * The URL is valid for 1 day.
+   * Maximum interval between begin and end dates is 6 months.
+   */
+getBrokerRebate(params: {
+    begin: string;
+    end: string;
+    tradeType: '1' | '2';
+  }): Promise<
+    APISuccessResponse<{
+      url: string;
+    }>
+  > {
+    return this.getPrivate('api/v1/broker/nd/rebase/download', params);
 
 ================
 File: .nvmrc
@@ -4902,102 +2728,1292 @@ File: .nvmrc
 v22.18.0
 
 ================
-File: eslint.config.cjs
-================
-/* eslint-disable @typescript-eslint/no-require-imports */
-⋮----
-// Bridge old-style ESLint config into the flat config format required by ESLint v9+
-
-================
-File: LICENSE.md
-================
-Copyright 2025 Tiago Siebler
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-================
-File: tsconfig.json
+File: .prettierrc
 ================
 {
-  "compilerOptions": {
-    "allowSyntheticDefaultImports": true,
-    "baseUrl": ".",
-    "noEmitOnError": true,
-    "declaration": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": false,
-    "inlineSourceMap": false,
-    "lib": ["esnext"],
-    "listEmittedFiles": false,
-    "listFiles": false,
-    "moduleResolution": "node",
-    "noFallthroughCasesInSwitch": true,
-    "noImplicitAny": true,
-    "noUnusedParameters": true,
-    "pretty": true,
-    "removeComments": false,
-    "resolveJsonModule": true,
-    "skipLibCheck": false,
-    "sourceMap": true,
-    "strict": true,
-    "strictNullChecks": true,
-    "types": ["node", "jest"],
-    "module": "commonjs",
-    "outDir": "dist/cjs",
-    "target": "esnext"
-  },
-  "compileOnSave": true,
-  "exclude": ["node_modules", "dist"],
-  "include": ["src/**/*.*", "test/**/*.*", "eslint.config.cjs"]
+  "tabWidth": 2,
+  "singleQuote": true,
+  "trailingComma": "all"
 }
 
 ================
-File: tsconfig.linting.json
+File: jest.config.ts
+================
+/**
+ * For a detailed explanation regarding each configuration property, visit:
+ * https://jestjs.io/docs/configuration
+ */
+⋮----
+import type { Config } from 'jest';
+⋮----
+// All imported modules in your tests should be mocked automatically
+// automock: false,
+⋮----
+// Stop running tests after `n` failures
+// bail: 0,
+bail: false, // enable to stop test when an error occur,
+⋮----
+// The directory where Jest should store its cached dependency information
+// cacheDirectory: "/private/var/folders/kf/2k3sz4px6c9cbyzj1h_b192h0000gn/T/jest_dx",
+⋮----
+// Automatically clear mock calls, instances, contexts and results before every test
+⋮----
+// Indicates whether the coverage information should be collected while executing the test
+⋮----
+// An array of glob patterns indicating a set of files for which coverage information should be collected
+⋮----
+// The directory where Jest should output its coverage files
+⋮----
+// An array of regexp pattern strings used to skip coverage collection
+// coveragePathIgnorePatterns: [
+//   "/node_modules/"
+// ],
+⋮----
+// Indicates which provider should be used to instrument code for coverage
+⋮----
+// A list of reporter names that Jest uses when writing coverage reports
+// coverageReporters: [
+//   "json",
+//   "text",
+//   "lcov",
+//   "clover"
+// ],
+⋮----
+// An object that configures minimum threshold enforcement for coverage results
+// coverageThreshold: undefined,
+⋮----
+// A path to a custom dependency extractor
+// dependencyExtractor: undefined,
+⋮----
+// Make calling deprecated APIs throw helpful error messages
+// errorOnDeprecated: false,
+⋮----
+// The default configuration for fake timers
+// fakeTimers: {
+//   "enableGlobally": false
+// },
+⋮----
+// Force coverage collection from ignored files using an array of glob patterns
+// forceCoverageMatch: [],
+⋮----
+// A path to a module which exports an async function that is triggered once before all test suites
+// globalSetup: undefined,
+⋮----
+// A path to a module which exports an async function that is triggered once after all test suites
+// globalTeardown: undefined,
+⋮----
+// A set of global variables that need to be available in all test environments
+// globals: {},
+⋮----
+// The maximum amount of workers used to run your tests. Can be specified as % or a number. E.g. maxWorkers: 10% will use 10% of your CPU amount + 1 as the maximum worker number. maxWorkers: 2 will use a maximum of 2 workers.
+// maxWorkers: "50%",
+⋮----
+// An array of directory names to be searched recursively up from the requiring module's location
+// moduleDirectories: [
+//   "node_modules"
+// ],
+⋮----
+// An array of file extensions your modules use
+⋮----
+// modulePaths: ['src'],
+⋮----
+// A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
+// moduleNameMapper: {},
+⋮----
+// An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
+// modulePathIgnorePatterns: [],
+⋮----
+// Activates notifications for test results
+// notify: false,
+⋮----
+// An enum that specifies notification mode. Requires { notify: true }
+// notifyMode: "failure-change",
+⋮----
+// A preset that is used as a base for Jest's configuration
+// preset: undefined,
+⋮----
+// Run tests from one or more projects
+// projects: undefined,
+⋮----
+// Use this configuration option to add custom reporters to Jest
+// reporters: undefined,
+⋮----
+// Automatically reset mock state before every test
+// resetMocks: false,
+⋮----
+// Reset the module registry before running each individual test
+// resetModules: false,
+⋮----
+// A path to a custom resolver
+// resolver: undefined,
+⋮----
+// Automatically restore mock state and implementation before every test
+// restoreMocks: false,
+⋮----
+// The root directory that Jest should scan for tests and modules within
+// rootDir: undefined,
+⋮----
+// A list of paths to directories that Jest should use to search for files in
+// roots: [
+//   "<rootDir>"
+// ],
+⋮----
+// Allows you to use a custom runner instead of Jest's default test runner
+// runner: "jest-runner",
+⋮----
+// The paths to modules that run some code to configure or set up the testing environment before each test
+// setupFiles: [],
+⋮----
+// A list of paths to modules that run some code to configure or set up the testing framework before each test
+// setupFilesAfterEnv: [],
+⋮----
+// The number of seconds after which a test is considered as slow and reported as such in the results.
+// slowTestThreshold: 5,
+⋮----
+// A list of paths to snapshot serializer modules Jest should use for snapshot testing
+// snapshotSerializers: [],
+⋮----
+// The test environment that will be used for testing
+// testEnvironment: "jest-environment-node",
+⋮----
+// Options that will be passed to the testEnvironment
+// testEnvironmentOptions: {},
+⋮----
+// Adds a location field to test results
+// testLocationInResults: false,
+⋮----
+// The glob patterns Jest uses to detect test files
+⋮----
+// "**/__tests__/**/*.[jt]s?(x)",
+⋮----
+// An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
+// testPathIgnorePatterns: [
+//   "/node_modules/"
+// ],
+⋮----
+// The regexp pattern or array of patterns that Jest uses to detect test files
+// testRegex: [],
+⋮----
+// This option allows the use of a custom results processor
+// testResultsProcessor: undefined,
+⋮----
+// This option allows use of a custom test runner
+// testRunner: "jest-circus/runner",
+⋮----
+// A map from regular expressions to paths to transformers
+// transform: undefined,
+⋮----
+// An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
+// transformIgnorePatterns: [
+//   "/node_modules/",
+//   "\\.pnp\\.[^\\/]+$"
+// ],
+⋮----
+// Prevents import esm module error from v1 axios release, issue #5026
+⋮----
+// An array of regexp pattern strings that are matched against all modules before the module loader will automatically return a mock for them
+// unmockedModulePathPatterns: undefined,
+⋮----
+// Indicates whether each individual test should be reported during the run
+// verbose: undefined,
+verbose: true, // report individual test
+⋮----
+// An array of regexp patterns that are matched against all source file paths before re-running tests in watch mode
+// watchPathIgnorePatterns: [],
+⋮----
+// Whether to use watchman for file crawling
+// watchman: true,
+
+================
+File: postBuild.sh
+================
+#!/bin/bash
+#
+#   Add package.json files to cjs/mjs subtrees
+#
+
+cat >dist/cjs/package.json <<!EOF
+{
+    "type": "commonjs"
+}
+!EOF
+
+cat >dist/mjs/package.json <<!EOF
+{
+    "type": "module"
+}
+!EOF
+
+find src -name '*.d.ts' -exec cp {} dist/mjs \;
+find src -name '*.d.ts' -exec cp {} dist/cjs \;
+
+================
+File: tsconfig.cjs.json
 ================
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "module": "commonjs",
     "outDir": "dist/cjs",
-    "target": "esnext",
-    "rootDir": "../",
-    "allowJs": true
+    "target": "esnext"
   },
-  "include": [
-    "src/**/*.*",
-    "test/**/*.*",
-    "examples/**/*.*",
-    "eslint.config.cjs",
-    ".eslintrc.cjs",
-    "jest.config.ts"
-  ]
+  "include": ["src/**/*.*"]
 }
 
 ================
-File: examples/WebSockets/README.md
+File: tsconfig.esm.json
 ================
-# WebSocket Subscriptions
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "outDir": "dist/mjs",
+    "target": "esnext"
+  },
+  "include": ["src/**/*.*"]
+}
 
-The examples in this folder demonstrate how to connect to KuCoin WebSockets using Node.js, JavaScript & TypeScript, to receive realtime events from either account updates or market data.
+================
+File: examples/Rest/rest-futures-orders-guide.ts
+================
+import { FuturesClient } from '../../src/index.ts';
+// import { FuturesClient } from 'kucoin-api';
+// normally you should install this module via npm: `npm install kucoin-api`
+⋮----
+async function start()
+⋮----
+/**
+     * =======
+     * Credits for this guide go to user: @DKTradingClient / Code Nerd from the Kucoin API Telegram group!
+     * =======
 
-## Versions
+    /**
+     * Futures are contracts, not currencies. In the futures symbols list you will see a "multiplier" field for each of the symbols. 
+     * Each contract equals to  Multiplier x Size
+     * For example:  https://api-futures.kucoin.com/api/v1/contracts/XRPUSDTM  - see the "multiplier" value.
+     * */
+⋮----
+/**
+     * E.g. if multiplier is 10(what you can see from the endpoint), that means each SIZE is 10 XRP. So if XRP is currently at $0.5,
+     * then each 1 contract (size 10) is going to cost $5.00
+     * size = (Funds x leverage) / (price x multiplier)
+     */
+⋮----
+/**
+     * The trade amount indicates the amount of contract to buy or sell, and contract uses the base currency or lot as the trading unit.
+     * The trade amount must be no less than 1 lot for the contract and no larger than the maxOrderQty.
+     * It should be a multiple number of the lot, or the system will report an error when you place the order.
+     * E.g. 1 lot of XBTUSDTM is 0.001 Bitcoin, while 1 lot of XBTUSDM is 1 USD.
+     * or check the XRPUSDTM example above.
+     *
+     * Here are function examples using the Futures Create Order endpoint:
+     */
+⋮----
+// A MARKET SHORT of 2 contracts of XBT using leverage of 5:
+⋮----
+// A MARKET LONG of 2 contracts of XBT using leverage of 5:
+⋮----
+// A LIMIT SHORT of 2 contracts of XBT using leverage of 5:
+⋮----
+// A LIMIT LONG of 2 contracts of XBT using leverage of 5:
+⋮----
+// On any "close position" action, if you specify a SIZE=0 or leave off the SIZE parameter,
+// then it will close the whole position, regardless of the size.
+// If you specify a SIZE, it will close only the number of contracts you specify.
+⋮----
+// If closeOrder is set to TRUE,
+// the system will close the position and the position size will become 0.
+// Side, Size and Leverage fields can be left empty and the system will determine the side and size automatically.
+⋮----
+// A MARKET CLOSE POSITION example:
+⋮----
+// A LIMIT CLOSE of a LONG example:
+⋮----
+// A LIMIT CLOSE of a SHORT example:
+⋮----
+// A STOP LOSS example for a LONG position:
+⋮----
+// A STOP LOSS example for a SHORT position:
 
-### V1
+================
+File: examples/Rest/rest-futures-private-trade.ts
+================
+import { FuturesClient } from '../../src/index.ts';
+// import { FuturesClient } from 'kucoin-api';
+// normally you should install this module via npm: `npm install kucoin-api`
+⋮----
+async function start()
+⋮----
+/**
+     * The trade amount indicates the amount of contract to buy or sell, and contract uses the base currency or lot as the trading unit.
+     * The trade amount must be no less than 1 lot for the contract and no larger than the maxOrderQty.
+     * It should be a multiple number of the lot, or the system will report an error when you place the order.
+     * E.g. 1 lot of XBTUSDTM is 0.001 Bitcoin, while 1 lot of XBTUSDM is 1 USD.
+     */
+⋮----
+// Submit a futures entry order for 1 lot of XBTUSDTM (0.001 bitcoin)
 
-This is the current / end of life generation of KuCoin's APIs. The old API docs can be found here:
-https://www.kucoin.com/docs-new
+================
+File: examples/Rest/rest-futures-public.ts
+================
+import { FuturesClient } from '../../src/index.ts';
+// import { FuturesClient } from 'kucoin-api';
+// normally you should install this module via npm: `npm install kucoin-api`
+⋮----
+async function start()
+⋮----
+// Fetch all symbols
+⋮----
+// Fetch ticker for a specific symbol
+⋮----
+// Fetch klines for a specific symbol
 
-Examples for this version are labelled with "v1" and tend to use the "v1" WsKeys (meaning they use the endpoints and WebSocket domains for the V1 APIs)
+================
+File: examples/Rest/rest-spot-private-trade.ts
+================
+import { SpotClient } from '../../src/index.ts';
+// import { SpotClient } from 'kucoin-api';
+// normally you should install this module via npm: `npm install kucoin-api`
+⋮----
+async function start()
 
-### V2 / Pro / Unified / UTA
+================
+File: examples/Rest/rest-spot-public.ts
+================
+import { SpotClient } from '../../src/index.ts';
+// import { SpotClient } from 'kucoin-api';
+// normally you should install this module via npm: `npm install kucoin-api`
+⋮----
+async function start()
+⋮----
+// Fetch all symbols
+⋮----
+// Fetch ticker for a specific symbol
+⋮----
+// Fetch klines for a specific symbol
 
-The new generation of KuCoin's APIs. It was briefly named Unified Trading APIs (UTA), but has more recently been renamed to KuCoin Pro APIs.
+================
+File: examples/WebSockets/WS-API/ws-api-client.ts
+================
+/**
+ * KuCoin WebSocket API Client - Complete Example
+ *
+ * This example demonstrates all available WebSocket API operations:
+ * - Spot trading: submit, modify, cancel, sync operations
+ * - Margin trading: submit and cancel orders
+ * - Futures trading: submit, cancel, batch operations
+ *
+ * Usage:
+ * Make sure to set your API credentials in environment variables:
+ *    - API_KEY
+ *    - API_SECRET
+ *    - API_PASSPHRASE
+ *
+ *  or pass them as arguments to the constructor
+ */
+⋮----
+import { DefaultLogger, WebsocketAPIClient } from '../../../src/index.js';
+⋮----
+async function main()
+⋮----
+// For a more detailed view of the WebsocketClient, enable the `trace` level by uncommenting the below line:
+// trace: (...params) => console.log(new Date(), 'trace', ...params),
+⋮----
+passphrase: process.env.API_PASSPHRASE || 'apiPassPhraseHere', // This is NOT your account password
+⋮----
+// If you want your own event handlers instead of the default ones with logs, disable this setting and see the `attachEventHandlers` example below:
+// attachEventListeners: false
+⋮----
+// Example usage for each WebSocket API operation
+⋮----
+// 1. Submit Spot Order
+⋮----
+price: '20000', // Very low price to avoid accidental execution
+⋮----
+// 2. Submit Sync Spot Order
+⋮----
+price: '1000', // Very high price to avoid accidental execution
+⋮----
+// 3. Modify Spot Order (requires existing order ID)
+⋮----
+orderId: '68cc3476693c1c00072ef1d9', // Replace with actual order ID
+⋮----
+// 4. Cancel Spot Order
+⋮----
+orderId: '68cc34c6693c1c0007301929', // Replace with actual order ID
+⋮----
+// 5. Cancel Sync Spot Order
+⋮----
+orderId: '68cc3530b9870a0007670294', // Replace with actual client order ID
+⋮----
+// 6. Submit Margin Order
+⋮----
+price: '19000', // Very low price to avoid accidental execution
+⋮----
+isIsolated: false, // false for cross margin, true for isolated
+⋮----
+// 7. Cancel Margin Order
+⋮----
+orderId: 'your-margin-order-id-here', // Replace with actual order ID
+⋮----
+// 8. Submit Futures Order
+⋮----
+price: '1000', // Very low price to avoid accidental execution
+⋮----
+positionSide: 'LONG', // needed if trading two-way (hedge) position mode
+⋮----
+// 9. Cancel Futures Order
+⋮----
+orderId: '358196976308797441', // Replace with actual order ID
+⋮----
+// 10. Submit Multiple Futures Orders
+⋮----
+price: '1000', // Very low price to avoid accidental execution
+⋮----
+positionSide: 'LONG', // Needed if trading hedge/two-way mode. Optional in one-way mode.
+⋮----
+price: '1010', // Very low price to avoid accidental execution
+⋮----
+// 11. Cancel Multiple Futures Orders
+⋮----
+orderIdsList: ['order-id-1', 'order-id-2'], // Replace with actual order IDs
+⋮----
+// Start executing the example workflow
 
-All examples for this version are labelled with "v2" and tend to use the "v2" WsKeys. Private WebSocket topics in KuCoin's V2 Pro APIs also share 1 connection (via the "privateProV2" WsKey). Previously in v1 these were split across two different connections.
+================
+File: examples/WebSockets/WS-API/ws-api-raw-promises.ts
+================
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import {
+  DefaultLogger,
+  WebsocketClient,
+  WS_KEY_MAP,
+} from '../../../src/index.js';
+// import { DefaultLogger, WebsocketClient, WS_KEY_MAP } from 'kucoin-api';
+// normally you should install this module via npm: `npm install kucoin-api`
+⋮----
+async function start()
+⋮----
+// Optional: inject a custom logger to override internal logging behaviour
+⋮----
+// Uncomment the below callback to introduce filtered trace logging in the WebsocketClient.
+// trace: (...params) => {
+//   if (
+//     [
+//       'Sending ping',
+//       // 'Sending upstream ws message: ',
+//       'Received pong',
+//     ].includes(params[0])
+//   ) {
+//     return;
+//   }
+//   console.log('trace', JSON.stringify(params, null, 2));
+// },
+⋮----
+passphrase: process.env.API_PASSPHRASE || 'apiPassPhraseHere', // This is NOT your account password
+⋮----
+// console.log('connecting with ', account);
+⋮----
+// logger,
+⋮----
+// Data received
+⋮----
+// Something happened, attempting to reconenct
+⋮----
+// Reconnect successful
+⋮----
+// Connection closed. If unexpected, expect reconnect -> reconnected.
+⋮----
+// Reply to a request, e.g. "subscribe"/"unsubscribe"/"authenticate"
+⋮----
+// console.info('response: ', data);
+⋮----
+/**
+   *
+   * Raw events can be routed via the sendWSAPIRequest in the WebsocketClient, as shown below.
+   * However, for a simpler integration, it is recommended to use the WebsocketAPIClient. The
+   * WebsocketAPIClient class is a wrapper around sendWSAPIRequest, with clear functions, typed
+   * requests and typed responses. The simpler WSAPIClient interface behaves much like a REST API
+   * wrapper, but all calls are routed via the WebSocket API.
+   *
+   * For a clearer example, refer to the "ws-api-client.ts" example found in this folder.
+   */
+⋮----
+price: '20000', // Very low price to avoid accidental execution
+
+================
+File: examples/WebSockets/ws-private-futures-v1.ts
+================
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { DefaultLogger, WebsocketClient } from '../../src/index.js';
+// import { DefaultLogger, WebsocketClient } from 'kucoin-api';
+// normally you should install this module via npm: `npm install kucoin-api`
+⋮----
+async function start()
+⋮----
+// Optional: inject and customise a logger for more control over internal logging
+// const logger: typeof DefaultLogger = {
+//   ...DefaultLogger,
+//   trace: (...params) => {
+//     if (
+//       [
+//         'Sending ping',
+//         // 'Sending upstream ws message: ',
+//         'Received pong',
+//       ].includes(params[0])
+//     ) {
+//       return;
+//     }
+//     console.log('trace', JSON.stringify(params, null, 2));
+//   },
+// };
+⋮----
+passphrase: process.env.API_PASSPHRASE || 'apiPassPhraseHere', // This is NOT your account password
+⋮----
+// logger,
+⋮----
+// Data received
+⋮----
+// Something happened, attempting to reconenct
+⋮----
+// Reconnect successful
+⋮----
+// Connection closed. If unexpected, expect reconnect -> reconnected.
+⋮----
+// Reply to a request, e.g. "subscribe"/"unsubscribe"/"authenticate"
+⋮----
+// throw new Error('res?');
+⋮----
+// Optional: await a connection to be ready before subscribing (this is not necessary)
+// await client.connect('futuresPrivateV1');
+// console.log('connected');
+⋮----
+/**
+     * For more detailed usage info, refer to the ws-spot-public.ts example.
+     *
+     * Below are some examples for subscribing to private futures websockets.
+     * Note: all "private" websocket topics should use the "futuresPrivateV1" wsKey.
+     */
+
+================
+File: examples/WebSockets/ws-private-spot-v1.ts
+================
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { DefaultLogger, WebsocketClient } from '../../src/index.js';
+// import { DefaultLogger, WebsocketClient } from 'kucoin-api';
+// normally you should install this module via npm: `npm install kucoin-api`
+⋮----
+async function start()
+⋮----
+// Optional: inject a custom logger to override internal logging behaviour
+// const logger: typeof DefaultLogger = {
+//   ...DefaultLogger,
+//   trace: (...params) => {
+//     if (
+//       [
+//         'Sending ping',
+//         // 'Sending upstream ws message: ',
+//         'Received pong',
+//       ].includes(params[0])
+//     ) {
+//       return;
+//     }
+//     console.log('trace', JSON.stringify(params, null, 2));
+//   },
+// };
+⋮----
+passphrase: process.env.API_PASSPHRASE || 'apiPassPhraseHere', // This is NOT your account password
+⋮----
+// logger,
+⋮----
+// Data received
+⋮----
+// Something happened, attempting to reconenct
+⋮----
+// Reconnect successful
+⋮----
+// Connection closed. If unexpected, expect reconnect -> reconnected.
+⋮----
+// Reply to a request, e.g. "subscribe"/"unsubscribe"/"authenticate"
+⋮----
+// throw new Error('res?');
+⋮----
+// Optional: await a connection to be ready before subscribing (this is not necessary)
+// await client.connect('spotPrivateV1');
+// console.log('connected');
+⋮----
+/**
+     * For more detailed usage info, refer to the ws-spot-public.ts example.
+     *
+     * Below are some examples for subscribing to private spot & margin websockets.
+     * Note: all "private" websocket topics should use the "spotPrivateV1" wsKey.
+     */
+⋮----
+/**
+     * Other margin websocket topics, which also use the "spotPrivateV1" WsKey:
+     */
+
+================
+File: examples/WebSockets/ws-public-futures-v1.ts
+================
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { DefaultLogger, WebsocketClient } from '../../src/index.js';
+// import { DefaultLogger, WebsocketClient } from 'kucoin-api';
+// normally you should install this module via npm: `npm install kucoin-api`
+⋮----
+async function start()
+⋮----
+// Optional: fully customise the logging experience by injecting a custom logger
+// const logger: typeof DefaultLogger = {
+//   ...DefaultLogger,
+//   trace: (...params) => {
+//     if (
+//       [
+//         'Sending ping',
+//         'Sending upstream ws message: ',
+//         'Received pong',
+//       ].includes(params[0])
+//     ) {
+//       return;
+//     }
+//     console.log('trace', params);
+//   },
+// };
+⋮----
+// const client = new WebsocketClient({}, logger);
+⋮----
+// Data received
+⋮----
+// Something happened, attempting to reconenct
+⋮----
+// Reconnect successful
+⋮----
+// Connection closed. If unexpected, expect reconnect -> reconnected.
+⋮----
+// Reply to a request, e.g. "subscribe"/"unsubscribe"/"authenticate"
+⋮----
+// throw new Error('res?');
+⋮----
+// Optional: await a connection to be ready before subscribing (this is not necessary)
+// await client.connect('futuresPublicV1');
+⋮----
+/**
+     * Examples for public futures websocket topics (that don't require authentication).
+     *
+     * These should all subscribe via the "futuresPublicV1" wsKey. For detailed usage, refer to the ws-spot-public.ts example.
+     */
+
+================
+File: examples/WebSockets/ws-public-spot-v1.ts
+================
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import {
+  DefaultLogger,
+  WebsocketClient,
+  WsTopicRequest,
+} from '../../src/index.js';
+// import { DefaultLogger, WebsocketClient, WsTopicRequest } from 'kucoin-api';
+// normally you should install this module via npm: `npm install kucoin-api`
+⋮----
+async function start()
+⋮----
+// Optional: fully customise the logging experience by injecting a custom logger
+// const logger: typeof DefaultLogger = {
+//   ...DefaultLogger,
+//   trace: (...params) => {
+//     if (
+//       [
+//         'Sending ping',
+//         'Sending upstream ws message: ',
+//         'Received pong',
+//       ].includes(params[0])
+//     ) {
+//       return;
+//     }
+//     console.log('trace', params);
+//   },
+// };
+⋮----
+// const client = new WebsocketClient({}, logger);
+⋮----
+// Data received
+⋮----
+// Something happened, attempting to reconenct
+⋮----
+// Reconnect successful
+⋮----
+// Connection closed. If unexpected, expect reconnect -> reconnected.
+⋮----
+// Reply to a request, e.g. "subscribe"/"unsubscribe"/"authenticate"
+⋮----
+// throw new Error('res?');
+⋮----
+/**
+   * The following example demonstrates the ways to consume data from the V1 WebSockets. For the V2 (Pro) WebSockets, see ws-spot-v2-public.ts
+   */
+⋮----
+// Optional: await a connection to be ready before subscribing (this is not necessary)
+// await client.connect('spotPublicV1');
+⋮----
+/**
+     * Use the client subscribe(topic, market) pattern to subscribe to any websocket topic.
+     *
+     * You can subscribe to topics one at a time or many one one request. Topics can be sent as simple strings:
+     *
+     */
+⋮----
+/**
+     * Or, as an array of simple strings
+     *
+     */
+⋮----
+/**
+     * Or send a more structured object with parameters
+     *
+     */
+⋮----
+/** Anything in the payload will be merged into the subscribe "request", allowing you to send misc parameters supported by the exchange.
+       *    For more info on parameters, see: https://www.kucoin.com/docs/websocket/basic-info/subscribe/introduction
+       */
+⋮----
+/**
+     * Or, send an array of structured objects with parameters, if you wanted to send multiple in one request
+     *
+     */
+// client.subscribe([subRequest1, subRequest2, etc], 'spotPublicV1');
+⋮----
+/**
+     * Other spot websocket topics:
+     */
+⋮----
+/**
+     * Other margin websocket topics, which also use the "spotPublicV1" WsKey:
+     */
+
+================
+File: examples/kucoin-UNIFIED-examples-nodejs.md
+================
+# **KuCoin Unified Trading Account (PRO) API Examples** - Node.js, JavaScript & TypeScript SDK for KuCoin REST APIs & WebSockets
+
+<p align="center">
+  <a href="https://www.npmjs.com/package/kucoin-api">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://github.com/tiagosiebler/kucoin-api/blob/master/docs/images/logoDarkMode2.svg?raw=true#gh-dark-mode-only">
+      <img alt="SDK Logo" src="https://github.com/tiagosiebler/kucoin-api/blob/master/docs/images/logoBrightMode2.svg?raw=true#gh-light-mode-only">
+    </picture>
+  </a>
+</p>
+
+This document provides comprehensive examples for using the KuCoin **Unified Trading Account (UTA / PRO)** API with Node.js and JavaScript. The Unified API gives a single set of endpoints for market data and trading across Spot, Futures, and Margin. The examples are designed to help developers quickly integrate the KuCoin Unified (PRO) API into their Node.js, JavaScript and TypeScript applications.
+
+If you are here, it means you will be great addition to our [Node.js Traders](https://t.me/nodetraders) community on Telegram where we discuss trading ideas, provide support regarding SDKs and share valuable resources!
+
+- [KuCoin Documentation](https://www.kucoin.com/docs) - official KuCoin API docs (Unified Trading Account)
+
+- [Node.js & JavaScript SDK for KuCoin](https://github.com/tiagosiebler/kucoin-api) - Github repo of our SDK
+
+Current file contains only certain most used examples. If you can't find what you need, you can search through [UnifiedAPIClient.ts](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts) - all of the endpoints and functions will be there! Otherwise, just ask in [Node.js Traders](https://t.me/nodetraders) Telegram group.
+
+Do you need help with Spot or Futures only? Check out [Spot Quickstart guide](https://github.com/tiagosiebler/kucoin-api/blob/master/examples/kucoin-SPOT-examples-nodejs.md) and [Futures Quickstart guide](https://github.com/tiagosiebler/kucoin-api/blob/master/examples/kucoin-FUTURES-examples-nodejs.md).
+
+**Table of contents:**
+
+- [Installation](#installation)
+- [Usage](#usage)
+- [REST API](#rest-api)
+
+  - [Market Data](#market-data)
+    - [Announcements and service status](#announcements-and-service-status)
+    - [Symbol and exchange info](#symbol-and-exchange-info)
+    - [Order Book, Trades, Klines](#order-book-trades-klines)
+    - [Funding rate and cross margin config](#funding-rate-and-cross-margin-config)
+  - [Account](#account)
+    - [Unified and Classic account balance](#unified-and-classic-account-balance)
+    - [Sub-account and transfers](#sub-account-and-transfers)
+    - [Account mode, fee rate, ledger, deposit](#account-mode-fee-rate-ledger-deposit)
+  - [Orders](#orders)
+    - [Place order (Unified vs Classic)](#place-order-unified-vs-classic)
+    - [Batch place, order details, open list, history](#batch-place-order-details-open-list-history)
+    - [Cancel order, batch cancel, DCP](#cancel-order-batch-cancel-dcp)
+  - [Positions](#positions)
+
+- [WebSocket](#websocket)
+- [Community group](#community-group)
+
+## Installation:
+
+```js
+// Install by npm
+npm install kucoin-api
+
+
+// Install by yarn
+yarn add kucoin-api
+```
+
+## Usage
+
+#### Create API credentials
+
+- [KuCoin API Key Management](https://www.kucoin.com/account/api)
+
+#### Import SDK to your project
+
+```js
+// require
+const { UnifiedAPIClient } = require('kucoin-api');
+
+// import
+import { UnifiedAPIClient } from 'kucoin-api';
+
+// initialise Unified (PRO) Client
+const unifiedClient = new UnifiedAPIClient({
+  // insert your api key, secret and passphrase - use env vars, if not just fill the string values
+  apiKey: process.env.KUCOIN_API_KEY || 'insert-your-api-key',
+  apiSecret: process.env.KUCOIN_API_SECRET || 'insert-your-api-secret',
+  apiPassphrase:
+    process.env.KUCOIN_API_PASSPHRASE || 'insert-your-api-passphrase',
+});
+```
+
+## REST API
+
+### Market Data
+
+All market data endpoints are **public** (no auth required for the client, but the client is typically created with credentials for private calls in the same app).
+
+#### Announcements and service status
+
+```js
+// Get Announcements (optional filters)
+unifiedClient.getAnnouncements({
+  language: 'en_US',
+  type: 'latest-announcements',
+  pageNumber: 1,
+  pageSize: 10,
+});
+
+// Get Service Status
+unifiedClient.getServiceStatus({ tradeType: 'SPOT' });
+unifiedClient.getServiceStatus({ tradeType: 'FUTURES' });
+```
+
+#### Symbol and exchange info
+
+```js
+// Get Currency (single or all)
+unifiedClient.getCurrency({ currency: 'BTC' });
+unifiedClient.getCurrency();
+
+// Get Symbol list - tradeType is required
+unifiedClient.getSymbols({ tradeType: 'SPOT' });
+unifiedClient.getSymbols({ tradeType: 'FUTURES' });
+unifiedClient.getSymbols({ tradeType: 'SPOT', symbol: 'BTC-USDT' });
+unifiedClient.getSymbols({ tradeType: 'FUTURES', symbol: 'XBTUSDTM' });
+
+// Get Tickers
+unifiedClient.getTickers({ tradeType: 'SPOT' });
+unifiedClient.getTickers({ tradeType: 'FUTURES', symbol: 'XBTUSDTM' });
+```
+
+#### Order Book, Trades, Klines
+
+```js
+// Get Trades (latest 100 public trades)
+unifiedClient.getTrades({ tradeType: 'SPOT', symbol: 'BTC-USDT' });
+unifiedClient.getTrades({ tradeType: 'FUTURES', symbol: 'XBTUSDTM' });
+
+// Get Order Book
+unifiedClient.getOrderBook({
+  tradeType: 'SPOT',
+  symbol: 'BTC-USDT',
+  limit: '20', // '20' | '50' | '100' | 'FULL'
+});
+unifiedClient.getOrderBook({
+  tradeType: 'FUTURES',
+  symbol: 'XBTUSDTM',
+  limit: '100',
+  rpiFilter: 0, // 0: noneRPI, 1: noneRPI + RPI (Futures only)
+});
+
+// Get Klines
+unifiedClient.getKlines({
+  tradeType: 'SPOT',
+  symbol: 'BTC-USDT',
+  interval: '1hour',
+  startAt: Date.now() - 24 * 60 * 60 * 1000,
+  endAt: Date.now(),
+});
+unifiedClient.getKlines({
+  tradeType: 'FUTURES',
+  symbol: 'XBTUSDTM',
+  interval: '15min',
+  startAt: Date.now() - 7 * 24 * 60 * 60 * 1000,
+  endAt: Date.now(),
+});
+```
+
+#### Funding rate and cross margin config
+
+```js
+// Get Current Funding Rate (Futures)
+unifiedClient.getCurrentFundingRate({ symbol: 'XBTUSDTM' });
+
+// Get History Funding Rate
+unifiedClient.getHistoryFundingRate({
+  symbol: 'XBTUSDTM',
+  startAt: Date.now() - 7 * 24 * 60 * 60 * 1000,
+  endAt: Date.now(),
+});
+
+// Get Cross Margin Config (Spot cross margin)
+unifiedClient.getCrossMarginConfig();
+```
+
+### Account
+
+#### Unified and Classic account balance
+
+```js
+// Get Unified Account (UTA) balance
+unifiedClient.getAccount();
+
+// Get Unified Account overview
+unifiedClient.getAccountOverview();
+
+// Get Classic Account balance (FUNDING, SPOT, FUTURES, CROSS, ISOLATED)
+unifiedClient.getClassicAccount({ accountType: 'SPOT' });
+unifiedClient.getClassicAccount({ accountType: 'FUTURES', currency: 'USDT,XBT' });
+unifiedClient.getClassicAccount({
+  accountType: 'ISOLATED',
+  accountSubtype: 'BTC-USDT',
+});
+```
+
+#### Sub-account and transfers
+
+```js
+// Get Sub Account
+unifiedClient.getSubAccount({ pageSize: 20 });
+unifiedClient.getSubAccount({ UID: '123,456' });
+
+// Get Transfer Quotas (transferable balance)
+unifiedClient.getTransferQuotas({
+  currency: 'USDT',
+  accountType: 'UNIFIED',
+});
+unifiedClient.getTransferQuotas({
+  currency: 'USDT',
+  accountType: 'SPOT',
+});
+unifiedClient.getTransferQuotas({
+  currency: 'USDT',
+  accountType: 'ISOLATED',
+  symbol: 'BTC-USDT',
+});
+
+// Flex Transfer (internal, parent-sub, sub-parent, sub-sub)
+unifiedClient.flexTransfer({
+  clientOid: 'your-unique-client-order-id',
+  currency: 'USDT',
+  amount: '100',
+  type: '0', // 0=INTERNAL, 1=PARENT_TO_SUB, 2=SUB_TO_PARENT, 3=SUB_TO_SUB
+  fromAccountType: 'SPOT',
+  toAccountType: 'FUTURES',
+});
+// For SUB transfers include fromUid / toUid
+unifiedClient.flexTransfer({
+  clientOid: 'unique-oid',
+  currency: 'USDT',
+  amount: '50',
+  type: '1',
+  fromAccountType: 'UNIFIED',
+  toAccountType: 'UNIFIED',
+  toUid: 'sub_account_uid',
+});
+
+// Set Sub Account Transfer Permission (sub-to-sub)
+unifiedClient.setSubAccountTransferPermission({
+  subUids: '123,456',
+  subToSub: true,
+});
+```
+
+#### Account mode, fee rate, ledger, deposit
+
+```js
+// Get / Set Account Mode (CLASSIC vs UNIFIED)
+unifiedClient.getAccountMode();
+unifiedClient.setAccountMode({ accountType: 'UNIFIED' });
+
+// Get Fee Rate (Spot: up to 10 symbols; Futures: 1 symbol)
+unifiedClient.getFeeRate({ tradeType: 'SPOT', symbol: 'BTC-USDT,ETH-USDT' });
+unifiedClient.getFeeRate({ tradeType: 'FUTURES', symbol: 'XBTUSDTM' });
+
+// Get Account Ledger (transfers, trades, etc.)
+unifiedClient.getAccountLedger({
+  accountType: 'UNIFIED',
+  currency: 'USDT',
+  direction: 'IN',
+  pageSize: 100,
+  startAt: Date.now() - 24 * 60 * 60 * 1000,
+  endAt: Date.now(),
+});
+
+// Get Interest History (UTA only)
+unifiedClient.getInterestHistory({
+  accountType: 'UNIFIED',
+  currency: 'USDT',
+  startTime: Date.now() - 7 * 24 * 60 * 60 * 1000,
+  endTime: Date.now(),
+  size: 50,
+});
+
+// Modify Leverage (Unified Futures)
+unifiedClient.modifyLeverage({ symbol: 'XBTUSDTM', leverage: '5' });
+
+// Get Deposit Address
+unifiedClient.getDepositAddress({ currency: 'BTC' });
+unifiedClient.getDepositAddress({ currency: 'BTC', chain: 'BTC' });
+```
+
+### Orders
+
+#### Place order (Unified vs Classic)
+
+Unified mode: use `accountMode: 'unified'` (default). For unified, `tradeType` is not sent in the request (the client omits it).  
+Classic mode: use `accountMode: 'classic'` and pass `tradeType` in the request (Spot/Futures/Isolated/Cross).
+
+```js
+// Unified mode - Spot limit order (default accountMode is 'unified')
+// tradeType can be omitted in request for unified; if provided it is not sent
+unifiedClient.placeOrder(
+  {
+    tradeType: 'SPOT',
+    clientOid: 'my-client-oid-' + Date.now(),
+    symbol: 'BTC-USDT',
+    side: 'BUY',
+    orderType: 'LIMIT',
+    size: '0.001',
+    sizeUnit: 'BASECCY',
+    price: '40000',
+    timeInForce: 'GTC',
+  },
+  'unified',
+);
+
+// Unified mode - Spot market order
+unifiedClient.placeOrder(
+  {
+    tradeType: 'SPOT',
+    clientOid: 'my-market-' + Date.now(),
+    symbol: 'BTC-USDT',
+    side: 'BUY',
+    orderType: 'MARKET',
+    size: '50',
+    sizeUnit: 'QUOTECCY',
+    timeInForce: 'GTC',
+  },
+  'unified',
+);
+
+// Unified mode - Futures limit order
+unifiedClient.placeOrder(
+  {
+    tradeType: 'FUTURES',
+    clientOid: 'futures-' + Date.now(),
+    symbol: 'XBTUSDTM',
+    side: 'BUY',
+    orderType: 'LIMIT',
+    size: '1',
+    sizeUnit: 'UNIT',
+    price: '95000',
+    timeInForce: 'GTC',
+    reduceOnly: false,
+  },
+  'unified',
+);
+
+// Classic mode - Spot (tradeType in request, sent as query by client)
+unifiedClient.placeOrder(
+  {
+    tradeType: 'SPOT',
+    clientOid: 'classic-spot-' + Date.now(),
+    symbol: 'BTC-USDT',
+    side: 'BUY',
+    orderType: 'LIMIT',
+    size: '0.001',
+    sizeUnit: 'BASECCY',
+    price: '40000',
+    timeInForce: 'GTC',
+  },
+  'classic',
+);
+
+// Classic mode - Futures
+unifiedClient.placeOrder(
+  {
+    tradeType: 'FUTURES',
+    clientOid: 'classic-futures-' + Date.now(),
+    symbol: 'XBTUSDTM',
+    side: 'SELL',
+    orderType: 'MARKET',
+    size: '1',
+    sizeUnit: 'UNIT',
+    timeInForce: 'GTC',
+    reduceOnly: true,
+  },
+  'classic',
+);
+```
+
+#### Batch place, order details, open list, history
+
+```js
+// Batch Place Order (Classic only by default; orderList per type)
+unifiedClient.batchPlaceOrder(
+  {
+    tradeType: 'SPOT',
+    orderList: [
+      {
+        clientOid: 'batch-1',
+        symbol: 'BTC-USDT',
+        side: 'BUY',
+        orderType: 'LIMIT',
+        size: '0.001',
+        sizeUnit: 'BASECCY',
+        price: '39000',
+        timeInForce: 'GTC',
+      },
+      {
+        clientOid: 'batch-2',
+        symbol: 'BTC-USDT',
+        side: 'BUY',
+        orderType: 'LIMIT',
+        size: '0.001',
+        sizeUnit: 'BASECCY',
+        price: '38500',
+        timeInForce: 'GTC',
+      },
+    ],
+  },
+  'classic',
+);
+
+// Get Order Details (unified or classic)
+unifiedClient.getOrderDetails(
+  { tradeType: 'SPOT', symbol: 'BTC-USDT', orderId: 'order-id-here' },
+  'classic',
+);
+unifiedClient.getOrderDetails(
+  { tradeType: 'FUTURES', symbol: 'XBTUSDTM', clientOid: 'my-client-oid' },
+  'unified',
+);
+
+// Get Open Order List
+unifiedClient.getOpenOrderList(
+  { tradeType: 'SPOT', symbol: 'BTC-USDT', pageSize: 50 },
+  'unified',
+);
+unifiedClient.getOpenOrderList(
+  { tradeType: 'FUTURES', symbol: 'XBTUSDTM', orderFilter: 'NORMAL' },
+  'unified',
+);
+
+// Get Order History
+unifiedClient.getOrderHistory(
+  {
+    tradeType: 'FUTURES',
+    symbol: 'XBTUSDTM',
+    startAt: Date.now() - 24 * 60 * 60 * 1000,
+    endAt: Date.now(),
+    pageSize: 100,
+  },
+  'unified',
+);
+
+// Get Trade History (executions)
+unifiedClient.getTradeHistory(
+  {
+    tradeType: 'SPOT',
+    symbol: 'BTC-USDT',
+    startAt: Date.now() - 24 * 60 * 60 * 1000,
+    endAt: Date.now(),
+    pageSize: 50,
+  },
+  'unified',
+);
+```
+
+#### Cancel order, batch cancel, DCP
+
+```js
+// Cancel Order
+unifiedClient.cancelOrder(
+  { tradeType: 'FUTURES', symbol: 'XBTUSDTM', orderId: 'order-id' },
+  'unified',
+);
+unifiedClient.cancelOrder(
+  { tradeType: 'SPOT', symbol: 'BTC-USDT', clientOid: 'client-oid' },
+  'unified',
+);
+
+// Batch Cancel Orders (max 20)
+unifiedClient.batchCancelOrders(
+  {
+    tradeType: 'FUTURES',
+    cancelOrderList: [
+      { symbol: 'XBTUSDTM', orderId: 'id1' },
+      { symbol: 'XBTUSDTM', clientOid: 'oid2' },
+    ],
+  },
+  'unified',
+);
+
+// DCP (Disconnection Protect / Deadman Switch) - Classic only
+unifiedClient.setDCP({
+  tradeType: 'FUTURES',
+  timeout: 300, // 5–86400 seconds, or -1 to unset
+  symbols: ['XBTUSDTM'],
+});
+unifiedClient.getDCP({ tradeType: 'FUTURES' });
+```
+
+### Positions
+
+Unified position endpoints apply to the Unified account (Futures positions).
+
+```js
+// Get Position List (all open positions or filter by symbol)
+unifiedClient.getPositionList();
+unifiedClient.getPositionList({ symbol: 'XBTUSDTM' });
+
+// Get Positions History (up to 3 months, max 7 days per query)
+unifiedClient.getPositionsHistory({
+  symbol: 'XBTUSDTM',
+  startAt: Date.now() - 7 * 24 * 60 * 60 * 1000,
+  endAt: Date.now(),
+  pageSize: 50,
+});
+
+// Get Account Position Tiers (risk limit) - Classic Futures isolated
+unifiedClient.getAccountPositionTiers(
+  { symbol: 'XBTUSDTM', tradeType: 'FUTURES', marginMode: 'ISOLATED' },
+  'classic',
+);
+```
+
+## Websocket
+
+For WebSocket examples that work with the unified (PRO) API, please refer to:
+
+- [Spot Public Websocket](https://github.com/tiagosiebler/kucoin-api/blob/master/examples/WebSockets/ws-public-spot-pro-v2.ts) (PRO v2)
+- [Futures Public Websocket](https://github.com/tiagosiebler/kucoin-api/blob/master/examples/WebSockets/ws-public-futures-pro-v2.ts) (PRO v2)
+- [Private WebSocket (PRO v2)](https://github.com/tiagosiebler/kucoin-api/blob/master/examples/WebSockets/ws-private-pro-v2.ts)
+
+## Community group
+
+If you need help, something is wrong/missing or you have suggestions, please join our [Node.js Traders](https://t.me/nodetraders) community group on Telegram and let us know!
 
 ================
 File: src/lib/websocket/logger.ts
@@ -5008,311 +4024,6 @@ export type LogParams = null | any;
 // console.log(_params);
 ⋮----
 export type DefaultLogger = typeof DefaultLogger;
-
-================
-File: src/lib/websocket/WsStore.ts
-================
-import WebSocket from 'isomorphic-ws';
-⋮----
-import { DefaultLogger } from './logger.js';
-import {
-  DeferredPromise,
-  WSConnectedResult,
-  WsConnectionStateEnum,
-  WsStoredState,
-} from './WsStore.types.js';
-⋮----
-/**
- * Simple comparison of two objects, recursive for nested objects. Adoped from OKX SDK.
- */
-export function isDeepObjectMatch(object1: any, object2: any): boolean
-⋮----
-// console.log('not same key count', { keys1, keys2 });
-// not the same amount of keys or keys don't match
-⋮----
-// console.log('not same key names: ', { keys1, keys2 });
-⋮----
-type DeferredPromiseRef =
-  (typeof DEFERRED_PROMISE_REF)[keyof typeof DEFERRED_PROMISE_REF];
-⋮----
-export class WsStore<
-WsKey extends string,
-⋮----
-constructor(logger: DefaultLogger)
-⋮----
-/** Get WS stored state for key, optionally create if missing */
-get(
-    key: WsKey,
-    createIfMissing?: true,
-  ): WsStoredState<TWSTopicSubscribeEventArgs>;
-⋮----
-get(
-    key: WsKey,
-    createIfMissing?: false,
-  ): WsStoredState<TWSTopicSubscribeEventArgs> | undefined;
-⋮----
-get(
-    key: WsKey,
-    createIfMissing?: boolean,
-): WsStoredState<TWSTopicSubscribeEventArgs> | undefined
-⋮----
-getKeys(): WsKey[]
-⋮----
-create(key: WsKey): WsStoredState<TWSTopicSubscribeEventArgs> | undefined
-⋮----
-delete(key: WsKey): void
-⋮----
-// TODO: should we allow this at all? Perhaps block this from happening...
-⋮----
-/* connection websocket */
-⋮----
-hasExistingActiveConnection(key: WsKey): boolean
-⋮----
-getWs(key: WsKey): WebSocket | undefined
-⋮----
-setWs(key: WsKey, wsConnection: WebSocket): WebSocket
-⋮----
-/**
-   * deferred promises
-   */
-⋮----
-getDeferredPromise<TSuccessResult = any>(
-    wsKey: WsKey,
-    promiseRef: string | DeferredPromiseRef,
-): DeferredPromise<TSuccessResult> | undefined
-⋮----
-createDeferredPromise<TSuccessResult = any>(
-    wsKey: WsKey,
-    promiseRef: string | DeferredPromiseRef,
-    throwIfExists: boolean,
-): DeferredPromise<TSuccessResult>
-⋮----
-// console.log('existing promise');
-⋮----
-// console.log('create promise');
-⋮----
-// TODO: Once stable, use Promise.withResolvers in future
-⋮----
-resolveDeferredPromise(
-    wsKey: WsKey,
-    promiseRef: string | DeferredPromiseRef,
-    value: unknown,
-    removeAfter: boolean,
-): void
-⋮----
-rejectDeferredPromise(
-    wsKey: WsKey,
-    promiseRef: string | DeferredPromiseRef,
-    value: unknown,
-    removeAfter: boolean,
-): void
-⋮----
-removeDeferredPromise(
-    wsKey: WsKey,
-    promiseRef: string | DeferredPromiseRef,
-): void
-⋮----
-// Just in case it's pending
-⋮----
-rejectAllDeferredPromises(wsKey: WsKey, reason: string): void
-⋮----
-// Skip reserved keys, such as the connection promise
-⋮----
-/** Get promise designed to track a connection attempt in progress. Resolves once connected. */
-getConnectionInProgressPromise(
-    wsKey: WsKey,
-): DeferredPromise<WSConnectedResult> | undefined
-⋮----
-getAuthenticationInProgressPromise(
-    wsKey: WsKey,
-): DeferredPromise<WSConnectedResult &
-⋮----
-/**
-   * Create a deferred promise designed to track a connection attempt in progress.
-   *
-   * Will throw if existing promise is found.
-   */
-createConnectionInProgressPromise(
-    wsKey: WsKey,
-    throwIfExists: boolean,
-): DeferredPromise<WSConnectedResult>
-⋮----
-createAuthenticationInProgressPromise(
-    wsKey: WsKey,
-    throwIfExists: boolean,
-): DeferredPromise<WSConnectedResult &
-⋮----
-/** Remove promise designed to track a connection attempt in progress */
-removeConnectingInProgressPromise(wsKey: WsKey): void
-⋮----
-removeAuthenticationInProgressPromise(wsKey: WsKey): void
-⋮----
-/* connection state */
-⋮----
-isWsOpen(key: WsKey): boolean
-⋮----
-getConnectionState(key: WsKey): WsConnectionStateEnum
-⋮----
-setConnectionState(key: WsKey, state: WsConnectionStateEnum)
-⋮----
-isConnectionState(key: WsKey, state: WsConnectionStateEnum): boolean
-⋮----
-/**
-   * Check if we're currently in the process of opening a connection for any reason. Safer than only checking "CONNECTING" as the state
-   * @param key
-   * @returns
-   */
-isConnectionAttemptInProgress(key: WsKey): boolean
-⋮----
-const stateChangeTimeout = 15000; // allow a max 15 second timeout since the last state change before assuming stuck;
-⋮----
-/* subscribed topics */
-⋮----
-getTopics(key: WsKey): Set<TWSTopicSubscribeEventArgs>
-⋮----
-getTopicsAsArray(key: WsKey): TWSTopicSubscribeEventArgs[]
-⋮----
-getTopicsByKey(): Record<string, Set<TWSTopicSubscribeEventArgs>>
-⋮----
-/**
-   * Find matching "topic" request from the store
-   * @param key
-   * @param topic
-   * @returns
-   */
-getMatchingTopic(key: WsKey, topic: TWSTopicSubscribeEventArgs)
-⋮----
-addTopic(key: WsKey, topic: TWSTopicSubscribeEventArgs)
-⋮----
-// Check for duplicate topic. If already tracked, don't store this one
-⋮----
-deleteTopic(key: WsKey, topic: TWSTopicSubscribeEventArgs)
-⋮----
-// Check if we're subscribed to a topic like this
-
-================
-File: src/lib/requestUtils.ts
-================
-/**
- * Used to switch how authentication/requests work under the hood
- */
-⋮----
-/** Spot & Margin */
-⋮----
-/** Futures */
-⋮----
-/** Broker */
-⋮----
-/** Unified Trading Account */
-⋮----
-export type RestClientType =
-  (typeof REST_CLIENT_TYPE_ENUM)[keyof typeof REST_CLIENT_TYPE_ENUM];
-⋮----
-export interface RestClientOptions {
-  /** Your API key */
-  apiKey?: string;
-
-  /** Your API secret */
-  apiSecret?: string;
-
-  /** Your API passphrase (can be anything) that you set when creating this API key (NOT your account password) */
-  apiPassphrase?: string;
-
-  /**
-   * Use access token instead of sign, if this is provided.
-   * For guidance refer to: https://github.com/tiagosiebler/kucoin-api/issues/2
-   */
-  apiAccessToken?: string;
-
-  /** The API key version. Defaults to "2" right now. You can see this in your API management page */
-  apiKeyVersion?: number | string;
-
-  /** Default: false. If true, we'll throw errors if any params are undefined */
-  strictParamValidation?: boolean;
-
-  /**
-   * Optionally override API protocol + domain
-   * e.g baseUrl: 'https://api.kucoin.com'
-   **/
-  baseUrl?: string;
-
-  /** Default: true. whether to try and post-process request exceptions (and throw them). */
-  parseExceptions?: boolean;
-
-  customTimestampFn?: () => number;
-
-  /**
-   * Enable keep alive for REST API requests (via axios).
-   */
-  keepAlive?: boolean;
-
-  /**
-   * When using HTTP KeepAlive, how often to send TCP KeepAlive packets over sockets being kept alive. Default = 1000.
-   * Only relevant if keepAlive is set to true.
-   * Default: 1000 (defaults comes from https agent)
-   */
-  keepAliveMsecs?: number;
-
-  /**
-   * Allows you to provide a custom "signMessage" function, e.g. to use node's much faster createHmac method
-   *
-   * Look in the examples folder for a demonstration on using node's createHmac instead.
-   */
-  customSignMessageFn?: (message: string, secret: string) => Promise<string>;
-}
-⋮----
-/** Your API key */
-⋮----
-/** Your API secret */
-⋮----
-/** Your API passphrase (can be anything) that you set when creating this API key (NOT your account password) */
-⋮----
-/**
-   * Use access token instead of sign, if this is provided.
-   * For guidance refer to: https://github.com/tiagosiebler/kucoin-api/issues/2
-   */
-⋮----
-/** The API key version. Defaults to "2" right now. You can see this in your API management page */
-⋮----
-/** Default: false. If true, we'll throw errors if any params are undefined */
-⋮----
-/**
-   * Optionally override API protocol + domain
-   * e.g baseUrl: 'https://api.kucoin.com'
-   **/
-⋮----
-/** Default: true. whether to try and post-process request exceptions (and throw them). */
-⋮----
-/**
-   * Enable keep alive for REST API requests (via axios).
-   */
-⋮----
-/**
-   * When using HTTP KeepAlive, how often to send TCP KeepAlive packets over sockets being kept alive. Default = 1000.
-   * Only relevant if keepAlive is set to true.
-   * Default: 1000 (defaults comes from https agent)
-   */
-⋮----
-/**
-   * Allows you to provide a custom "signMessage" function, e.g. to use node's much faster createHmac method
-   *
-   * Look in the examples folder for a demonstration on using node's createHmac instead.
-   */
-⋮----
-export function serializeParams<T extends Record<string, any> | undefined = {}>(
-  params: T,
-  strict_validation: boolean | undefined,
-  encodeValues: boolean,
-  prefixWith: string,
-): string
-⋮----
-// Only prefix if there's a value
-⋮----
-export function getRestBaseUrl(
-  useTestnet: boolean,
-  restInverseOptions: RestClientOptions,
-  restClientType: RestClientType,
-): string
 
 ================
 File: src/types/request/spot-affiliate.ts
@@ -5773,6 +4484,1888 @@ export interface GetMarginCollateralRatioRequest {
 currencyList?: string; // If not specified, all currencies will be returned. Supports multiple currencies, separated by commas.
 
 ================
+File: src/types/response/spot-account.ts
+================
+export interface SpotAccountSummary {
+  level: number;
+  subQuantity: number;
+  spotSubQuantity: number;
+  marginSubQuantity: number;
+  futuresSubQuantity: number;
+  optionSubQuantity: number;
+  maxSubQuantity: number;
+  maxDefaultSubQuantity: number;
+  maxSpotSubQuantity: number;
+  maxMarginSubQuantity: number;
+  maxFuturesSubQuantity: number;
+  maxOptionSubQuantity: number;
+}
+⋮----
+export interface Balances {
+  id: string;
+  currency: string;
+  type: 'main' | 'trade';
+  balance: string;
+  available: string;
+  holds: string;
+}
+⋮----
+export interface Account {
+  currency: string;
+  balance: string;
+  available: string;
+  holds: string;
+}
+⋮----
+export interface SpotAccountTransaction {
+  id: string;
+  currency: string;
+  amount: string;
+  fee: string;
+  tax: string;
+  balance: string;
+  accountType: string; // 'TRADE_HF'
+  bizType: string;
+  direction: 'out' | 'in';
+  createdAt: string;
+  context: string;
+}
+⋮----
+accountType: string; // 'TRADE_HF'
+⋮----
+export interface SpotAccountTransactions {
+  currentPage: number;
+  pageSize: number;
+  totalNum: number;
+  totalPage: number;
+  items: SpotAccountTransaction[];
+}
+⋮----
+export interface AccountHFMarginTransactions {
+  id: string;
+  currency: string;
+  amount: string;
+  fee: string;
+  balance: string;
+  /** Migrating from MARGIN_V2/ISOLATED_V2 to MARGIN/ISOLATED per SPOT Margin HF migration */
+  accountType: 'MARGIN' | 'ISOLATED' | 'MARGIN_V2' | 'ISOLATED_V2';
+  bizType:
+    | 'TRANSFER'
+    | 'MARGIN_EXCHANGE'
+    | 'ISOLATED_EXCHANGE'
+    | 'LIQUIDATION'
+    | 'ASSERT_RETURN';
+  direction: 'out' | 'in';
+  createdAt: string;
+  tax: string;
+  context: string;
+}
+⋮----
+/** Migrating from MARGIN_V2/ISOLATED_V2 to MARGIN/ISOLATED per SPOT Margin HF migration */
+⋮----
+/**
+ *
+ * Sub-Account
+ *
+ */
+⋮----
+export interface SubAccountInfo {
+  userId: string;
+  uid: number;
+  subName: string;
+  status: number;
+  type: number;
+  access: string;
+  createdAt: number;
+  remarks: string;
+  tradeTypes: string[];
+  openedTradeTypes: string[];
+  hostedStatus: null | string;
+}
+⋮----
+export interface SubAccountsV2 {
+  currentPage: number;
+  pageSize: number;
+  totalNum: number;
+  totalPage: number;
+  items: SubAccountInfo[];
+}
+⋮----
+export interface SubAccountItem {
+  userId: string;
+  uid: number;
+  subName: string;
+  status: number;
+  type: number;
+  access: string;
+  createdAt: number;
+  remarks: string;
+  tradeTypes: string[];
+  openedTradeTypes: string[];
+  hostedStatus: null | string;
+}
+⋮----
+export interface CreateSubAccount {
+  currentPage: number;
+  pageSize: number;
+  totalNum: number;
+  totalPage: number;
+  items: SubAccountItem[];
+}
+⋮----
+export interface SubAccountBalance {
+  currency: string;
+  balance: string;
+  available: string;
+  holds: string;
+  baseCurrency: string;
+  baseCurrencyPrice: string;
+  baseAmount: string;
+}
+⋮----
+// deprecated
+export interface SubAccountBalances {
+  subUserId: string;
+  subName: string;
+  mainAccounts: SubAccountBalance[];
+  tradeAccounts: SubAccountBalance[];
+  marginAccounts: SubAccountBalance[];
+}
+⋮----
+export interface SubAccountBalancesV2 {
+  currentPage: number;
+  pageSize: number;
+  totalNum: number;
+  totalPage: number;
+  items: {
+    subUserId: string;
+    subName: string;
+    mainAccounts: SubAccountBalance[];
+  }[];
+}
+export interface SubAccountV2Details {
+  currency?: string;
+  balance?: string;
+  available?: string;
+  holds?: string;
+  baseCurrency?: string;
+  baseCurrencyPrice?: string;
+  baseAmount?: string;
+  tag?: string;
+}
+⋮----
+export interface SubAccountBalanceItemV2 {
+  subUserId: string;
+  subName: string;
+  mainAccounts: SubAccountV2Details[]; // Funding Account
+  tradeAccounts: SubAccountV2Details[]; // Spot Account
+  marginAccounts: SubAccountV2Details[]; // Margin Account
+  tradeHFAccounts: string[]; // Deprecated, only for old users
+}
+⋮----
+mainAccounts: SubAccountV2Details[]; // Funding Account
+tradeAccounts: SubAccountV2Details[]; // Spot Account
+marginAccounts: SubAccountV2Details[]; // Margin Account
+tradeHFAccounts: string[]; // Deprecated, only for old users
+⋮----
+/**
+ *
+ * Sub-Account API
+ *
+ *
+ */
+⋮----
+export interface SubAccountAPIInfo {
+  subName: string;
+  remark: string;
+  apiKey: string;
+  apiVersion: number;
+  permission: string;
+  ipWhitelist: string;
+  createdAt: number;
+  uid: number;
+  isMaster: boolean;
+}
+⋮----
+export interface CreateSubAPI {
+  subName: string;
+  remark: string;
+  apiKey: string;
+  apiSecret: string;
+  apiVersion: number;
+  passphrase: string;
+  permission: string;
+  createdAt: number;
+}
+⋮----
+export interface UpdateSubAPI {
+  apiKey: string;
+  ipWhitelist: string;
+  permission: string;
+  subName: string;
+}
+⋮----
+export interface DeleteSubAccountAPI {
+  subName: string;
+  apiKey: string;
+}
+⋮----
+/**
+ * Get KYC Regions Response
+ */
+export interface KYCRegion {
+  code: string; // Two-letter country code
+  enName: string; // English name of the region
+}
+⋮----
+code: string; // Two-letter country code
+enName: string; // English name of the region
+⋮----
+/**
+ * Get API Key Info Response
+ */
+export interface ApiKeyInfo {
+  uid: number; // Account UID
+  parentUid?: number; // Master account UID. Returns empty when called by the master account itself
+  region: string; // KYC region of the account, returns the two-letter country code
+  kycStatus: 0 | 1; // KYC status
+  subName?: string; // Sub-account name (not present for the master account)
+  remark: string; // Remarks
+  apiKey: string; // API key
+  apiVersion: number; // API version
+  permission: string; // Permissions
+  ipWhitelist?: string; // IP whitelist (comma-separated list of allowed IPs)
+  isMaster: boolean; // Indicates whether this is the master account
+  createdAt: number; // API key creation timestamp (Unix milliseconds)
+  expiredAt?: number | null; // API key expiration timestamp (Unix milliseconds). Returns null if no expiration is set
+  thirdPartyApp?: string; // Third-party application name. Returns empty string if not associated with any third-party app
+  siteType?: 'global' | 'turkey' | 'australia' | 'europe' | 'thailand'; // Site Type
+}
+⋮----
+uid: number; // Account UID
+parentUid?: number; // Master account UID. Returns empty when called by the master account itself
+region: string; // KYC region of the account, returns the two-letter country code
+kycStatus: 0 | 1; // KYC status
+subName?: string; // Sub-account name (not present for the master account)
+remark: string; // Remarks
+apiKey: string; // API key
+apiVersion: number; // API version
+permission: string; // Permissions
+ipWhitelist?: string; // IP whitelist (comma-separated list of allowed IPs)
+isMaster: boolean; // Indicates whether this is the master account
+createdAt: number; // API key creation timestamp (Unix milliseconds)
+expiredAt?: number | null; // API key expiration timestamp (Unix milliseconds). Returns null if no expiration is set
+thirdPartyApp?: string; // Third-party application name. Returns empty string if not associated with any third-party app
+siteType?: 'global' | 'turkey' | 'australia' | 'europe' | 'thailand'; // Site Type
+
+================
+File: src/types/response/spot-affiliate.ts
+================
+export interface AffiliateTradeHistoryItem {
+  tradeTime: number; // Trade time (13-digit timestamp)
+  tradeType: string; // Trading type (e.g., "SPOT")
+  tradeCurrency: string; // Trade currency
+  tradeAmount: string; // Trade amount
+  tradeAmountU: string; // Trade amount in USDT
+  feeU: string; // Fee in USDT
+  commission: string; // Commission
+  currency: string; // Currency (e.g., "USDT")
+}
+⋮----
+tradeTime: number; // Trade time (13-digit timestamp)
+tradeType: string; // Trading type (e.g., "SPOT")
+tradeCurrency: string; // Trade currency
+tradeAmount: string; // Trade amount
+tradeAmountU: string; // Trade amount in USDT
+feeU: string; // Fee in USDT
+commission: string; // Commission
+currency: string; // Currency (e.g., "USDT")
+⋮----
+export interface AffiliateTradeHistory {
+  currentPage: number; // Current page number
+  pageSize: number; // Page size
+  totalNum: number; // Total number of records
+  totalPage: number; // Total number of pages
+  items: AffiliateTradeHistoryItem[]; // Array of trade history items
+}
+⋮----
+currentPage: number; // Current page number
+pageSize: number; // Page size
+totalNum: number; // Total number of records
+totalPage: number; // Total number of pages
+items: AffiliateTradeHistoryItem[]; // Array of trade history items
+⋮----
+export interface AffiliateCommissionItem {
+  siteType: string; // Source site of the commission
+  rebateType: 1 | 2; // Rebate type
+  payoutTime: number; // Commission payout time (T+1 settlement), 13-digit timestamp (UTC+8)
+  periodStartTime: number; // Start time of commission calculation period, 13-digit timestamp
+  periodEndTime: number; // End time of commission calculation period, 13-digit timestamp
+  status: 1 | 2 | 3 | 4; // Payout status
+  takerVolume: string; // Invitee's taker trading volume
+  makerVolume: string; // Invitee's maker trading volume
+  commission: string; // Total rebate contributed by the invitee
+  currency: string; // Denomination unit for trading volume/amount (USDT or USDC)
+}
+⋮----
+siteType: string; // Source site of the commission
+rebateType: 1 | 2; // Rebate type
+payoutTime: number; // Commission payout time (T+1 settlement), 13-digit timestamp (UTC+8)
+periodStartTime: number; // Start time of commission calculation period, 13-digit timestamp
+periodEndTime: number; // End time of commission calculation period, 13-digit timestamp
+status: 1 | 2 | 3 | 4; // Payout status
+takerVolume: string; // Invitee's taker trading volume
+makerVolume: string; // Invitee's maker trading volume
+commission: string; // Total rebate contributed by the invitee
+currency: string; // Denomination unit for trading volume/amount (USDT or USDC)
+⋮----
+export interface AffiliateInviteeItem {
+  uid: string; // UID of the invitee
+  nickName: string; // Nickname (partially hidden)
+  referralCode: string; // Referral code used for registration
+  country: string; // Country
+  registrationTime: number; // Registration time (13-digit timestamp)
+  completedKyc: boolean; // Whether KYC is completed
+  completedFirstDeposit: boolean; // Whether first deposit is completed
+  completedFirstTrade: boolean; // Whether first trade is completed
+  past7dFees: string; // Fees in the past 7 days
+  past7dCommission: string; // Commission in the past 7 days
+  totalCommission: string; // Total commission
+  myCommissionRate: string; // My commission rate (percentage)
+  cashbackRate: string; // Cashback rate (percentage)
+  currency: string; // Currency (e.g., "USDT")
+}
+⋮----
+uid: string; // UID of the invitee
+nickName: string; // Nickname (partially hidden)
+referralCode: string; // Referral code used for registration
+country: string; // Country
+registrationTime: number; // Registration time (13-digit timestamp)
+completedKyc: boolean; // Whether KYC is completed
+completedFirstDeposit: boolean; // Whether first deposit is completed
+completedFirstTrade: boolean; // Whether first trade is completed
+past7dFees: string; // Fees in the past 7 days
+past7dCommission: string; // Commission in the past 7 days
+totalCommission: string; // Total commission
+myCommissionRate: string; // My commission rate (percentage)
+cashbackRate: string; // Cashback rate (percentage)
+currency: string; // Currency (e.g., "USDT")
+⋮----
+export interface AffiliateInvitees {
+  currentPage: number; // Current page number
+  pageSize: number; // Page size
+  totalNum: number; // Total number of records
+  totalPage: number; // Total number of pages
+  items: AffiliateInviteeItem[]; // Array of invited user items
+}
+⋮----
+currentPage: number; // Current page number
+pageSize: number; // Page size
+totalNum: number; // Total number of records
+totalPage: number; // Total number of pages
+items: AffiliateInviteeItem[]; // Array of invited user items
+⋮----
+export interface AffiliateTransactionItem {
+  uid: string; // The uid of the invitee
+  tradeTime: number; // Trade time (13-digit timestamp)
+  tradeType: 'SPOT' | 'FEATURE'; // Trade type
+  tradeCurrency: string; // Trade currency
+  tradeAmount: string; // Trade amount
+  tradeAmountU: string; // Trade amount transfer to U(USDT or usdt)
+  feeU: string; // Fee transfer to U(USDT or usdt)
+  commission: string; // Trade commission
+  currency: 'USDT' | 'USDC'; // Transaction volume or amount converted to U
+}
+⋮----
+uid: string; // The uid of the invitee
+tradeTime: number; // Trade time (13-digit timestamp)
+tradeType: 'SPOT' | 'FEATURE'; // Trade type
+tradeCurrency: string; // Trade currency
+tradeAmount: string; // Trade amount
+tradeAmountU: string; // Trade amount transfer to U(USDT or usdt)
+feeU: string; // Fee transfer to U(USDT or usdt)
+commission: string; // Trade commission
+currency: 'USDT' | 'USDC'; // Transaction volume or amount converted to U
+⋮----
+export interface AffiliateTransaction {
+  items: AffiliateTransactionItem[]; // Array of transaction items
+  lastId: string; // The offset ID for pagination
+}
+⋮----
+items: AffiliateTransactionItem[]; // Array of transaction items
+lastId: string; // The offset ID for pagination
+⋮----
+export interface KuminingItem {
+  uid: string; // User Id
+  goodsName: string; // Product Name
+  amount: string; // Product amount
+  currency: string; // The currency
+  lastId: string; // Last Id
+  payTime: number; // Trade time
+}
+⋮----
+uid: string; // User Id
+goodsName: string; // Product Name
+amount: string; // Product amount
+currency: string; // The currency
+lastId: string; // Last Id
+payTime: number; // Trade time
+
+================
+File: src/types/response/ws.ts
+================
+export interface WsServerInfo {
+  endpoint: string;
+  encrypt: boolean;
+  protocol: string;
+  pingInterval: number;
+  pingTimeout: number;
+}
+⋮----
+export interface WsConnectionInfo {
+  token: string;
+  instanceServers: WsServerInfo[];
+}
+⋮----
+export interface WsConnectionInfoV2 {
+  token: string;
+  instanceServers: undefined;
+}
+
+================
+File: src/types/websockets/ws-events.ts
+================
+export interface WsDataEvent<TData = any, TWSKey = string> {
+  data: TData;
+  table: string;
+  wsKey: TWSKey;
+}
+⋮----
+export interface MessageEventLike<TDataType = string> {
+  target: WebSocket;
+  type: 'message';
+  data: TDataType;
+}
+⋮----
+export function isMessageEvent(msg: unknown): msg is MessageEventLike
+
+================
+File: webpack/webpack.config.cjs
+================
+function generateConfig(name)
+⋮----
+// Add '.ts' and '.tsx' as resolvable extensions.
+⋮----
+// Node.js core modules not available in browsers
+// The REST client's https.Agent (for keepAlive) is Node.js-only and won't work in browsers
+⋮----
+// Code is already transpiled from TypeScript, no additional loaders needed
+
+================
+File: .gitignore
+================
+examples/futures-private-test.ts
+examples/spot-private-test.ts
+node_modules
+
+rest-spot-private-ts-test.ts
+
+localtest.sh
+testfile.ts
+dist
+repomix.sh
+doc
+
+coverage
+
+privaterepotracker
+restClientRegex.ts
+
+================
+File: eslint.config.cjs
+================
+/* eslint-disable @typescript-eslint/no-require-imports */
+⋮----
+// Bridge old-style ESLint config into the flat config format required by ESLint v9+
+
+================
+File: LICENSE.md
+================
+Copyright 2025 Tiago Siebler
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+================
+File: tsconfig.json
+================
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "baseUrl": ".",
+    "noEmitOnError": true,
+    "declaration": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": false,
+    "inlineSourceMap": false,
+    "lib": ["esnext"],
+    "listEmittedFiles": false,
+    "listFiles": false,
+    "moduleResolution": "node",
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitAny": true,
+    "noUnusedParameters": true,
+    "pretty": true,
+    "removeComments": false,
+    "resolveJsonModule": true,
+    "skipLibCheck": false,
+    "sourceMap": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "types": ["node", "jest"],
+    "module": "commonjs",
+    "outDir": "dist/cjs",
+    "target": "esnext"
+  },
+  "compileOnSave": true,
+  "exclude": ["node_modules", "dist"],
+  "include": ["src/**/*.*", "test/**/*.*", "eslint.config.cjs"]
+}
+
+================
+File: tsconfig.linting.json
+================
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "dist/cjs",
+    "target": "esnext",
+    "rootDir": "../",
+    "allowJs": true
+  },
+  "include": [
+    "src/**/*.*",
+    "test/**/*.*",
+    "examples/**/*.*",
+    "eslint.config.cjs",
+    ".eslintrc.cjs",
+    "jest.config.ts"
+  ]
+}
+
+================
+File: examples/auth/fasterHmacSign.ts
+================
+import { createHmac } from 'crypto';
+⋮----
+import { DefaultLogger, SpotClient, WebsocketClient } from '../../src/index.js';
+⋮----
+// or
+// import { createHmac } from 'crypto';
+// import { DefaultLogger, SpotClient, WebsocketClient } from 'kucoin-api';
+⋮----
+/**
+ * Injecting a custom signMessage function.
+ *
+ * The SDK uses the Web Crypto API for signing requests.
+ * While it is compatible with Node and Browser environments, it is
+ * slightly slower than using Node's native crypto module (only
+ * available in backend Node environments).
+ *
+ * For latency sensitive users, you can inject the previous node crypto sign
+ * method (or your own even faster implementation), if this change affects you.
+ *
+ * This example demonstrates how to inject a custom sign function, to achieve
+ * the same peformance as seen before the Web Crypto API was introduced.
+ *
+ * For context on standard usage, the "signMessage" function is used:
+ * - During every single API call
+ * - After opening a new private WebSocket connection
+ */
+⋮----
+/**
+   * Overkill in almost every case, but if you need any optimisation available,
+   * you can inject a faster sign mechanism such as node's native createHmac:
+   */
+⋮----
+// Optional, uncomment the "trace" override to log a lot more info about what the WS client is doing
+⋮----
+// trace: (...params) => console.log('trace', ...params),
+⋮----
+/**
+     * Overkill in almost every case, but if you need any optimisation available,
+     * you can inject a faster sign mechanism such as node's native createHmac:
+     */
+⋮----
+function setWsClientEventListeners(
+  websocketClient: WebsocketClient,
+  accountRef: string,
+): Promise<void>
+⋮----
+// console.log('raw message received ', JSON.stringify(data, null, 2));
+⋮----
+// Simple promise to ensure we're subscribed before trying anything else
+⋮----
+// Start trading
+
+================
+File: examples/WebSockets/README.md
+================
+# WebSocket Subscriptions
+
+The examples in this folder demonstrate how to connect to KuCoin WebSockets using Node.js, JavaScript & TypeScript, to receive realtime events from either account updates or market data.
+
+## Versions
+
+### V1
+
+This is the current / end of life generation of KuCoin's APIs. The old API docs can be found here:
+https://www.kucoin.com/docs-new
+
+Examples for this version are labelled with "v1" and tend to use the "v1" WsKeys (meaning they use the endpoints and WebSocket domains for the V1 APIs)
+
+### V2 / Pro / Unified / UTA
+
+The new generation of KuCoin's APIs. It was briefly named Unified Trading APIs (UTA), but has more recently been renamed to KuCoin Pro APIs.
+
+All examples for this version are labelled with "v2" and tend to use the "v2" WsKeys. Private WebSocket topics in KuCoin's V2 Pro APIs also share 1 connection (via the "privateProV2" WsKey). Previously in v1 these were split across two different connections.
+
+================
+File: examples/kucoin-FUTURES-examples-nodejs.md
+================
+# **KuCoin FUTURES API Examples** - Node.js, JavaScript & Typescript SDK for KuCoin REST APIs & WebSockets
+
+<p align="center">
+  <a href="https://www.npmjs.com/package/kucoin-api">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://github.com/tiagosiebler/kucoin-api/blob/master/docs/images/logoDarkMode2.svg?raw=true#gh-dark-mode-only">
+      <img alt="SDK Logo" src="https://github.com/tiagosiebler/kucoin-api/blob/master/docs/images/logoBrightMode2.svg?raw=true#gh-light-mode-only">
+    </picture>
+  </a>
+</p>
+
+This document provides comprehensive examples for using the KuCoin FUTURES API with Node.js and JavaScript. It covers various functionalities including account management, fund transfers, trade execution, order management, and market data retrieval. The examples are designed to help developers quickly integrate KuCoin Futures API into their NodeJS, Javascript and Typscript applications.
+
+If you are here, it means you will be great addition to our [Node.js Traders](https://t.me/nodetraders) community on Telegram where we discuss trading ideas, provide support regarding SDKs and share valuable resources!
+
+- [KuCoin Documentation](https://docs.kucoin.com/futures/#introduction) - official KuCoin API docs
+
+- [Node.js & JavaScript SDK for KuCoin](https://github.com/tiagosiebler/kucoin-api) - Github repo of our SDK
+
+Current file contains only certain most used examples. If you can't find what you need, you can search through [FuturesClient.ts](https://github.com/tiagosiebler/kucoin-api/blob/master/src/FuturesClient.ts) - all of the endpoints and functions will be there! Otherwise, just ask in [Node.js Traders](https://t.me/nodetraders) Telegram group.
+
+Do you need help with Spot? Check out [Spot Quickstart guide](https://github.com/tiagosiebler/kucoin-api/blob/master/examples/kucoin-SPOT-examples-nodejs.md). Using Unified (PRO) account? See [Unified / PRO examples](https://github.com/tiagosiebler/kucoin-api/blob/master/examples/kucoin-UNIFIED-examples-nodejs.md).
+
+**Table of contents:**
+
+- [Installation](#installation)
+- [Usage](#usage)
+- [REST API](#rest-api)
+
+  - [Account and balance](#account-examples)
+  - [Subaccount API management](#subaccount-api-management)
+  - [Market Data](#market-data)
+    - [Symbol and exchange info](#symbol-and-exchange-info)
+    - [Order Book data](#order-book-data)
+    - [Public Trades and Index data](#public-trades-and-index-data)
+    - [Funding Fees](#funding-fees)
+    - [Kline/Candles](#klinecandles)
+  - [Transfer funds in and out of Futures Account](#transfer-funds-in-and-out-of-futures-account)
+  - [Trade Execution](#trade)
+    - [General info](#general-info)
+    - [Market short](#market-short)
+    - [Market long](#market-long)
+    - [Limit short](#limit-short)
+    - [Limit long](#limit-long)
+    - [Market close](#market-close)
+    - [Limit close](#limit-close)
+    - [Stop loss](#stop-loss)
+    - [Place multiple orders](#place-multiple-orders)
+    - [Cancel order](#cancel-order)
+    - [Cancel all orders for specific symbol](#cancel-all-orders-for-specific-symbol)
+  - [Trade/Order/Positions Management](#tradeorderpositions-management)
+    - [Fetching orders](#fetching-orders)
+    - [Fills](#fills)
+    - [Positions](#positions)
+
+- [WebSocket](#websocket)
+- [Community group](#community-group)
+
+## Installation:
+
+```js
+// Install by npm
+npm install kucoin-api
+
+
+// Install by yarn
+yarn add kucoin-api
+```
+
+## Usage
+
+#### Create API credentials
+
+- [KuCoin API Key Management](https://www.kucoin.com/account/api)
+
+#### Import SDK to your project
+
+```js
+// require
+const { FuturesClient } = require('kucoin-api');
+
+// import
+import { FuturesClient } from 'kucoin-api';
+
+// initialise Futures Client
+const futuresClient = new FuturesClient({
+  // insert your api key, secret and passphrase - use env vars, if not just fill the string values
+  apiKey: process.env.KUCOIN_API_KEY || 'insert-your-api-key',
+  apiSecret: process.env.KUCOIN_API_SECRET || 'insert-your-api-secret',
+  apiPassphrase:
+    process.env.KUCOIN_API_PASSPHRASE || 'insert-your-api-passphrase',
+});
+```
+
+## REST API
+
+### Account examples
+
+#### Get Account Overview
+
+```js
+// Get Account Balance - XBT or USDT, default XBT
+futuresClient.getBalance({ currency: 'XBT' });
+
+// Get All Subaccount Accounts Balance
+futuresClient.getSubBalances({ currency: 'XBT' });
+```
+
+#### Get Transaction History
+
+```js
+futuresClient.getTransactions({
+  type: 'RealisedPNL', // 'RealisedPNL' | 'Deposit' | 'Withdrawal' | 'Transferin' | 'TransferOut'
+  maxCount: 10,
+  currency: 'USDT',
+});
+```
+
+### Subaccount API management
+
+```js
+// Get all subaccount APIs
+
+futuresClient.getSubAPIs({
+  subName: 'my_sub_name',
+});
+
+// Create Futures APIs for Sub-Account
+
+futuresClient.createSubAPI({
+  subName: 'my_sub_name',
+  passphrase: 'my_passphrase',
+  remark: 'my_remark',
+});
+
+// Modify Sub-Account Futures APIs
+
+futuresClient.updateSubAPI({
+  subName: 'my_sub_name',
+  passphrase: 'my_passphrase',
+  apiKey: 'my_api_key',
+});
+
+// Delete Sub-Account Futures APIs
+
+futuresClient.deleteSubAPI({
+  subName: 'my_sub_name',
+  passphrase: 'my_passphrase',
+  apiKey: 'my_api_key',
+});
+```
+
+### Market Data
+
+#### Symbol and exchange info
+
+```js
+// Get All Contract List
+futuresClient.getSymbols();
+
+// Get Order Info of the Contract
+futuresClient.getSymbol({ symbol: 'XBTUSDTM' });
+
+// Get Ticker
+futuresClient.getTicker({ symbol: 'XBTUSDTM' });
+```
+
+#### Order Book data
+
+```js
+// Get Full Order Book - Level 2
+futuresClient.getFullOrderBookLevel2({ symbol: 'XBTUSDTM' });
+
+// Get Level2 depth20
+futuresClient.getPartOrderBookLevel2Depth20({ symbol: 'XBTUSDTM' });
+
+// Get Level2 depth100
+futuresClient.getPartOrderBookLevel2Depth100({ symbol: 'XBTUSDTM' });
+```
+
+#### Public Trades and Index data
+
+```js
+// Get Public Trades
+futuresClient.getMarketTrades({ symbol: 'XBTUSDTM' });
+
+// Get Interest Rate List
+futuresClient.getInterestRates({ symbol: '.XBTINT' });
+
+// Get Index List
+futuresClient.getIndex({ symbol: '.KXBT' });
+
+// Get Current Mark Price
+futuresClient.getMarkPrice({ symbol: 'XBTUSDM' });
+
+// Get Premium Index
+futuresClient.getPremiumIndex({ symbol: '.XBTUSDMPI' });
+
+// Get 24hour futures transaction volume
+futuresClient.get24HourTransactionVolume();
+```
+
+#### Funding Fees
+
+```js
+// Get Current Funding Rate
+futuresClient.getFundingRate({ symbol: 'XBTUSDM' });
+
+// Get Public Funding History
+futuresClient.getFundingRates({
+  symbol: 'XBTUSDTM',
+  from: '1700310700000',
+  to: '1702310700000',
+});
+
+// Get Private Funding History
+futuresClient.getFundingHistory({ symbol: 'ETHUSDTM' });
+```
+
+#### Kline/Candles
+
+```js
+futuresClient.getKlines({
+  symbol: 'XBTUSDTM',
+  granularity: 60,
+  from: new Date().getTime() - 24 * 60 * 60 * 1000, // 24 hours ago
+  to: new Date().getTime(),
+});
+```
+
+### Transfer funds in and out of Futures Account
+
+```js
+// Transfer out of the Futures to main acc
+
+futuresClient.submitTransferOut({
+  amount: 0.01,
+  currency: 'USDT',
+  recAccountType: 'MAIN',
+});
+
+// Transfer to Futures Account
+
+futuresClient.submitTransferIn({
+  amount: 0.01,
+  currency: 'USDT',
+  payAccountType: 'MAIN',
+});
+
+// Get All Transfers
+
+futuresClient.futureTransfers({
+  status: 'SUCCESS', // optional, 'PROCESSING' | 'SUCCESS' | 'FAILURE';
+  currency: 'USDT', // optional
+  startAt: 1723550000, // optional
+  endAt: 1723557472, // optional
+  currentPage: 1, // optional
+  pageSize: 100, // optional
+});
+```
+
+---
+
+### Trade
+
+#### General info
+
+Futures are contracts, not currencies. In the futures symbols list you will see a "multiplier" field for each of the symbols. Each contract is equal to Multiplier x Size.
+
+For example click on this endpoint and get a symbol info for XRPUSDTM: https://api-futures.kucoin.com/api/v1/contracts/XRPUSDTM
+
+In the object, find the "multiplier" value.
+
+```js
+// In your code, you can fetch it like this
+const symbolInfo = await client.getSymbol({ symbol: 'XRPUSDTM' });
+const multiplier = symbolInfo.data.multiplier;
+```
+
+E.g. if multiplier is 10(what you can see from the endpoint), that means each SIZE is 10 XRP. So if XRP is currently at $0.5, then each 1 contract (size 10) is going to cost $5.00
+
+size = (Funds x leverage) / (price x multiplier)
+
+```js
+const XRPPriceExample = 0.5;
+const leverage = 5;
+const fundsToTradeUSDT = 100;
+
+const costOfContract = XRPPriceExample * multiplier;
+
+const size = (fundsToTradeUSDT * leverage) / costOfContract;
+console.log(`Size: ${size}`);
+```
+
+The trade amount indicates the amount of contract to buy or sell, and contract uses the base currency(USD contracts e.g. XBTUSDM) or lot( USDT contracts e.g. XBTUSDTM) as the trading unit.
+The trade amount must be no less than 1 lot for the contract and no larger than the maxOrderQty.
+It should be a multiple number of the lot, or the system will report an error when you place the order.
+E.g. 1 lot of XBTUSDTM is 0.001 Bitcoin, while 1 lot of XBTUSDM is 1 USD.
+You can get info about any contract on the link: https://api-futures.kucoin.com/api/v1/contracts/****\_\_**** - just replace the empty space with the symbol of the contract.
+
+Here are function examples using the Futures Create Order endpoint:
+
+#### Market Short
+
+```js
+// A MARKET SHORT of 2 contracts of XBT using leverage of 5:
+const marketShort = futureTransfers.submitOrder({
+  clientOid: '123456789',
+  leverage: '5',
+  side: 'sell',
+  size: 2,
+  symbol: 'XBTUSDTM',
+  timeInForce: 'GTC',
+  type: 'market',
+});
+```
+
+#### Market Long
+
+```js
+// A MARKET LONG of 2 contracts of XBT using leverage of 5:
+const marketLong = futureTransfers.submitOrder({
+  clientOid: '123456789',
+  leverage: '5',
+  side: 'buy',
+  size: 2,
+  symbol: 'XBTUSDTM',
+  timeInForce: 'GTC',
+  type: 'market',
+});
+```
+
+#### Limit Short
+
+```js
+// A LIMIT SHORT of 2 contracts of XBT using leverage of 5:
+const limitShort = futureTransfers.submitOrder({
+  clientOid: '123456789',
+  leverage: '5',
+  price: '70300.31',
+  side: 'sell',
+  size: 2,
+  symbol: 'XBTUSDTM',
+  timeInForce: 'GTC',
+  type: 'limit',
+});
+```
+
+#### Limit Long
+
+```js
+// A LIMIT LONG of 2 contracts of XBT using leverage of 5:
+const limitLong = futureTransfers.submitOrder({
+  clientOid: '123456789',
+  leverage: '5',
+  price: '40300.31',
+  side: 'buy',
+  size: 2,
+  symbol: 'XBTUSDTM',
+  timeInForce: 'GTC',
+  type: 'limit',
+});
+```
+
+On any "close position" action, if you specify a SIZE=0 or leave off the SIZE parameter,
+then it will close the whole position, regardless of the size.
+If you specify a SIZE, it will close only the number of contracts you specify.
+
+If closeOrder is set to TRUE,
+the system will close the position and the position size will become 0.
+Side, Size and Leverage fields can be left empty and the system will determine the side and size automatically.
+
+#### Market close
+
+```js
+// A MARKET CLOSE POSITION example:
+const marketClose = futureTransfers.submitOrder({
+  clientOid: '123456789',
+  closeOrder: true,
+  symbol: 'XBTUSDTM',
+  timeInForce: 'GTC',
+  type: 'market',
+  side: 'sell',
+  size: 0,
+});
+```
+
+#### Limit close
+
+```js
+// A LIMIT CLOSE of a LONG example:
+const limitCloseLong = futureTransfers.submitOrder({
+  clientOid: '123456789',
+  leverage: '5',
+  price: '70300.31',
+  closeOrder: true,
+  side: 'sell',
+  size: 2,
+  symbol: 'XBTUSDTM',
+  timeInForce: 'GTC',
+  type: 'limit',
+});
+
+// A LIMIT CLOSE of a SHORT example:
+const limitCloseShort = futureTransfers.submitOrder({
+  clientOid: '123456789',
+  leverage: '5',
+  price: '40300.31',
+  closeOrder: true,
+  side: 'buy',
+  size: 2,
+  symbol: 'XBTUSDTM',
+  timeInForce: 'GTC',
+  type: 'limit',
+});
+```
+
+#### Stop loss
+
+```js
+// A STOP LOSS example for a LONG position:
+const stopLossLong = futureTransfers.submitOrder({
+  clientOid: '123456789',
+  closeOrder: true,
+  stop: 'down',
+  stopPrice: '40200.31',
+  stopPriceType: 'TP',
+  symbol: 'XBTUSDTM',
+  timeInForce: 'GTC',
+  type: 'market',
+});
+
+// A STOP LOSS example for a SHORT position:
+const stopLossShort = futureTransfers.submitOrder({
+  clientOid: '123456789',
+  closeOrder: true,
+  stop: 'up',
+  stopPrice: '40200.31',
+  stopPriceType: 'TP',
+  symbol: 'XBTUSDTM',
+  timeInForce: 'GTC',
+  type: 'market',
+});
+```
+
+##### Place Multiple Orders
+
+```js
+//request
+
+const orders = [
+  {
+    clientOid: '5c52e11203aa677f33e491',
+    side: 'buy',
+    symbol: 'ETHUSDTM',
+    type: 'limit',
+    price: '2150',
+    leverage: '1',
+    size: 2,
+  },
+  {
+    clientOid: 'je12019ka012ja013099',
+    side: 'buy',
+    symbol: 'XBTUSDTM',
+    type: 'limit',
+    price: '32150',
+    leverage: '1',
+    size: 2,
+  },
+];
+
+futuresClient.submitMultipleOrders(orders);
+```
+
+#### Cancel Order
+
+```js
+futuresClient.cancelOrderById({ orderId: 'orderId' });
+futuresClient.cancelOrderByClientOid({ clientOid: 'clientOid' });
+```
+
+#### Cancel all orders for specific symbol
+
+```js
+futuresClient.cancelAllOrders({ symbol: 'XBTUSDTM' });
+
+futuresClient.cancelAllStopOrders({ symbol: 'XBTUSDTM' });
+```
+
+### Trade/Order/Positions Management
+
+#### Fetching orders
+
+```js
+// Get open orders
+futuresClient.getOrders({ status: 'active' });
+
+// Get closed orders
+futuresClient.getOrders({ status: 'done' });
+
+// Get Untriggered Stop Orders
+futuresClient.getStopOrders({ type: 'limit' });
+
+// Get List of Orders Completed in 24h
+futuresClient.getRecentOrders();
+
+// Get Details of a Single Order by ClientOrderId
+futuresClient.getOrderByClientOrderId({ clientOid: 'clientOid' });
+// Or By OrderId
+futuresClient.getOrderByOrderId({ orderId: 'orderId' });
+```
+
+#### Fills
+
+```js
+// Get Specific Fills
+futuresClient.getFills({ type: 'market' });
+// or search for all
+futuresClient.getFills({});
+
+// Recent Fills from last 24 hours
+futuresClient.futuresRecentFills({ symbol: 'ETHUSDTM' });
+// Or Search All
+futuresClient.futuresRecentFills({});
+
+// Active Order Value Calculation
+futuresClient.getOpenOrderStatistics({ symbol: 'ETHUSDTM' });
+```
+
+#### Positions
+
+```js
+// Get Position Details
+futuresClient.getPosition({ symbol: 'ETHUSDTM' });
+
+// Get Position List
+futuresClient.getPositions({ currency: 'USDT' });
+// Or Search All
+futuresClient.getPositions();
+
+// Get History Positions
+futuresClient.getHistoryPositions({ symbol: 'ETHUSDTM' });
+```
+
+## Websocket
+
+For Websocket examples, please refer to these links:
+
+- [Spot Public Websocket](https://github.com/tiagosiebler/kucoin-api/blob/master/examples/ws-spot-public.ts)
+- [Spot Private Websocket](https://github.com/tiagosiebler/kucoin-api/blob/master/examples/ws-spot-private.ts)
+- [Futures Public Websocket](https://github.com/tiagosiebler/kucoin-api/blob/master/examples/ws-futures-public.ts)
+- [Futures Private Websocket](https://github.com/tiagosiebler/kucoin-api/blob/master/examples/ws-futures-private.ts)
+
+## Community group
+
+If you need help, something is wrong/missing or you have suggestions, please join our [Node.js Traders](https://t.me/nodetraders) community group on Telegram and let us know!
+
+================
+File: examples/kucoin-SPOT-examples-nodejs.md
+================
+# **KuCoin SPOT API Examples** - Node.js, JavaScript & Typescript SDK for KuCoin REST APIs & WebSockets
+
+<p align="center">
+  <a href="https://www.npmjs.com/package/kucoin-api">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://github.com/tiagosiebler/kucoin-api/blob/master/docs/images/logoDarkMode2.svg?raw=true#gh-dark-mode-only">
+      <img alt="SDK Logo" src="https://github.com/tiagosiebler/kucoin-api/blob/master/docs/images/logoBrightMode2.svg?raw=true#gh-light-mode-only">
+    </picture>
+  </a>
+</p>
+
+This document provides comprehensive examples for using the KuCoin SPOT API with Node.js and JavaScript. It covers various functionalities including account management, fund transfers, trade execution, order management, and market data retrieval. The examples are designed to help developers quickly integrate KuCoin Spot API into their NodeJS, Javascript and Typscript applications.
+
+If you are here, it means you will be great addition to our [Node.js Traders](https://t.me/nodetraders) community on Telegram where we discuss trading ideas, provide support regarding SDKs and share valuable resources!
+
+- [KuCoin Documentation](https://www.kucoin.com/docs/beginners/introduction) - official KuCoin API docs
+
+- [Node.js & JavaScript SDK for KuCoin](https://github.com/tiagosiebler/kucoin-api) - Github repo of our SDK
+
+Current file contains only certain most used examples. If you can't find what you need, you can search through [SpotClient.ts](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts) - all of the endpoints and functions will be there! Otherwise, just ask in [Node.js Traders](https://t.me/nodetraders) Telegram group.
+
+Do you need help with Futures? Check out [Futures Quickstart guide](https://github.com/tiagosiebler/kucoin-api/blob/master/examples/kucoin-FUTURES-examples-nodejs.md). Using Unified (PRO) account? See [Unified / PRO examples](https://github.com/tiagosiebler/kucoin-api/blob/master/examples/kucoin-UNIFIED-examples-nodejs.md).
+
+**Table of contents:**
+
+- [Installation](#installation)
+- [Usage](#usage)
+- [REST API](#rest-api)
+
+  - [Account and balance](#account-examples)
+
+    - [Account overview](#account-overview)
+    - [Transactions](#transactions)
+    - [Deposit and Withdrawal](#deposit-and-withdrawal)
+
+  - [Subaccount](#subaccount)
+    - [Subaccount management](#subaccount-management)
+    - [Subaccount API management](#subaccount-api-management)
+  - [Market Data](#market-data)
+    - [Symbol and exchange info](#symbol-and-exchange-info)
+    - [Order Book data](#order-book-data)
+    - [Kline/Candles](#klinecandles)
+  - [Trade Execution](#trade)
+    - [General info](#general-info)
+    - [Market short](#market-short)
+    - [Market long](#market-long)
+    - [Limit short](#limit-short)
+    - [Limit long](#limit-long)
+    - [Place multiple orders](#place-multiple-orders)
+  - [Trade/Order/Positions Management](#tradeorderpositions-management)
+    - [Fetching orders](#fetching-orders)
+    - [Cancel order](#cancel-order)
+    - [Cancel all orders for specific symbol](#cancel-all-orders-for-specific-symbol)
+    - [Fills](#fills)
+  - [Spot HF trade](#spot-hf-trade)
+  - [Margin trade](#margin-trade--margin-hf-trade)
+
+- [WebSocket](#websocket)
+- [Community group](#community-group)
+
+## Installation:
+
+```js
+// Install by npm
+npm install kucoin-api
+
+
+// Install by yarn
+yarn add kucoin-api
+```
+
+## Usage
+
+#### Create API credentials
+
+- [KuCoin API Key Management](https://www.kucoin.com/account/api)
+
+#### Import SDK to your project
+
+```js
+// require
+const { SpotClient } = require('kucoin-api');
+
+// import
+import { SpotClient } from 'kucoin-api';
+
+// initialise Spot Client
+const spotClient = new SpotClient({
+  // insert your api key, secret and passphrase - use env vars, if not just fill the string values
+  apiKey: process.env.KUCOIN_API_KEY || 'insert-your-api-key',
+  apiSecret: process.env.KUCOIN_API_SECRET || 'insert-your-api-secret',
+  apiPassphrase:
+    process.env.KUCOIN_API_PASSPHRASE || 'insert-your-api-passphrase',
+});
+```
+
+## REST API
+
+### Account examples
+
+#### Account Overview
+
+```js
+// Get Account Summary
+spotClient.getAccountSummary();
+
+// Get all Account Balances
+spotClient.getBalances();
+
+// Get specific Account or Currency Balance
+spotClient.getBalance({
+  currency: 'USDT',
+  type: 'main', // 'trade' | 'margin' | 'trade_hf'
+});
+
+// Example call to get account details by ID
+spotClient.getAccountDetails({ accountId: '5bd6e9286d99522a52e458de' });
+
+// Margin endpoints for balances
+spotClient.getMarginBalances();
+spotClient.getMarginBalance();
+spotClient.getIsolatedMarginBalance();
+```
+
+#### Transactions
+
+```js
+// Example call to get account ledgers with specified parameters
+spotClient.getTransactions({ currency: 'BTC', startAt: 1601395200000 });
+
+// Example call to get high-frequency account ledgers with specified parameters
+spotClient.getHFTransactions({
+  bizType: 'TRADE_EXCHANGE',
+  currency: 'YOP,DAI',
+  startAt: 1601395200000,
+});
+
+// Example call to get high-frequency margin account ledgers with specified parameters
+spotClient.getHFMarginTransactions({
+  bizType: 'MARGIN_EXCHANGE',
+  currency: 'YOP,DAI',
+  startAt: 1601395200000,
+});
+```
+
+#### Deposit and Withdrawal
+
+```js
+// Example call to create a deposit address
+spotClient.createDepositAddress({
+  currency: 'BTC',
+  // Optional parameter
+  chain: 'BTC',
+});
+
+// Example call to get deposit addresses with specified parameters
+spotClient.getDepositAddressesV2({
+  currency: 'BTC',
+});
+
+// Example call to get deposits
+spotClient.getDeposits();
+
+// Example call to get withdrawals with specified parameters
+spotClient.getWithdrawals({
+  currency: 'BTC', // Optional parameter
+});
+
+// Example call to submit a withdrawal
+spotClient.submitWithdraw({
+  currency: 'BTC',
+  address: '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa',
+  amount: 0.01,
+  // Optional parameters
+  memo: 'exampleMemo',
+  chain: 'BTC',
+});
+
+// Example call to cancel a withdrawal by ID
+spotClient.cancelWithdrawal({
+  withdrawalId: '5bffb63303aa675e8bbe18f9',
+});
+```
+
+### Subaccount
+
+#### Subaccount Management
+
+```js
+// Get all subaccounts
+spotClient.getSubAccountsV2({});
+
+// Example call to create a sub-account
+spotClient.createSubAccount({
+  // Fill in the required parameters for creating a sub-account
+  subName: 'exampleSubAccount',
+  password: 'examplePassword',
+  access: 'trade',
+});
+
+// Example call to get sub-account balance with specified parameters
+spotClient.getSubAccountBalance({
+  subUserId: '5caefba7d9575a0688f83c45',
+  includeBaseAmount: false,
+});
+
+// Example call to get sub-account balances
+spotClient.getSubAccountBalancesV2();
+
+// Example call to get transferable funds
+spotClient.getTransferable({
+  currency: 'BTC',
+  type: 'MAIN',
+});
+
+// Example call to submit a transfer from master to sub-account
+spotClient.submitTransferMasterSub({
+  clientOid: client.generateNewOrderID(), // or use your custom UUID
+  amount: 0.01,
+  currency: 'USDT',
+  direction: 'OUT', // 'IN' for transfer to master, 'OUT' for transfer to sub
+  subUserId: 'enter_sub_user_id_here',
+});
+
+// Example call to submit an inner transfer within same account
+spotClient.submitInnerTransfer({
+  clientOid: client.generateNewOrderID(), // or use your custom UUID
+  amount: 0.01,
+  currency: 'USDT',
+  from: 'main', // Source account type
+  to: 'trade', // Destination account type
+});
+```
+
+#### Subaccount API management
+
+```js
+// Get all subaccount APIs
+
+spotClient.getSubAPIs({
+  subName: 'my_sub_name',
+});
+
+// Create APIs for Sub-Account
+
+spotClient.createSubAPI({
+  subName: 'my_sub_name',
+  passphrase: 'my_passphrase',
+  remark: 'my_remark',
+});
+
+// Modify Sub-Account APIs
+
+spotClient.updateSubAPI({
+  subName: 'my_sub_name',
+  passphrase: 'my_passphrase',
+  apiKey: 'my_api_key',
+});
+
+// Delete Sub-Account APIs
+
+spotClient.deleteSubAPI({
+  subName: 'my_sub_name',
+  passphrase: 'my_passphrase',
+  apiKey: 'my_api_key',
+});
+```
+
+### Market Data
+
+#### Symbol and exchange info
+
+```js
+// Get All Currencies List
+spotClient.getCurrencies();
+
+// Get info for a specific currency
+spotClient.getCurrency({
+  currency: 'BTC',
+});
+
+// Get all Symbols
+spotClient.getSymbols();
+
+// Example call to get ticker information for a specific symbol
+spotClient.getTicker({
+  symbol: 'BTC-USDT',
+});
+
+// All tickers
+spotClient.getTickers();
+
+// Get 24h stats for a specific symbol
+spotClient.get24hrStats({
+  symbol: 'BTC-USDT',
+});
+```
+
+#### Order Book data
+
+```js
+// get partial orderbook
+spotClient.getOrderBookLevel20({ symbol: 'BTC-USDT' });
+
+// get partial orderbook
+spotClient.getOrderBookLevel100({ symbol: 'BTC-USDT' });
+
+// get full orderbook
+spotClient.getFullOrderBook({ symbol: 'BTC-USDT' });
+```
+
+#### Kline/Candles
+
+```js
+// Example call to get Klines (candlestick data) with specified parameters
+spotClient.getKlines({
+  type: '1min',
+  symbol: 'BTC-USDT',
+  startAt: 1566703297,
+  endAt: 1566789757,
+});
+```
+
+---
+
+### Trade
+
+#### General info
+
+Please, read official [KuCoin API docs](https://www.kucoin.com/docs/rest/spot-trading/orders/place-order) to understand how to place orders, cancel orders, etc. and what is needed for each endpoint. These are just low-end examples to understand how to use it with SDK.
+
+#### Market Short
+
+```js
+// Market short order
+const marketShort = spotClient.submitOrder({
+  clientOid: client.generateNewOrderID(), // or use your custom UUID
+  side: 'sell',
+  symbol: 'ETH-BTC',
+  type: 'market',
+  size: '0.5', // Specify the quantity to sell
+});
+```
+
+#### Market Long
+
+```js
+// Market long order
+const marketLong = spotClient.submitOrder({
+  clientOid: client.generateNewOrderID(), // or use your custom UUID
+  side: 'buy',
+  symbol: 'ETH-BTC',
+  type: 'market',
+  size: '0.5', // Specify the quantity to buy
+});
+```
+
+#### Limit Short
+
+```js
+// Limit short order
+const limitShort = spotClient.submitOrder({
+  clientOid: client.generateNewOrderID(), // or use your custom UUID
+  side: 'sell',
+  symbol: 'ETH-BTC',
+  type: 'limit',
+  price: '0.03', // Specify the price to sell
+  size: '0.5', // Specify the quantity to sell
+  timeInForce: 'GTC', // Good Till Canceled
+});
+```
+
+#### Limit Long
+
+```js
+// Limit long order
+const limitLong = spotClient.submitOrder({
+  clientOid: client.generateNewOrderID(), // or use your custom UUID
+  side: 'buy',
+  symbol: 'ETH-BTC',
+  type: 'limit',
+  price: '0.03', // Specify the price to buy
+  size: '0.5', // Specify the quantity to buy
+  timeInForce: 'GTC', // Good Till Canceled
+});
+```
+
+##### Place Multiple Orders
+
+```js
+//request
+
+const multipleOrders = [
+  {
+    clientOid: '3d07008668054da6b3cb12e432c2b13a',
+    side: 'buy',
+    type: 'limit',
+    price: '0.01',
+    size: '0.01',
+  },
+  {
+    clientOid: '37245dbe6e134b5c97732bfb36cd4a9d',
+    side: 'buy',
+    type: 'limit',
+    price: '0.01',
+    size: '0.01',
+  },
+];
+
+spotClient.submitMultipleOrders({
+  symbol: 'KCS-USDT',
+  orderList: multipleOrders,
+});
+```
+
+### Trade/Order/Positions Management
+
+#### Fetching orders
+
+```js
+// Get open orders
+spotClient.getOrders({ status: 'active' });
+
+// Get closed orders
+spotClient.getOrders({ status: 'done' });
+
+// Get List of Orders Completed in 24h
+spotClient.getRecentOrders();
+
+// Get Details of a Single Order by ClientOrderId
+spotClient.getOrderByClientOid({ clientOid: 'clientOid' });
+// Or By OrderId
+spotClient.getOrderByOrderId({ orderId: 'orderId' });
+```
+
+#### Cancel Order
+
+```js
+spotClient.cancelOrderById({ orderId: 'orderId' });
+spotClient.cancelOrderByClientOid({ clientOid: 'clientOid' });
+```
+
+#### Cancel all orders for specific symbol
+
+```js
+//cancel all orders for symbol
+spotClient.cancelAllOrders({ symbol: 'XBTUSDTM' });
+
+// cancel all orders for all symbols
+spotClient.cancelAllOrders();
+```
+
+#### Fills
+
+```js
+// Get Specific Fills
+spotClient.getFills({ type: 'market' });
+// or search for all
+spotClient.getFills();
+
+// Recent Fills from last 24 hours
+spotClient.getRecentFills();
+```
+
+### Spot HF trade
+
+All of the examples are 99% same as regular spot, but you can follow the [official HF Trade API documentation](https://www.kucoin.com/docs/rest/spot-trading/spot-hf-trade-pro-account/place-hf-order) and list of functions in [SpotClient.ts](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts) to find what you need!
+
+### Margin trade & Margin HF trade
+
+All of the examples are 99% same as regular spot, but you can follow the [official Margin Trade API documentation](https://www.kucoin.com/docs/rest/margin-trading/market-data) and list of functions in [SpotClient.ts](https://github.com/tiagosiebler/kucoin-api/blob/master/src/SpotClient.ts) to find what you need!
+
+---
+
+## Websocket
+
+For Websocket examples, please refer to these links:
+
+- [Spot Public Websocket](https://github.com/tiagosiebler/kucoin-api/blob/master/examples/ws-spot-public.ts)
+- [Spot Private Websocket](https://github.com/tiagosiebler/kucoin-api/blob/master/examples/ws-spot-private.ts)
+- [Futures Public Websocket](https://github.com/tiagosiebler/kucoin-api/blob/master/examples/ws-futures-public.ts)
+- [Futures Private Websocket](https://github.com/tiagosiebler/kucoin-api/blob/master/examples/ws-futures-private.ts)
+
+## Community group
+
+If you need help, something is wrong/missing or you have suggestions, please join our [Node.js Traders](https://t.me/nodetraders) community group on Telegram and let us know!
+
+================
+File: src/lib/websocket/WsStore.ts
+================
+import WebSocket from 'isomorphic-ws';
+⋮----
+import { DefaultLogger } from './logger.js';
+import {
+  DeferredPromise,
+  WSConnectedResult,
+  WsConnectionStateEnum,
+  WsStoredState,
+} from './WsStore.types.js';
+⋮----
+/**
+ * Simple comparison of two objects, recursive for nested objects. Adoped from OKX SDK.
+ */
+export function isDeepObjectMatch(object1: any, object2: any): boolean
+⋮----
+// console.log('not same key count', { keys1, keys2 });
+// not the same amount of keys or keys don't match
+⋮----
+// console.log('not same key names: ', { keys1, keys2 });
+⋮----
+type DeferredPromiseRef =
+  (typeof DEFERRED_PROMISE_REF)[keyof typeof DEFERRED_PROMISE_REF];
+⋮----
+export class WsStore<
+WsKey extends string,
+⋮----
+constructor(logger: DefaultLogger)
+⋮----
+/** Get WS stored state for key, optionally create if missing */
+get(
+    key: WsKey,
+    createIfMissing?: true,
+  ): WsStoredState<TWSTopicSubscribeEventArgs>;
+⋮----
+get(
+    key: WsKey,
+    createIfMissing?: false,
+  ): WsStoredState<TWSTopicSubscribeEventArgs> | undefined;
+⋮----
+get(
+    key: WsKey,
+    createIfMissing?: boolean,
+): WsStoredState<TWSTopicSubscribeEventArgs> | undefined
+⋮----
+getKeys(): WsKey[]
+⋮----
+create(key: WsKey): WsStoredState<TWSTopicSubscribeEventArgs> | undefined
+⋮----
+delete(key: WsKey): void
+⋮----
+// TODO: should we allow this at all? Perhaps block this from happening...
+⋮----
+/* connection websocket */
+⋮----
+hasExistingActiveConnection(key: WsKey): boolean
+⋮----
+getWs(key: WsKey): WebSocket | undefined
+⋮----
+setWs(key: WsKey, wsConnection: WebSocket): WebSocket
+⋮----
+/**
+   * deferred promises
+   */
+⋮----
+getDeferredPromise<TSuccessResult = any>(
+    wsKey: WsKey,
+    promiseRef: string | DeferredPromiseRef,
+): DeferredPromise<TSuccessResult> | undefined
+⋮----
+createDeferredPromise<TSuccessResult = any>(
+    wsKey: WsKey,
+    promiseRef: string | DeferredPromiseRef,
+    throwIfExists: boolean,
+): DeferredPromise<TSuccessResult>
+⋮----
+// console.log('existing promise');
+⋮----
+// console.log('create promise');
+⋮----
+// TODO: Once stable, use Promise.withResolvers in future
+⋮----
+resolveDeferredPromise(
+    wsKey: WsKey,
+    promiseRef: string | DeferredPromiseRef,
+    value: unknown,
+    removeAfter: boolean,
+): void
+⋮----
+rejectDeferredPromise(
+    wsKey: WsKey,
+    promiseRef: string | DeferredPromiseRef,
+    value: unknown,
+    removeAfter: boolean,
+): void
+⋮----
+removeDeferredPromise(
+    wsKey: WsKey,
+    promiseRef: string | DeferredPromiseRef,
+): void
+⋮----
+// Just in case it's pending
+⋮----
+rejectAllDeferredPromises(wsKey: WsKey, reason: string): void
+⋮----
+// Skip reserved keys, such as the connection promise
+⋮----
+/** Get promise designed to track a connection attempt in progress. Resolves once connected. */
+getConnectionInProgressPromise(
+    wsKey: WsKey,
+): DeferredPromise<WSConnectedResult> | undefined
+⋮----
+getAuthenticationInProgressPromise(
+    wsKey: WsKey,
+): DeferredPromise<WSConnectedResult &
+⋮----
+/**
+   * Create a deferred promise designed to track a connection attempt in progress.
+   *
+   * Will throw if existing promise is found.
+   */
+createConnectionInProgressPromise(
+    wsKey: WsKey,
+    throwIfExists: boolean,
+): DeferredPromise<WSConnectedResult>
+⋮----
+createAuthenticationInProgressPromise(
+    wsKey: WsKey,
+    throwIfExists: boolean,
+): DeferredPromise<WSConnectedResult &
+⋮----
+/** Remove promise designed to track a connection attempt in progress */
+removeConnectingInProgressPromise(wsKey: WsKey): void
+⋮----
+removeAuthenticationInProgressPromise(wsKey: WsKey): void
+⋮----
+/* connection state */
+⋮----
+isWsOpen(key: WsKey): boolean
+⋮----
+getConnectionState(key: WsKey): WsConnectionStateEnum
+⋮----
+setConnectionState(key: WsKey, state: WsConnectionStateEnum)
+⋮----
+isConnectionState(key: WsKey, state: WsConnectionStateEnum): boolean
+⋮----
+/**
+   * Check if we're currently in the process of opening a connection for any reason. Safer than only checking "CONNECTING" as the state
+   * @param key
+   * @returns
+   */
+isConnectionAttemptInProgress(key: WsKey): boolean
+⋮----
+const stateChangeTimeout = 15000; // allow a max 15 second timeout since the last state change before assuming stuck;
+⋮----
+/* subscribed topics */
+⋮----
+getTopics(key: WsKey): Set<TWSTopicSubscribeEventArgs>
+⋮----
+getTopicsAsArray(key: WsKey): TWSTopicSubscribeEventArgs[]
+⋮----
+getTopicsByKey(): Record<string, Set<TWSTopicSubscribeEventArgs>>
+⋮----
+/**
+   * Find matching "topic" request from the store
+   * @param key
+   * @param topic
+   * @returns
+   */
+getMatchingTopic(key: WsKey, topic: TWSTopicSubscribeEventArgs)
+⋮----
+addTopic(key: WsKey, topic: TWSTopicSubscribeEventArgs)
+⋮----
+// Check for duplicate topic. If already tracked, don't store this one
+⋮----
+deleteTopic(key: WsKey, topic: TWSTopicSubscribeEventArgs)
+⋮----
+// Check if we're subscribed to a topic like this
+
+================
 File: src/types/request/uta-types.ts
 ================
 /**
@@ -6215,6 +6808,14 @@ export interface BatchCancelOrdersRequestUTA {
 ⋮----
 cancelOrderList: CancelOrderItemRequestUTA[]; // Maximum 20 orders
 ⋮----
+/** Batch cancel orders by symbol (POST /order/cancel-all) */
+export interface BatchCancelOrdersBySymbolRequestUTA {
+  tradeType: 'SPOT' | 'FUTURES' | 'MARGIN';
+  symbol: string;
+  marginMode?: 'CROSS' | 'ISOLATED';
+  orderFilter?: 'NORMAL' | 'ADVANCED';
+}
+⋮----
 export interface SetDCPRequestUTA {
   tradeType: 'SPOT' | 'FUTURES' | 'MARGIN';
   timeout: number; // Range: timeout=-1 (unset) or 5 <= timeout <= 86400 seconds
@@ -6262,1724 +6863,6 @@ symbol: string; // Supports up to 10 symbols, comma-separated
 tradeType?: 'FUTURES' | 'MARGIN'; // Not support margin for the time being
 marginMode?: 'ISOLATED' | 'CROSS'; // Not support cross for the time being
 data?: 'RISK_LIMIT' | 'BORROW'; // Not support borrow for the time being
-
-================
-File: src/types/response/spot-affiliate.ts
-================
-export interface AffiliateTradeHistoryItem {
-  tradeTime: number; // Trade time (13-digit timestamp)
-  tradeType: string; // Trading type (e.g., "SPOT")
-  tradeCurrency: string; // Trade currency
-  tradeAmount: string; // Trade amount
-  tradeAmountU: string; // Trade amount in USDT
-  feeU: string; // Fee in USDT
-  commission: string; // Commission
-  currency: string; // Currency (e.g., "USDT")
-}
-⋮----
-tradeTime: number; // Trade time (13-digit timestamp)
-tradeType: string; // Trading type (e.g., "SPOT")
-tradeCurrency: string; // Trade currency
-tradeAmount: string; // Trade amount
-tradeAmountU: string; // Trade amount in USDT
-feeU: string; // Fee in USDT
-commission: string; // Commission
-currency: string; // Currency (e.g., "USDT")
-⋮----
-export interface AffiliateTradeHistory {
-  currentPage: number; // Current page number
-  pageSize: number; // Page size
-  totalNum: number; // Total number of records
-  totalPage: number; // Total number of pages
-  items: AffiliateTradeHistoryItem[]; // Array of trade history items
-}
-⋮----
-currentPage: number; // Current page number
-pageSize: number; // Page size
-totalNum: number; // Total number of records
-totalPage: number; // Total number of pages
-items: AffiliateTradeHistoryItem[]; // Array of trade history items
-⋮----
-export interface AffiliateCommissionItem {
-  siteType: string; // Source site of the commission
-  rebateType: 1 | 2; // Rebate type
-  payoutTime: number; // Commission payout time (T+1 settlement), 13-digit timestamp (UTC+8)
-  periodStartTime: number; // Start time of commission calculation period, 13-digit timestamp
-  periodEndTime: number; // End time of commission calculation period, 13-digit timestamp
-  status: 1 | 2 | 3 | 4; // Payout status
-  takerVolume: string; // Invitee's taker trading volume
-  makerVolume: string; // Invitee's maker trading volume
-  commission: string; // Total rebate contributed by the invitee
-  currency: string; // Denomination unit for trading volume/amount (USDT or USDC)
-}
-⋮----
-siteType: string; // Source site of the commission
-rebateType: 1 | 2; // Rebate type
-payoutTime: number; // Commission payout time (T+1 settlement), 13-digit timestamp (UTC+8)
-periodStartTime: number; // Start time of commission calculation period, 13-digit timestamp
-periodEndTime: number; // End time of commission calculation period, 13-digit timestamp
-status: 1 | 2 | 3 | 4; // Payout status
-takerVolume: string; // Invitee's taker trading volume
-makerVolume: string; // Invitee's maker trading volume
-commission: string; // Total rebate contributed by the invitee
-currency: string; // Denomination unit for trading volume/amount (USDT or USDC)
-⋮----
-export interface AffiliateInviteeItem {
-  uid: string; // UID of the invitee
-  nickName: string; // Nickname (partially hidden)
-  referralCode: string; // Referral code used for registration
-  country: string; // Country
-  registrationTime: number; // Registration time (13-digit timestamp)
-  completedKyc: boolean; // Whether KYC is completed
-  completedFirstDeposit: boolean; // Whether first deposit is completed
-  completedFirstTrade: boolean; // Whether first trade is completed
-  past7dFees: string; // Fees in the past 7 days
-  past7dCommission: string; // Commission in the past 7 days
-  totalCommission: string; // Total commission
-  myCommissionRate: string; // My commission rate (percentage)
-  cashbackRate: string; // Cashback rate (percentage)
-  currency: string; // Currency (e.g., "USDT")
-}
-⋮----
-uid: string; // UID of the invitee
-nickName: string; // Nickname (partially hidden)
-referralCode: string; // Referral code used for registration
-country: string; // Country
-registrationTime: number; // Registration time (13-digit timestamp)
-completedKyc: boolean; // Whether KYC is completed
-completedFirstDeposit: boolean; // Whether first deposit is completed
-completedFirstTrade: boolean; // Whether first trade is completed
-past7dFees: string; // Fees in the past 7 days
-past7dCommission: string; // Commission in the past 7 days
-totalCommission: string; // Total commission
-myCommissionRate: string; // My commission rate (percentage)
-cashbackRate: string; // Cashback rate (percentage)
-currency: string; // Currency (e.g., "USDT")
-⋮----
-export interface AffiliateInvitees {
-  currentPage: number; // Current page number
-  pageSize: number; // Page size
-  totalNum: number; // Total number of records
-  totalPage: number; // Total number of pages
-  items: AffiliateInviteeItem[]; // Array of invited user items
-}
-⋮----
-currentPage: number; // Current page number
-pageSize: number; // Page size
-totalNum: number; // Total number of records
-totalPage: number; // Total number of pages
-items: AffiliateInviteeItem[]; // Array of invited user items
-⋮----
-export interface AffiliateTransactionItem {
-  uid: string; // The uid of the invitee
-  tradeTime: number; // Trade time (13-digit timestamp)
-  tradeType: 'SPOT' | 'FEATURE'; // Trade type
-  tradeCurrency: string; // Trade currency
-  tradeAmount: string; // Trade amount
-  tradeAmountU: string; // Trade amount transfer to U(USDT or usdt)
-  feeU: string; // Fee transfer to U(USDT or usdt)
-  commission: string; // Trade commission
-  currency: 'USDT' | 'USDC'; // Transaction volume or amount converted to U
-}
-⋮----
-uid: string; // The uid of the invitee
-tradeTime: number; // Trade time (13-digit timestamp)
-tradeType: 'SPOT' | 'FEATURE'; // Trade type
-tradeCurrency: string; // Trade currency
-tradeAmount: string; // Trade amount
-tradeAmountU: string; // Trade amount transfer to U(USDT or usdt)
-feeU: string; // Fee transfer to U(USDT or usdt)
-commission: string; // Trade commission
-currency: 'USDT' | 'USDC'; // Transaction volume or amount converted to U
-⋮----
-export interface AffiliateTransaction {
-  items: AffiliateTransactionItem[]; // Array of transaction items
-  lastId: string; // The offset ID for pagination
-}
-⋮----
-items: AffiliateTransactionItem[]; // Array of transaction items
-lastId: string; // The offset ID for pagination
-⋮----
-export interface KuminingItem {
-  uid: string; // User Id
-  goodsName: string; // Product Name
-  amount: string; // Product amount
-  currency: string; // The currency
-  lastId: string; // Last Id
-  payTime: number; // Trade time
-}
-⋮----
-uid: string; // User Id
-goodsName: string; // Product Name
-amount: string; // Product amount
-currency: string; // The currency
-lastId: string; // Last Id
-payTime: number; // Trade time
-
-================
-File: src/types/response/uta-types.ts
-================
-/**
- * Unified Trading Account Response Types
- */
-⋮----
-export interface AnnouncementItemUTA {
-  id: number;
-  title: string;
-  type: string[];
-  description: string;
-  releaseTime: number;
-  language: string;
-  url: string;
-}
-⋮----
-export interface GetAnnouncementsResponseUTA {
-  totalNumber: number;
-  totalPage: number;
-  pageNumber: number;
-  pageSize: number;
-  list: AnnouncementItemUTA[];
-}
-⋮----
-export interface CurrencyChainUTA {
-  chainName: string;
-  minWithdrawSize: string | null;
-  minDepositSize: string | null;
-  withdrawFeeRate: string;
-  minWithdrawFee: string;
-  isWithdrawEnabled: boolean;
-  isDepositEnabled: boolean;
-  confirms: number;
-  preConfirms: number;
-  contractAddress: string;
-  withdrawPrecision: number;
-  maxWithdrawSize: string | null;
-  maxDepositSize: string | null;
-  needTag: boolean;
-  chainId: string;
-}
-⋮----
-export interface GetCurrencyResponseUTA {
-  currency: string;
-  name: string;
-  fullName: string;
-  precision: number;
-  confirms: number | null;
-  contractAddress: string | null;
-  isMarginEnabled: boolean;
-  isDebitEnabled: boolean;
-  list: CurrencyChainUTA[];
-}
-⋮----
-export interface SymbolUTA {
-  symbol: string;
-  name?: string;
-  baseCurrency: string;
-  quoteCurrency: string;
-  market?: string;
-  minBaseOrderSize?: string;
-  minQuoteOrderSize?: string;
-  maxBaseOrderSize?: string | number;
-  maxQuoteOrderSize?: string;
-  baseOrderStep?: string;
-  quoteOrderStep?: string;
-  tickSize?: string | number;
-  feeCurrency?: string;
-  tradingStatus?: string;
-  marginMode?: string;
-  priceLimitRatio?: string;
-  feeCategory?: number;
-  makerFeeCoefficient?: string;
-  takerFeeCoefficient?: string;
-  st?: boolean;
-  settlementCurrency?: string;
-  contractType?: string;
-  isInverse?: boolean;
-  launchTime?: number;
-  expiryTime?: number | null;
-  settlementTime?: number | null;
-  maxPrice?: string | number;
-  lotSize?: string | number;
-  /**
-   * Unit size. As of 2026.01.12:
-   * - For inverse contracts: changed from -1 to 1 (1 contract = 1 USD)
-   * - For Futures: unitSize indicates contract size
-   */
-  unitSize?: string | number;
-  makerFeeRate?: string | number;
-  takerFeeRate?: string | number;
-  settlementFeeRate?: string | number | null;
-  maxLeverage?: number;
-  indexSourceExchanges?: string[];
-  k?: string | number;
-  m?: string | number;
-  f?: string | number;
-  mmrLimit?: string | number;
-  mmrLevConstant?: string | number;
-  alertRiskRatio?: string;
-  liquidationRiskRatio?: string;
-  baseBorrowEnable?: boolean | string;
-  quoteBorrowEnable?: boolean | string;
-  baseTransferInEnable?: boolean | string;
-  quoteTransferInEnable?: boolean | string;
-  /** Display symbol for Futures (added 2025.12.26 & 2026.01.12) */
-  displaySymbol?: string;
-  /** Display base currency for Futures (added 2025.12.26 & 2026.01.12) */
-  displayBaseCurrency?: string;
-}
-⋮----
-/**
-   * Unit size. As of 2026.01.12:
-   * - For inverse contracts: changed from -1 to 1 (1 contract = 1 USD)
-   * - For Futures: unitSize indicates contract size
-   */
-⋮----
-/** Display symbol for Futures (added 2025.12.26 & 2026.01.12) */
-⋮----
-/** Display base currency for Futures (added 2025.12.26 & 2026.01.12) */
-⋮----
-export interface GetSymbolResponseUTA {
-  tradeType: string;
-  list: SymbolUTA[];
-}
-⋮----
-export interface TickerUTA {
-  symbol: string;
-  name?: string;
-  bestBidPrice: string;
-  bestBidSize: string;
-  bestAskPrice: string;
-  bestAskSize: string;
-  high: string;
-  low: string;
-  baseVolume: string;
-  quoteVolume: string;
-  lastPrice: string;
-  open: string;
-  size: string;
-}
-⋮----
-export interface GetTickerResponseUTA {
-  tradeType: string;
-  /** Timestamp in nanoseconds (as of 2026.01.12) */
-  ts: number;
-  list: TickerUTA[];
-}
-⋮----
-/** Timestamp in nanoseconds (as of 2026.01.12) */
-⋮----
-export interface TradeUTA {
-  sequence: string | number;
-  tradeId: string;
-  price: string;
-  size: string;
-  side: 'buy' | 'sell';
-  /** Timestamp in nanoseconds */
-  ts: number;
-  /** Whether it is an RPI trade (Futures only) */
-  isRpiTrade?: boolean;
-}
-⋮----
-/** Timestamp in nanoseconds */
-⋮----
-/** Whether it is an RPI trade (Futures only) */
-⋮----
-export interface GetTradesResponseUTA {
-  tradeType: string;
-  list: TradeUTA[];
-}
-⋮----
-export interface GetOrderBookResponseUTA {
-  tradeType: string;
-  symbol: string;
-  /** Sequence number. Changed from string to number for Spot as of 2026.01.17 */
-  sequence: number;
-  /**
-   * Bids array, ordered from high to low.
-   * When rpiFilter=0 (or not set): each entry is [price, size]
-   * When rpiFilter=1: each entry is [price, noneRPISize, RPISize]
-   * As of 2026.01.17: All values are strings
-   */
-  bids: string[][];
-  /**
-   * Asks array, ordered from low to high.
-   * When rpiFilter=0 (or not set): each entry is [price, size]
-   * When rpiFilter=1: each entry is [price, noneRPISize, RPISize]
-   * As of 2026.01.17: All values are strings
-   */
-  asks: string[][];
-  /** Timestamp in nanoseconds (Futures only) */
-  ts?: number;
-}
-⋮----
-/** Sequence number. Changed from string to number for Spot as of 2026.01.17 */
-⋮----
-/**
-   * Bids array, ordered from high to low.
-   * When rpiFilter=0 (or not set): each entry is [price, size]
-   * When rpiFilter=1: each entry is [price, noneRPISize, RPISize]
-   * As of 2026.01.17: All values are strings
-   */
-⋮----
-/**
-   * Asks array, ordered from low to high.
-   * When rpiFilter=0 (or not set): each entry is [price, size]
-   * When rpiFilter=1: each entry is [price, noneRPISize, RPISize]
-   * As of 2026.01.17: All values are strings
-   */
-⋮----
-/** Timestamp in nanoseconds (Futures only) */
-⋮----
-export interface GetKlinesResponseUTA {
-  tradeType: string;
-  symbol: string;
-  list: string[][]; // [time, open, close, high, low, volume, turnover]
-}
-⋮----
-list: string[][]; // [time, open, close, high, low, volume, turnover]
-⋮----
-export interface GetCurrentFundingRateResponseUTA {
-  symbol: string;
-  nextFundingRate: number;
-  fundingTime: number;
-  fundingRateCap: number;
-  fundingRateFloor: number;
-}
-⋮----
-export interface FundingRateHistoryItemUTA {
-  fundingRate: number;
-  ts: number;
-}
-⋮----
-export interface GetHistoryFundingRateResponseUTA {
-  symbol: string;
-  list: FundingRateHistoryItemUTA[];
-}
-⋮----
-export interface GetCrossMarginConfigResponseUTA {
-  maxLeverage: number;
-  alertRiskRatio: string;
-  liquidationRiskRatio: string;
-  currencyList: string[];
-}
-⋮----
-export interface GetServiceStatusResponseUTA {
-  tradeType: string;
-  serverStatus: 'open' | 'close' | 'cancelonly';
-  msg: string;
-}
-⋮----
-/**
- * Account Response Types
- */
-⋮----
-export interface AccountCurrencyUTA {
-  currency: string;
-  hold: string;
-  available: string;
-  balance: string;
-  equity: string;
-  liability?: string;
-  totalCrossMargin?: string;
-  crossPosMargin?: string;
-  crossOrderMargin?: string;
-  crossUnPnl?: string;
-  isolatedPosMargin?: string;
-  isolatedOrderMargin?: string;
-  isolatedFundingFeeMargin?: string;
-  isolatedUnPnl?: string;
-  liabilityPrinciple?: string;
-  liabilityInterest?: string;
-  unrealisedPnl?: string;
-}
-⋮----
-export interface AccountDataUTA {
-  accountSubtype?: string; // For ISOLATED (trading pair) or FUTURES (settlement currency)
-  riskRatio?: string;
-  currencies: AccountCurrencyUTA[];
-}
-⋮----
-accountSubtype?: string; // For ISOLATED (trading pair) or FUTURES (settlement currency)
-⋮----
-export interface GetClassicAccountResponseUTA {
-  accountType: string;
-  ts: number;
-  accounts: AccountDataUTA[];
-}
-⋮----
-export interface GetAccountOverviewResponseUTA {
-  accountType: string;
-  riskRatio: string;
-  equity: string;
-  liability: string;
-  availableMargin: string;
-  adjustedEquity: string;
-  im: string;
-  mm: string;
-}
-⋮----
-export interface SubAccountUserUTA {
-  uid: number;
-  accountList: {
-    accountType:
-      | 'FUNDING'
-      | 'SPOT'
-      | 'FUTURES'
-      | 'CROSS'
-      | 'ISOLATED'
-      | 'OPTIONS'
-      | 'UNIFIED';
-    accountSubType: string | null;
-    currencyList: AccountCurrencyUTA[];
-  }[];
-}
-⋮----
-export interface GetSubAccountResponseUTA {
-  ts: number;
-  userList: SubAccountUserUTA[];
-}
-⋮----
-export interface GetTransferQuotasResponseUTA {
-  currency: string;
-  transferable: string;
-  accountType: string;
-}
-⋮----
-export interface FlexTransferResponseUTA {
-  orderId: string;
-  clientOid: string;
-}
-⋮----
-export interface SubAccountTransferPermissionUTA {
-  subUid: string;
-  subToSub: boolean;
-}
-⋮----
-export interface GetAccountModeResponseUTA {
-  selfAccountMode: 'CLASSIC' | 'UNIFIED';
-  unifiedSubAccount: number[];
-  classicSubAccount: number[];
-}
-⋮----
-export interface FeeRateItemUTA {
-  symbol: string;
-  takerFeeRate: string;
-  makerFeeRate: string;
-}
-⋮----
-export interface GetFeeRateResponseUTA {
-  tradeType: string;
-  list: FeeRateItemUTA[];
-}
-⋮----
-export interface AccountLedgerItemUTA {
-  accountType:
-    | 'FUNDING'
-    | 'SPOT'
-    | 'FUTURES'
-    | 'CROSS'
-    | 'ISOLATED'
-    | 'UNIFIED';
-  id: string;
-  currency: string;
-  direction: 'IN' | 'OUT';
-  businessType: string;
-  amount: string;
-  balance: string;
-  fee: string;
-  tax: string;
-  remark: string;
-  /** Timestamp in nanoseconds (standardized as of 2026.01.12) */
-  ts: number;
-}
-⋮----
-/** Timestamp in nanoseconds (standardized as of 2026.01.12) */
-⋮----
-export interface GetAccountLedgerResponseUTA {
-  lastId?: number;
-  items?: AccountLedgerItemUTA[];
-}
-⋮----
-export type GetAccountLedgerResponseClassicUTA = AccountLedgerItemUTA[];
-⋮----
-export interface InterestHistoryItemUTA {
-  liability: string;
-  interest: string;
-  hourlyInterestRate: string;
-  currency: string;
-  ts: number;
-  interestFreeLiability: string;
-}
-⋮----
-export interface GetInterestHistoryResponseUTA {
-  items: InterestHistoryItemUTA[];
-  lastId: number;
-}
-⋮----
-export interface DepositAddressUTA {
-  address: string;
-  memo: string;
-  chainId: string;
-  to: 'MAIN' | 'TRADE';
-  currency: string;
-  contractAddress: string;
-  chainName: string;
-  expirationDate: string;
-  remark: string;
-}
-⋮----
-/**
- * Order Response Types
- */
-⋮----
-export interface PlaceOrderResponseUTA {
-  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS';
-  orderId: string;
-  clientOid: string;
-  /** Timestamp when system completes order request in nanoseconds. Classic mode not supported */
-  ts?: number;
-  /** Borrow amount. Unified mode not supported */
-  borrowSize?: string;
-  /** Loan order ID. Unified mode not supported */
-  loanApplyId?: string;
-}
-⋮----
-/** Timestamp when system completes order request in nanoseconds. Classic mode not supported */
-⋮----
-/** Borrow amount. Unified mode not supported */
-⋮----
-/** Loan order ID. Unified mode not supported */
-⋮----
-export interface BatchPlaceOrderItemResponseUTA {
-  orderId?: string;
-  clientOid?: string;
-  symbol?: string;
-  code?: string;
-  msg?: string;
-}
-⋮----
-export interface BatchPlaceOrderResponseUTA {
-  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS';
-  items: BatchPlaceOrderItemResponseUTA[];
-}
-⋮----
-export interface OrderDetailsUTA {
-  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS';
-  orderId: string;
-  clientOid: string;
-  /**
-   * Order status:
-   * - 0: notTriggered (conditional order, not triggered)
-   * - 1: triggered (conditional order, triggered but not live)
-   * - 2: live (not filled)
-   * - 3: filled (fully filled)
-   * - 4: partial filled (partially filled, still active)
-   * - 5: canceled (no fills, fully canceled)
-   * - 6: partial canceled (partially filled, remainder canceled)
-   * Changed from String to Number for UTA as of 2026.01.17
-   */
-  status: number;
-  filledSize: string;
-  avgPrice: string;
-  fee: string;
-  feeCurrency: string;
-  tax: string;
-  tradeId: string;
-  symbol: string;
-  side: 'BUY' | 'SELL';
-  positionSide?: 'BOTH' | 'LONG' | 'SHORT';
-  orderType: 'LIMIT' | 'MARKET';
-  size: string;
-  sizeUnit: 'BASECCY' | 'QUOTECCY' | 'UNIT';
-  price: string;
-  leverage?: string;
-  reduceOnly?: boolean;
-  marginMode?: 'ISOLATED' | 'CROSS';
-  stp?: 'DC' | 'CO' | 'CN' | 'CB' | '';
-  /**
-   * Time in Force. Added 'RPI' as of 2025.01.02
-   */
-  timeInForce: 'GTC' | 'IOC' | 'GTT' | 'FOK' | 'RPI';
-  cancelReason?: number;
-  cancelSize: string;
-  cancelAfter?: number;
-  triggerDirection?: 'UP' | 'DOWN';
-  triggerPrice?: string;
-  triggerPriceType?: 'TP' | 'IP' | 'MP';
-  tpTriggerPrice?: string;
-  tpTriggerPriceType?: 'TP' | 'IP' | 'MP';
-  tpOrderPrice?: string;
-  slTriggerPrice?: string;
-  slTriggerPriceType?: 'TP' | 'IP' | 'MP';
-  slOrderPrice?: string;
-  postOnly?: boolean;
-  tags?: string;
-  triggerOrderId?: string;
-  /** Order creation time in nanoseconds (standardized as of 2026.01.12) */
-  orderTime: number;
-  /** Latest order update time in nanoseconds (standardized as of 2026.01.12) */
-  updatedTime: number;
-}
-⋮----
-/**
-   * Order status:
-   * - 0: notTriggered (conditional order, not triggered)
-   * - 1: triggered (conditional order, triggered but not live)
-   * - 2: live (not filled)
-   * - 3: filled (fully filled)
-   * - 4: partial filled (partially filled, still active)
-   * - 5: canceled (no fills, fully canceled)
-   * - 6: partial canceled (partially filled, remainder canceled)
-   * Changed from String to Number for UTA as of 2026.01.17
-   */
-⋮----
-/**
-   * Time in Force. Added 'RPI' as of 2025.01.02
-   */
-⋮----
-/** Order creation time in nanoseconds (standardized as of 2026.01.12) */
-⋮----
-/** Latest order update time in nanoseconds (standardized as of 2026.01.12) */
-⋮----
-export interface GetOpenOrderListResponseUTA {
-  pageNumber: number;
-  pageSize?: number;
-  totalNum?: number;
-  totalPage?: number;
-  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS';
-  items: OrderDetailsUTA[];
-}
-⋮----
-export interface GetOrderHistoryResponseUTA {
-  lastId: number;
-  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS';
-  items: OrderDetailsUTA[];
-}
-⋮----
-export interface TradeHistoryItemUTA {
-  tradeId: string;
-  orderId: string;
-  symbol: string;
-  side: 'BUY' | 'SELL';
-  positionSide?: 'BOTH' | 'LONG' | 'SHORT';
-  type: 'LIMIT' | 'MARKET';
-  price: string;
-  size: string;
-  sizeUnit: 'BASECCY' | 'QUOTECCY' | 'UNIT';
-  value: string;
-  feeRate: string;
-  fee: string;
-  feeCurrency: string;
-  tax: string;
-  liquidity: 'TAKER' | 'MAKER';
-  /** Execution time in nanoseconds (standardized as of 2026.01.12) */
-  executionTime: number;
-  /** Whether it is an RPI trade (added 2025.01.02, Futures only) */
-  isRpiTrade?: boolean;
-}
-⋮----
-/** Execution time in nanoseconds (standardized as of 2026.01.12) */
-⋮----
-/** Whether it is an RPI trade (added 2025.01.02, Futures only) */
-⋮----
-export interface GetTradeHistoryResponseUTA {
-  lastId: number;
-  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS';
-  items: TradeHistoryItemUTA[];
-}
-⋮----
-export interface CancelOrderResponseUTA {
-  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS';
-  orderId?: string;
-  clientOid?: string;
-  /** Timestamp when system completes order cancellation request (nanoseconds). Only for unified accounts */
-  ts?: number;
-}
-⋮----
-/** Timestamp when system completes order cancellation request (nanoseconds). Only for unified accounts */
-⋮----
-export interface BatchCancelOrderItemResponseUTA {
-  code?: string;
-  msg?: string;
-  orderId?: string;
-  clientOid?: string;
-  /** Timestamp when system completes order cancellation request (nanoseconds). Not supported for classic accounts */
-  ts?: number;
-}
-⋮----
-/** Timestamp when system completes order cancellation request (nanoseconds). Not supported for classic accounts */
-⋮----
-export interface BatchCancelOrdersResponseUTA {
-  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS';
-  items: BatchCancelOrderItemResponseUTA[];
-}
-⋮----
-export interface DCPResponseUTA {
-  tradeType: 'SPOT' | 'FUTURES' | 'MARGIN';
-  symbol: string[]; // Empty means effective for all symbols
-  systemTime: number; // Time when system received request (in seconds)
-  triggerTime: number; // Trigger cancellation time (in seconds)
-}
-⋮----
-symbol: string[]; // Empty means effective for all symbols
-systemTime: number; // Time when system received request (in seconds)
-triggerTime: number; // Trigger cancellation time (in seconds)
-⋮----
-/**
- * Position Response Types
- */
-⋮----
-export interface PositionUTA {
-  id: string;
-  symbol: string;
-  marginMode: 'CROSS' | 'ISOLATED';
-  size: string; // Positive = long, negative = short
-  entryPrice: string;
-  positionValue: string;
-  markPrice: string;
-  leverage: string;
-  unrealizedPnL: string;
-  realizedPnL: string;
-  initialMargin: string;
-  mmr: string; // Maintenance Margin Rate
-  maintenanceMargin: string;
-  /** Timestamp when position was first opened (nanoseconds, standardized as of 2026.01.12) */
-  creationTime: number;
-}
-⋮----
-size: string; // Positive = long, negative = short
-⋮----
-mmr: string; // Maintenance Margin Rate
-⋮----
-/** Timestamp when position was first opened (nanoseconds, standardized as of 2026.01.12) */
-⋮----
-export interface PositionHistoryItemUTA {
-  closeId: string;
-  symbol: string;
-  marginMode: 'CROSS' | 'ISOLATED';
-  side: 'LONG' | 'SHORT';
-  entryPrice: string;
-  closePrice: string;
-  avgClosePrice: string;
-  maxSize: string;
-  leverage: string;
-  realizedPnL: string;
-  fee: string;
-  tax: string;
-  fundingFee: string;
-  /** Position opening timestamp (nanoseconds, standardized as of 2026.01.12) */
-  creationTime: number;
-  /** Position closing timestamp (nanoseconds, standardized as of 2026.01.12) */
-  closingTime: number;
-}
-⋮----
-/** Position opening timestamp (nanoseconds, standardized as of 2026.01.12) */
-⋮----
-/** Position closing timestamp (nanoseconds, standardized as of 2026.01.12) */
-⋮----
-export interface GetPositionsHistoryResponseUTA {
-  items: PositionHistoryItemUTA[];
-  lastId?: number;
-}
-⋮----
-export interface PositionTierUTA {
-  symbol: string;
-  tier: number; // Current tier of user
-  maxSize: string; // Upper limit (USDT) (included)
-  minSize: string; // Lower limit (USDT)
-  maxLeverage: string;
-  initialMarginRate: string;
-  maintainMarginRate: string;
-}
-⋮----
-tier: number; // Current tier of user
-maxSize: string; // Upper limit (USDT) (included)
-minSize: string; // Lower limit (USDT)
-
-================
-File: src/types/websockets/ws-events.ts
-================
-export interface WsDataEvent<TData = any, TWSKey = string> {
-  data: TData;
-  table: string;
-  wsKey: TWSKey;
-}
-⋮----
-export interface MessageEventLike<TDataType = string> {
-  target: WebSocket;
-  type: 'message';
-  data: TDataType;
-}
-⋮----
-export function isMessageEvent(msg: unknown): msg is MessageEventLike
-
-================
-File: examples/WebSockets/ws-private-pro-v2.ts
-================
-import {
-  WebsocketClient,
-  WS_KEY_MAP,
-  WsTopicRequest,
-} from '../../src/index.js';
-// import { DefaultLogger, WebsocketClient } from 'kucoin-api';
-// normally you should install this module via npm: `npm install kucoin-api`
-⋮----
-async function start()
-⋮----
-// Optional: inject a custom logger to override internal logging behaviour
-// const logger: typeof DefaultLogger = {
-//   ...DefaultLogger,
-//   trace: (...params) => {
-//     // Simple way to exclude certain messages from trace logs
-//     if (
-//       [
-//         'Sending ping',
-//         // 'Sending upstream ws message: ',
-//         'Received pong',
-//         'Decompressed message event from buffer',
-//       ].includes(params[0])
-//     ) {
-//       return;
-//     }
-//     console.log('trace', JSON.stringify(params, null, 2));
-//   },
-// };
-⋮----
-passphrase: process.env.API_PASSPHRASE || 'apiPassPhraseHere', // This is NOT your account password
-⋮----
-// logger,
-⋮----
-// Data received
-⋮----
-// Something happened, attempting to reconenct
-⋮----
-// Reconnect successful
-⋮----
-// Connection closed. If unexpected, expect reconnect -> reconnected.
-⋮----
-// Reply to a request, e.g. "subscribe"/"unsubscribe"/"authenticate"
-⋮----
-// throw new Error('res?');
-⋮----
-/**
-   * The below examples demonstrate consuming private V2 (Pro) WebSocket topics.
-   * For V1 private WebSocket examples, see ws-private-spot-v1.ts and ws-private-futures-v1.ts
-   */
-⋮----
-// Optional: await a connection to be ready before subscribing (this is not necessary)
-// await client.connect(WS_KEY_MAP.privateProV2);
-// console.log('connected');
-⋮----
-/**
-     * Structure your requests into the following format. The below example will be sent as per the example in the docs. The parameters are automatically merged into the request. Just follow the example below:
-     * {
-     *   "id": "1545910660739", // OPTIONAL
-     *   "action": "SUBSCRIBE", // or UNSUBSCRIBE
-     *   "channel":"orderAll", //
-     *   "tradeType": "SPOT" // SPOT / FUTURES / ISOLATED / CROSS / UNIFIED
-     * }
-     *
-     * https://www.kucoin.com/docs-new/3470228w0
-     */
-⋮----
-/**
-       * Anything in the payload will be merged into the subscribe "request", allowing you to send misc parameters supported by the exchange.
-       * For more info on parameters, see: https://www.kucoin.com/docs-new/websocket-api/base-info/introduction-uta#5-subscribe
-       */
-⋮----
-tradeType: 'SPOT', // SPOT / FUTURES / ISOLATED / CROSS / UNIFIED
-⋮----
-// Or, subscribe to multiple topics at once:
-⋮----
-// Other markets for orderAll topic:
-// https://www.kucoin.com/docs-new/3470228w0
-⋮----
-tradeType: 'FUTURES', // SPOT / FUTURES / ISOLATED / CROSS / UNIFIED
-⋮----
-// Specific order updates for a given symbol:
-// https://www.kucoin.com/docs-new/3470228w0
-⋮----
-tradeType: 'SPOT', // SPOT / FUTURES / ISOLATED / CROSS / UNIFIED
-⋮----
-// Futures positions:
-// https://www.kucoin.com/docs-new/3470233w0
-⋮----
-tradeType: 'FUTURES', //  FUTURES / UNIFIED
-⋮----
-tradeType: 'FUTURES', //  FUTURES / UNIFIED
-⋮----
-// Account balance updates:
-// https://www.kucoin.com/docs-new/3470231w0
-⋮----
-accountType: 'TRADING', // TRADING / ISOLATED / CROSS / FUTURES / UNIFIED
-⋮----
-// Execution/trade updates:
-// https://www.kucoin.com/docs-new/3470232w0
-⋮----
-tradeType: 'SPOT', // SPOT / ISOLATED / CROSS / FUTURES / UNIFIED
-⋮----
-// Liquidation warnings:
-// https://www.kucoin.com/docs-new/3470236w0
-⋮----
-// Leverage updates:
-// https://www.kucoin.com/docs-new/3470237w0
-
-================
-File: examples/WebSockets/ws-public-futures-pro-v2.ts
-================
-/* eslint-disable no-unused-vars */
-import {
-  WebsocketClient,
-  WS_KEY_MAP,
-  WsTopicRequest,
-} from '../../src/index.js';
-// import { DefaultLogger, WebsocketClient, WsTopicRequest } from 'kucoin-api';
-// normally you should install this module via npm: `npm install kucoin-api`
-⋮----
-async function start()
-⋮----
-// Optional: fully customise the logging experience by injecting a custom logger
-// const logger: typeof DefaultLogger = {
-//   ...DefaultLogger,
-//   trace: (...params) => {
-//     if (
-//       [
-//         'Sending ping',
-//         'Sending upstream ws message: ',
-//         'Received pong',
-//         'Decompressed message event from buffer',
-//       ].includes(params[0])
-//     ) {
-//       return;
-//     }
-//     console.log('trace', params);
-//   },
-// };
-⋮----
-// const client = new WebsocketClient({}, logger);
-⋮----
-// Data received
-⋮----
-// Something happened, attempting to reconenct
-⋮----
-// Reconnect successful
-⋮----
-// Connection closed. If unexpected, expect reconnect -> reconnected.
-⋮----
-// Reply to a request, e.g. "subscribe"/"unsubscribe"/"authenticate"
-⋮----
-// throw new Error('res?');
-⋮----
-/**
-   * The following example demonstrates the ways to consume data from the V2 (Pro) WebSockets. For the V1 examples, ws-public-futures-v1.ts
-   */
-⋮----
-// Optional: await a connection to be ready before subscribing (this is not necessary)
-// await client.connect(WS_KEY_MAP.futuresPublicProV2);
-⋮----
-/**
-     * Structure your requests into the following format. The below example will be sent as per the example in the docs. The parameters are automatically merged into the request. Just follow the example below:
-     * {
-     *    "id": "1545910660739", // automatically generated by SDK
-     *    "action": "SUBSCRIBE", // automatically added by SDK
-     *    "channel":"kline",
-     *    "tradeType": "FUTURES",       // SPOT / FUTURES
-     *    "symbol": "XBTUSDTM",
-     *    "interval": "1min"
-     * }
-     *
-     * https://www.kucoin.com/docs-new/3470223w0
-     */
-⋮----
-/**
-       * Anything in the payload will be merged into the subscribe "request", allowing you to send misc parameters supported by the exchange.
-       * For more info on parameters, see: https://www.kucoin.com/docs-new/websocket-api/base-info/introduction-uta#5-subscribe
-       */
-⋮----
-// this needs to match the WsKey below.
-// tradeType: SPOT ==> spotPublicProV2
-// tradeType: FUTURES ==> futuresPublicProV2
-⋮----
-/**
-     * Or, send an array of structured objects with parameters, if you wanted to send multiple in one request
-     *
-     */
-⋮----
-// BTCUSDT tickers for FUTURES market
-// https://www.kucoin.com/docs-new/3470222w0
-⋮----
-// BTCUSDT orderbook updates for FUTURES market
-// https://www.kucoin.com/docs-new/3470221w0
-⋮----
-depth: '5', // 1 / 5 / 50 / increment
-rpiFilter: 0, // 0：Only NoneRPI orders [Default]  1(Only Support Futures)：NoneRPI+ RPI Orders. When rpiFilter=1, "depth" only supports 5/50.
-⋮----
-// BTCUSDT trades for spot market
-// https://www.kucoin.com/docs-new/3470224w0
-
-================
-File: examples/WebSockets/ws-public-spot-pro-v2.ts
-================
-/* eslint-disable no-unused-vars */
-import {
-  WebsocketClient,
-  WS_KEY_MAP,
-  WsTopicRequest,
-} from '../../src/index.js';
-// import { DefaultLogger, WebsocketClient, WsTopicRequest } from 'kucoin-api';
-// normally you should install this module via npm: `npm install kucoin-api`
-⋮----
-async function start()
-⋮----
-// Optional: fully customise the logging experience by injecting a custom logger
-// const logger: typeof DefaultLogger = {
-//   ...DefaultLogger,
-//   trace: (...params) => {
-//     if (
-//       [
-//         'Sending ping',
-//         'Sending upstream ws message: ',
-//         'Received pong',
-//       ].includes(params[0])
-//     ) {
-//       return;
-//     }
-//     console.log('trace', params);
-//   },
-// };
-⋮----
-// const client = new WebsocketClient({}, logger);
-⋮----
-// Data received
-⋮----
-// Something happened, attempting to reconenct
-⋮----
-// Reconnect successful
-⋮----
-// Connection closed. If unexpected, expect reconnect -> reconnected.
-⋮----
-// Reply to a request, e.g. "subscribe"/"unsubscribe"/"authenticate"
-⋮----
-// throw new Error('res?');
-⋮----
-/**
-   * The following example demonstrates the ways to consume data from the V2 (Pro) WebSockets. For the V1 examples, ws-private-spot-v1.ts
-   */
-⋮----
-// Optional: await a connection to be ready before subscribing (this is not necessary)
-// await client.connect(WS_KEY_MAP.spotPublicProV2);
-⋮----
-/**
-     * Structure your requests into the following format. The below example will be sent as per the example in the docs. The parameters are automatically merged into the request. Just follow the example below:
-     * {
-     *    "id": "1545910660739", // automatically generated by SDK
-     *    "action": "SUBSCRIBE", // automatically added by SDK
-     *    "channel":"kline",
-     *    "tradeType": "SPOT",       // SPOT / FUTURES
-     *    "symbol": "BTC-USDT",
-     *    "interval": "1min"
-     * }
-     *
-     * https://www.kucoin.com/docs-new/3470223w0
-     */
-⋮----
-/**
-       * Anything in the payload will be merged into the subscribe "request", allowing you to send misc parameters supported by the exchange.
-       * For more info on parameters, see: https://www.kucoin.com/docs-new/websocket-api/base-info/introduction-uta#5-subscribe
-       */
-⋮----
-// this needs to match the WsKey below.
-// tradeType: SPOT ==> spotPublicProV2
-// tradeType: FUTURES ==> futuresPublicProV2
-⋮----
-/**
-     * Or, send an array of structured objects with parameters, if you wanted to send multiple in one request
-     *
-     */
-⋮----
-// BTCUSDT tickers for spot market
-// https://www.kucoin.com/docs-new/3470222w0
-⋮----
-// BTCUSDT orderbook updates for spot market
-// https://www.kucoin.com/docs-new/3470221w0
-⋮----
-depth: '5', // 1 / 5 / 50 / increment
-rpiFilter: 0, // 0：Only NoneRPI orders [Default]  1(Only Support Futures)：NoneRPI+ RPI Orders. When rpiFilter=1, "depth" only supports 5/50.
-⋮----
-// BTCUSDT trades for spot market
-// https://www.kucoin.com/docs-new/3470224w0
-
-================
-File: src/lib/BaseRestClient.ts
-================
-import axios, { AxiosRequestConfig, AxiosResponse, Method } from 'axios';
-// NOTE: https.Agent is Node.js-only and not available in browser environments
-// Browser builds (via webpack) exclude this module - see webpack.config.js fallback settings
-import https from 'https';
-⋮----
-import { neverGuard } from './misc-util.js';
-import {
-  APIIDFutures,
-  APIIDFuturesSign,
-  APIIDMain,
-  APIIDMainSign,
-  getRestBaseUrl,
-  REST_CLIENT_TYPE_ENUM,
-  RestClientOptions,
-  RestClientType,
-  serializeParams,
-} from './requestUtils.js';
-import {
-  checkWebCryptoAPISupported,
-  SignAlgorithm,
-  SignEncodeMethod,
-  signMessage,
-} from './webCryptoAPI.js';
-⋮----
-export interface SignedRequest<T extends object | undefined = {}> {
-  originalParams: T;
-  paramsWithSign?: T & { sign: string };
-  serializedParams: string;
-  sign: string;
-  queryParamsWithSign: string;
-  timestamp: number;
-  recvWindow: number;
-}
-⋮----
-interface UnsignedRequest<T extends object | undefined = {}> {
-  originalParams: T;
-  paramsWithSign: T;
-}
-⋮----
-type SignMethod = 'kucoin';
-⋮----
-// request: {
-//   url: response.config.url,
-//   method: response.config.method,
-//   data: response.config.data,
-//   headers: response.config.headers,
-// },
-⋮----
-export abstract class BaseRestClient
-⋮----
-/** Defines the client type (affecting how requests & signatures behave) */
-abstract getClientType(): RestClientType;
-⋮----
-/**
-   * Create an instance of the REST client. Pass API credentials in the object in the first parameter.
-   * @param {RestClientOptions} [restClientOptions={}] options to configure REST API connectivity
-   * @param {AxiosRequestConfig} [networkOptions={}] HTTP networking options for axios
-   */
-constructor(
-    restClientOptions: RestClientOptions = {},
-    networkOptions: AxiosRequestConfig = {},
-)
-⋮----
-/** Throw errors if any request params are empty */
-⋮----
-/** in ms == 5 minutes by default */
-⋮----
-/** inject custom rquest options based on axios specs - see axios docs for more guidance on AxiosRequestConfig: https://github.com/axios/axios#request-config */
-⋮----
-// If enabled, configure a https agent with keepAlive enabled
-// NOTE: This is Node.js-only functionality. In browser environments, this code is skipped
-// as the 'https' module is excluded via webpack fallback configuration.
-// Browser connection pooling is handled automatically by the browser itself.
-⋮----
-// Extract existing https agent parameters, if provided, to prevent the keepAlive flag from overwriting an existing https agent completely
-⋮----
-// For more advanced configuration, raise an issue on GitHub or use the "networkOptions"
-// parameter to define a custom httpsAgent with the desired properties
-⋮----
-// Check Web Crypto API support when credentials are provided
-⋮----
-// Throw if one of the 3 values is missing, but at least one of them is set
-⋮----
-/**
-   * Generates a timestamp for signing API requests.
-   *
-   * This method can be overridden or customized using `customTimestampFn`
-   * to implement a custom timestamp synchronization mechanism.
-   * If no custom function is provided, it defaults to the current system time.
-   */
-private getSignTimestampMs(): number
-⋮----
-private hasValidCredentials()
-⋮----
-setAccessToken(newAccessToken: string)
-⋮----
-hasAccessToken(): boolean
-⋮----
-get(endpoint: string, params?: any)
-⋮----
-post(endpoint: string, params?: any)
-⋮----
-getPrivate(endpoint: string, params?: any)
-⋮----
-postPrivate(endpoint: string, params?: any)
-⋮----
-deletePrivate(endpoint: string, params?: any)
-⋮----
-/**
-   * @private Make a HTTP request to a specific endpoint. Private endpoint API calls are automatically signed.
-   */
-private async _call(
-    method: Method,
-    endpoint: string,
-    params?: any,
-    isPublicApi?: boolean,
-): Promise<any>
-⋮----
-// Sanity check to make sure it's only ever prefixed by one forward slash
-⋮----
-// Build a request and handle signature process
-⋮----
-// Dispatch request
-⋮----
-// Throw if API returns an error (e.g. insufficient balance)
-⋮----
-/**
-   * @private generic handler to parse request exceptions
-   */
-parseException(e: any, requestParams: any): unknown
-⋮----
-// Something happened in setting up the request that triggered an error
-⋮----
-// request made but no response received
-⋮----
-// The request was made and the server responded with a status code
-// that falls out of the range of 2xx
-⋮----
-// console.error('err: ', response?.data);
-⋮----
-// Prevent credentials from leaking into error messages
-⋮----
-private async signMessage(
-    paramsStr: string,
-    secret: string,
-    method: SignEncodeMethod,
-    algorithm: SignAlgorithm,
-): Promise<string>
-⋮----
-/**
-   * @private sign request and set recv window
-   */
-private async signRequest<T extends object | undefined = {}>(
-    data: T,
-    endpoint: string,
-    method: Method,
-    signMethod: SignMethod,
-): Promise<SignedRequest<T>>
-⋮----
-// Only sign when no access token is provided
-⋮----
-private async prepareSignParams<TParams extends object | undefined>(
-    method: Method,
-    endpoint: string,
-    signMethod: SignMethod,
-    params?: TParams,
-    isPublicApi?: true,
-  ): Promise<UnsignedRequest<TParams>>;
-⋮----
-private async prepareSignParams<TParams extends object | undefined>(
-    method: Method,
-    endpoint: string,
-    signMethod: SignMethod,
-    params?: TParams,
-    isPublicApi?: false | undefined,
-  ): Promise<SignedRequest<TParams>>;
-⋮----
-private async prepareSignParams<TParams extends object | undefined>(
-    method: Method,
-    endpoint: string,
-    signMethod: SignMethod,
-    params?: TParams,
-    isPublicApi?: boolean,
-)
-⋮----
-/** Returns an axios request object. Handles signing process automatically if this is a private API call */
-private async buildRequest(
-    method: Method,
-    endpoint: string,
-    url: string,
-    params?: any,
-    isPublicApi?: boolean,
-): Promise<AxiosRequestConfig>
-⋮----
-// Support for Authorization header, if provided:
-// https://github.com/tiagosiebler/kucoin-api/issues/2
-// Use restClient.setAccessToken(newToken), if you need to store a new access token
-
-================
-File: src/types/request/futures.types.ts
-================
-/**
- * REST - ACCOUNT  - BASIC INFO
- * Get Account Ledgers - Futures
- */
-⋮----
-export interface GetTransactionsRequest {
-  startAt?: number;
-  endAt?: number;
-  type?:
-    | 'RealisedPNL'
-    | 'Deposit'
-    | 'Withdrawal'
-    | 'Transferin'
-    | 'TransferOut';
-  offset?: number;
-  maxCount?: number;
-  currency?: string;
-  forward?: boolean;
-}
-⋮----
-/**
- * REST - ACCOUNT  - SUBACCOUNT API
- */
-⋮----
-export interface GetSubAPIsRequest {
-  apiKey?: string;
-  subName: string;
-}
-⋮----
-export interface CreateSubAPIRequest {
-  subName: string;
-  passphrase: string;
-  remark: string;
-  permission?: string;
-  ipWhitelist?: string;
-  expire?: string;
-}
-⋮----
-export interface UpdateSubAPIRequest {
-  subName: string;
-  apiKey: string;
-  passphrase: string;
-  permission?: string;
-  ipWhitelist?: string;
-  expire?: string;
-}
-⋮----
-export interface DeleteSubAPIRequest {
-  apiKey: string;
-  passphrase: string;
-  subName: string;
-}
-⋮----
-/**
- * REST - FUNDING - FUNDING OVERVIEW
- */
-⋮----
-/**
- * REST - FUNDING - TRANSFER
- */
-⋮----
-export interface SubmitTransfer {
-  amount: number;
-  currency: string;
-  recAccountType: 'MAIN' | 'TRADE';
-}
-⋮----
-export interface GetTransfersRequest {
-  startAt?: number;
-  endAt?: number;
-  status?: 'PROCESSING' | 'SUCCESS' | 'FAILURE';
-  queryStatus?: 'PROCESSING' | 'SUCCESS' | 'FAILURE'[];
-  currency?: string;
-  currentPage?: number;
-  pageSize?: number;
-}
-⋮----
-/**
- *
- * Futures Market Data
- *
- */
-⋮----
-export interface GetKlinesRequest {
-  symbol: string;
-  granularity: number;
-  from?: number;
-  to?: number;
-}
-⋮----
-export interface GetInterestRatesRequest {
-  symbol: string;
-  startAt?: number;
-  endAt?: number;
-  reverse?: boolean;
-  offset?: number;
-  forward?: boolean;
-  maxCount?: number;
-}
-⋮----
-/**
- *
- ***********
- * Account
- ***********
- *
- */
-⋮----
-/**
- *
- * Orders
- *
- */
-⋮----
-export interface Order {
-  clientOid: string;
-  side: 'buy' | 'sell';
-  symbol: string;
-  leverage?: number;
-  type?: 'limit' | 'market';
-  remark?: string;
-  stop?: 'down' | 'up';
-  stopPriceType?: 'TP' | 'MP' | 'IP';
-  stopPrice?: string;
-  reduceOnly?: boolean;
-  closeOrder?: boolean;
-  forceHold?: boolean;
-  stp?: 'CN' | 'CO' | 'CB';
-  marginMode?: 'ISOLATED' | 'CROSS';
-  price?: string;
-  size?: number;
-  qty?: string;
-  valueQty?: string;
-  /**
-   * Time in Force. Added 'RPI' as of 2025.01.02
-   * - GTC: Good Till Cancel (default)
-   * - IOC: Immediate Or Cancel
-   * - RPI: Retail Price Improvement Order (Phase 1: Futures only)
-   */
-  timeInForce?: 'GTC' | 'IOC' | 'RPI';
-  postOnly?: boolean;
-  hidden?: boolean;
-  iceberg?: boolean;
-  visibleSize?: string;
-  positionSide?: 'BOTH' | 'LONG' | 'SHORT';
-}
-⋮----
-/**
-   * Time in Force. Added 'RPI' as of 2025.01.02
-   * - GTC: Good Till Cancel (default)
-   * - IOC: Immediate Or Cancel
-   * - RPI: Retail Price Improvement Order (Phase 1: Futures only)
-   */
-⋮----
-export interface SLTPOrder {
-  clientOid: string;
-  side: 'buy' | 'sell';
-  symbol: string;
-  leverage?: number;
-  type: 'limit' | 'market';
-  remark?: string;
-  triggerStopUpPrice?: string;
-  stopPriceType?: 'TP' | 'MP' | 'IP';
-  triggerStopDownPrice?: string;
-  reduceOnly?: boolean;
-  closeOrder?: boolean;
-  forceHold?: boolean;
-  stp?: 'CN' | 'CO' | 'CB';
-  marginMode?: 'ISOLATED' | 'CROSS';
-  price?: string;
-  size?: number;
-  qty?: string;
-  valueQty?: string;
-  /**
-   * Time in Force. Added 'RPI' as of 2025.01.02
-   * - GTC: Good Till Cancel (default)
-   * - IOC: Immediate Or Cancel
-   * - RPI: Retail Price Improvement Order (Phase 1: Futures only)
-   */
-  timeInForce?: 'GTC' | 'IOC' | 'RPI';
-  postOnly?: boolean;
-  hidden?: boolean;
-  iceberg?: boolean;
-  visibleSize?: string;
-}
-⋮----
-/**
-   * Time in Force. Added 'RPI' as of 2025.01.02
-   * - GTC: Good Till Cancel (default)
-   * - IOC: Immediate Or Cancel
-   * - RPI: Retail Price Improvement Order (Phase 1: Futures only)
-   */
-⋮----
-export interface GetOrdersRequest {
-  status: 'active' | 'done';
-  symbol?: string;
-  side: 'buy' | 'sell';
-  type: 'limit' | 'market' | 'limit_stop' | 'market_stop';
-  startAt?: number;
-  endAt?: number;
-  currentPage?: number;
-  pageSize?: number;
-}
-⋮----
-export interface GetStopOrdersRequest {
-  symbol?: string;
-  side?: 'buy' | 'sell';
-  type?: 'limit' | 'market';
-  startAt?: number;
-  endAt?: number;
-  currentPage?: number;
-  pageSize?: number;
-}
-⋮----
-// Note: Either orderIdsList or clientOidsList must be provided, but not both.
-// When both are provided, orderIdsList takes precedence.
-export interface BatchCancelOrdersRequest {
-  orderIdsList?: string[];
-  clientOidsList?: {
-    symbol: string;
-    clientOid: string;
-  }[];
-}
-⋮----
-/**
- *
- * Futures Fills
- *
- */
-⋮----
-export interface AccountFillsRequest {
-  orderId?: string;
-  symbol?: string;
-  side?: 'buy' | 'sell';
-  type?: 'limit' | 'market' | 'limit_stop' | 'market_stop';
-  startAt?: number;
-  endAt?: number;
-  currentPage?: number;
-  pageSize?: number;
-  tradeTypes?: string;
-}
-⋮----
-/**
- *
- * Futures Positions
- *
- */
-⋮----
-export interface MaxOpenSizeRequest {
-  symbol: string;
-  price: string;
-  leverage: number;
-}
-⋮----
-/**
- *
- * Futures risk limit
- *
- */
-⋮----
-/**
- *
- * Futures funding fees
- *
- */
-⋮----
-export interface GetFundingRatesRequest {
-  symbol: string;
-  from: number;
-  to: number;
-}
-⋮----
-export interface GetFundingHistoryRequest {
-  symbol: string;
-  from?: number;
-  to?: number;
-  reverse?: boolean;
-  offset?: number;
-  forward?: boolean;
-  maxCount?: number;
-}
-⋮----
-/**
- *
- * Futures Copy Trading
- *
- */
-⋮----
-export interface CopyTradeOrderRequest {
-  clientOid: string;
-  side: 'buy' | 'sell';
-  symbol: string;
-  type: 'limit' | 'market';
-  leverage?: number;
-  remark?: string;
-  stop?: 'up' | 'down';
-  stopPriceType?: 'TP' | 'MP' | 'IP';
-  stopPrice?: string;
-  reduceOnly?: boolean;
-  closeOrder?: boolean;
-  forceHold?: boolean;
-  marginMode?: 'ISOLATED' | 'CROSS';
-  positionSide?: 'BOTH' | 'LONG' | 'SHORT';
-  price?: string;
-  size: number;
-  /**
-   * Time in Force. Added 'RPI' as of 2025.01.02
-   * - GTC: Good Till Cancel (default)
-   * - IOC: Immediate Or Cancel
-   * - RPI: Retail Price Improvement Order (Phase 1: Futures only)
-   */
-  timeInForce?: 'GTC' | 'IOC' | 'RPI';
-  postOnly?: boolean;
-  hidden?: boolean;
-  iceberg?: boolean;
-  visibleSize?: string;
-}
-⋮----
-/**
-   * Time in Force. Added 'RPI' as of 2025.01.02
-   * - GTC: Good Till Cancel (default)
-   * - IOC: Immediate Or Cancel
-   * - RPI: Retail Price Improvement Order (Phase 1: Futures only)
-   */
-⋮----
-export interface CopyTradeSLTPOrderRequest extends CopyTradeOrderRequest {
-  triggerStopUpPrice?: string; // Take profit price
-  triggerStopDownPrice?: string; // Stop loss price
-  stopPriceType?: 'TP' | 'MP' | 'IP';
-}
-⋮----
-triggerStopUpPrice?: string; // Take profit price
-triggerStopDownPrice?: string; // Stop loss price
-⋮----
-/**
- * Switch Margin Mode (Copy Trading)
- */
-export interface CopyTradeSwitchMarginModeRequest {
-  symbol: string;
-  marginMode: 'ISOLATED' | 'CROSS';
-}
-⋮----
-/**
- * Modify Cross Margin Leverage (Copy Trading)
- */
-export interface CopyTradeChangeCrossMarginLeverageRequest {
-  symbol: string;
-  leverage: string;
-}
-⋮----
-/**
- * Get Cross Margin Requirement (Copy Trading)
- */
-export interface CopyTradeGetCrossMarginRequirementRequest {
-  symbol: string;
-  positionValue: string;
-  leverage?: string;
-}
-⋮----
-/**
- * Switch Position Mode (Copy Trading)
- */
-export interface CopyTradeSwitchPositionModeRequest {
-  positionMode: '0' | '1'; // 0 = one-way mode, 1 = hedge mode
-}
-⋮----
-positionMode: '0' | '1'; // 0 = one-way mode, 1 = hedge mode
 
 ================
 File: src/types/response/spot-margin-trading.ts
@@ -8616,487 +7499,1378 @@ currency: string; // Currency
 borrowableAmount: string; // Borrowable Amount
 
 ================
-File: src/UnifiedAPIClient.ts
+File: src/types/response/uta-types.ts
 ================
-import { AxiosRequestConfig } from 'axios';
-⋮----
-import { BaseRestClient } from './lib/BaseRestClient.js';
-import {
-  REST_CLIENT_TYPE_ENUM,
-  RestClientOptions,
-  RestClientType,
-} from './lib/requestUtils.js';
-import {
-  BatchCancelOrdersRequestUTA,
-  BatchPlaceOrderRequestUTA,
-  CancelOrderRequestUTA,
-  FlexTransferRequestUTA,
-  GetAccountLedgerRequestUTA,
-  GetAccountPositionTiersRequestUTA,
-  GetAnnouncementsRequestUTA,
-  GetClassicAccountRequestUTA,
-  GetCurrencyRequestUTA,
-  GetCurrentFundingRateRequestUTA,
-  GetDCPRequestUTA,
-  GetDepositAddressRequestUTA,
-  GetFeeRateRequestUTA,
-  GetHistoryFundingRateRequestUTA,
-  GetInterestHistoryRequestUTA,
-  GetKlinesRequestUTA,
-  GetOpenOrderListRequestUTA,
-  GetOrderBookRequestUTA,
-  GetOrderDetailsRequestUTA,
-  GetOrderHistoryRequestUTA,
-  GetPositionListRequestUTA,
-  GetPositionsHistoryRequestUTA,
-  GetServiceStatusRequestUTA,
-  GetSubAccountRequestUTA,
-  GetSymbolRequestUTA,
-  GetTickerRequestUTA,
-  GetTradeHistoryRequestUTA,
-  GetTradesRequestUTA,
-  GetTransferQuotasRequestUTA,
-  ModifyLeverageRequestUTA,
-  PlaceOrderRequestUTA,
-  SetAccountModeRequestUTA,
-  SetDCPRequestUTA,
-  SetSubAccountTransferPermissionRequestUTA,
-} from './types/request/uta-types.js';
-import { APISuccessResponse } from './types/response/shared.types.js';
-import {
-  BatchCancelOrdersResponseUTA,
-  BatchPlaceOrderResponseUTA,
-  CancelOrderResponseUTA,
-  DCPResponseUTA,
-  DepositAddressUTA,
-  FlexTransferResponseUTA,
-  GetAccountLedgerResponseClassicUTA,
-  GetAccountLedgerResponseUTA,
-  GetAccountModeResponseUTA,
-  GetAccountOverviewResponseUTA,
-  GetAnnouncementsResponseUTA,
-  GetClassicAccountResponseUTA,
-  GetCrossMarginConfigResponseUTA,
-  GetCurrencyResponseUTA,
-  GetCurrentFundingRateResponseUTA,
-  GetFeeRateResponseUTA,
-  GetHistoryFundingRateResponseUTA,
-  GetInterestHistoryResponseUTA,
-  GetKlinesResponseUTA,
-  GetOpenOrderListResponseUTA,
-  GetOrderBookResponseUTA,
-  GetOrderHistoryResponseUTA,
-  GetPositionsHistoryResponseUTA,
-  GetServiceStatusResponseUTA,
-  GetSubAccountResponseUTA,
-  GetSymbolResponseUTA,
-  GetTickerResponseUTA,
-  GetTradeHistoryResponseUTA,
-  GetTradesResponseUTA,
-  GetTransferQuotasResponseUTA,
-  OrderDetailsUTA,
-  PlaceOrderResponseUTA,
-  PositionTierUTA,
-  PositionUTA,
-  SubAccountTransferPermissionUTA,
-} from './types/response/uta-types.js';
-⋮----
 /**
- * Unified Trading Account Client
- *
- * This client provides access to the Unified Trading Account API endpoints
- * that unify market data access across Spot, Futures, and Margin trading.
+ * Unified Trading Account Response Types
  */
-export class UnifiedAPIClient extends BaseRestClient
 ⋮----
-constructor(
-    restClientOptions: RestClientOptions = {},
-    requestOptions: AxiosRequestConfig = {},
-)
+export interface AnnouncementItemUTA {
+  id: number;
+  title: string;
+  type: string[];
+  description: string;
+  releaseTime: number;
+  language: string;
+  url: string;
+}
 ⋮----
-getClientType(): RestClientType
+export interface GetAnnouncementsResponseUTA {
+  totalNumber: number;
+  totalPage: number;
+  pageNumber: number;
+  pageSize: number;
+  list: AnnouncementItemUTA[];
+}
+⋮----
+export interface CurrencyChainUTA {
+  chainName: string;
+  minWithdrawSize: string | null;
+  minDepositSize: string | null;
+  withdrawFeeRate: string;
+  minWithdrawFee: string;
+  isWithdrawEnabled: boolean;
+  isDepositEnabled: boolean;
+  confirms: number;
+  preConfirms: number;
+  contractAddress: string;
+  withdrawPrecision: number;
+  maxWithdrawSize: string | null;
+  maxDepositSize: string | null;
+  needTag: boolean;
+  chainId: string;
+}
+⋮----
+export interface GetCurrencyResponseUTA {
+  currency: string;
+  name: string;
+  fullName: string;
+  precision: number;
+  confirms: number | null;
+  contractAddress: string | null;
+  isMarginEnabled: boolean;
+  isDebitEnabled: boolean;
+  list: CurrencyChainUTA[];
+}
+⋮----
+export interface SymbolUTA {
+  symbol: string;
+  name?: string;
+  baseCurrency: string;
+  quoteCurrency: string;
+  market?: string;
+  minBaseOrderSize?: string;
+  minQuoteOrderSize?: string;
+  maxBaseOrderSize?: string | number;
+  maxQuoteOrderSize?: string;
+  baseOrderStep?: string;
+  quoteOrderStep?: string;
+  tickSize?: string | number;
+  feeCurrency?: string;
+  tradingStatus?: string;
+  marginMode?: string;
+  priceLimitRatio?: string;
+  feeCategory?: number;
+  makerFeeCoefficient?: string;
+  takerFeeCoefficient?: string;
+  st?: boolean;
+  settlementCurrency?: string;
+  contractType?: string;
+  isInverse?: boolean;
+  launchTime?: number;
+  expiryTime?: number | null;
+  settlementTime?: number | null;
+  maxPrice?: string | number;
+  lotSize?: string | number;
+  /**
+   * Unit size. As of 2026.01.12:
+   * - For inverse contracts: changed from -1 to 1 (1 contract = 1 USD)
+   * - For Futures: unitSize indicates contract size
+   */
+  unitSize?: string | number;
+  makerFeeRate?: string | number;
+  takerFeeRate?: string | number;
+  settlementFeeRate?: string | number | null;
+  maxLeverage?: number;
+  indexSourceExchanges?: string[];
+  k?: string | number;
+  m?: string | number;
+  f?: string | number;
+  mmrLimit?: string | number;
+  mmrLevConstant?: string | number;
+  alertRiskRatio?: string;
+  liquidationRiskRatio?: string;
+  baseBorrowEnable?: boolean | string;
+  quoteBorrowEnable?: boolean | string;
+  baseTransferInEnable?: boolean | string;
+  quoteTransferInEnable?: boolean | string;
+  /** Display symbol for Futures (added 2025.12.26 & 2026.01.12) */
+  displaySymbol?: string;
+  /** Display base currency for Futures (added 2025.12.26 & 2026.01.12) */
+  displayBaseCurrency?: string;
+}
 ⋮----
 /**
-   *
-   * REST - Unified Trading Account - Market Data
-   *
+   * Unit size. As of 2026.01.12:
+   * - For inverse contracts: changed from -1 to 1 (1 contract = 1 USD)
+   * - For Futures: unitSize indicates contract size
+   */
+⋮----
+/** Display symbol for Futures (added 2025.12.26 & 2026.01.12) */
+⋮----
+/** Display base currency for Futures (added 2025.12.26 & 2026.01.12) */
+⋮----
+export interface GetSymbolResponseUTA {
+  tradeType: string;
+  list: SymbolUTA[];
+}
+⋮----
+export interface TickerUTA {
+  symbol: string;
+  name?: string;
+  bestBidPrice: string;
+  bestBidSize: string;
+  bestAskPrice: string;
+  bestAskSize: string;
+  high: string;
+  low: string;
+  baseVolume: string;
+  quoteVolume: string;
+  lastPrice: string;
+  open: string;
+  size: string;
+}
+⋮----
+export interface GetTickerResponseUTA {
+  tradeType: string;
+  /** Timestamp in nanoseconds (as of 2026.01.12) */
+  ts: number;
+  list: TickerUTA[];
+}
+⋮----
+/** Timestamp in nanoseconds (as of 2026.01.12) */
+⋮----
+export interface TradeUTA {
+  sequence: string | number;
+  tradeId: string;
+  price: string;
+  size: string;
+  side: 'buy' | 'sell';
+  /** Timestamp in nanoseconds */
+  ts: number;
+  /** Whether it is an RPI trade (Futures only) */
+  isRpiTrade?: boolean;
+}
+⋮----
+/** Timestamp in nanoseconds */
+⋮----
+/** Whether it is an RPI trade (Futures only) */
+⋮----
+export interface GetTradesResponseUTA {
+  tradeType: string;
+  list: TradeUTA[];
+}
+⋮----
+export interface GetOrderBookResponseUTA {
+  tradeType: string;
+  symbol: string;
+  /** Sequence number. Changed from string to number for Spot as of 2026.01.17 */
+  sequence: number;
+  /**
+   * Bids array, ordered from high to low.
+   * When rpiFilter=0 (or not set): each entry is [price, size]
+   * When rpiFilter=1: each entry is [price, noneRPISize, RPISize]
+   * As of 2026.01.17: All values are strings
+   */
+  bids: string[][];
+  /**
+   * Asks array, ordered from low to high.
+   * When rpiFilter=0 (or not set): each entry is [price, size]
+   * When rpiFilter=1: each entry is [price, noneRPISize, RPISize]
+   * As of 2026.01.17: All values are strings
+   */
+  asks: string[][];
+  /** Timestamp in nanoseconds (Futures only) */
+  ts?: number;
+}
+⋮----
+/** Sequence number. Changed from string to number for Spot as of 2026.01.17 */
+⋮----
+/**
+   * Bids array, ordered from high to low.
+   * When rpiFilter=0 (or not set): each entry is [price, size]
+   * When rpiFilter=1: each entry is [price, noneRPISize, RPISize]
+   * As of 2026.01.17: All values are strings
    */
 ⋮----
 /**
-   * Get Announcements
-   * This interface can obtain the latest news announcements, and the default
-   * page search is for announcements within a month.
-   */
-getAnnouncements(
-    params?: GetAnnouncementsRequestUTA,
-): Promise<APISuccessResponse<GetAnnouncementsResponseUTA>>
-⋮----
-/**
-   * Get Currency
-   * Request the currency details of a specified currency via this endpoint.
-   */
-getCurrency(
-    params?: GetCurrencyRequestUTA,
-): Promise<APISuccessResponse<GetCurrencyResponseUTA>>
-⋮----
-/**
-   * Get Symbol
-   * Request a list of available currency pairs for trading via this endpoint.
-   */
-getSymbols(
-    params: GetSymbolRequestUTA,
-): Promise<APISuccessResponse<GetSymbolResponseUTA>>
-⋮----
-/**
-   * Get Ticker
-   * Request market tickers for the trading pairs in the market (including 24h volume).
-   */
-getTickers(
-    params: GetTickerRequestUTA,
-): Promise<APISuccessResponse<GetTickerResponseUTA>>
-⋮----
-/**
-   * Get Trades
-   * Request via this endpoint to get the latest 100 public trades of the specified symbol.
-   */
-getTrades(
-    params: GetTradesRequestUTA,
-): Promise<APISuccessResponse<GetTradesResponseUTA>>
-⋮----
-/**
-   * Get OrderBook
-   * Query order book depth information (aggregated by price).
-   */
-getOrderBook(
-    params: GetOrderBookRequestUTA,
-): Promise<APISuccessResponse<GetOrderBookResponseUTA>>
-⋮----
-/**
-   * Get Klines
-   * Get the Kline of the symbol. Data are returned in grouped buckets based on requested type.
-   */
-getKlines(
-    params: GetKlinesRequestUTA,
-): Promise<APISuccessResponse<GetKlinesResponseUTA>>
-⋮----
-/**
-   * Get Current Funding Rate
-   * Get current Futures funding fee rate.
-   */
-getCurrentFundingRate(
-    params: GetCurrentFundingRateRequestUTA,
-): Promise<APISuccessResponse<GetCurrentFundingRateResponseUTA>>
-⋮----
-/**
-   * Get History Funding Rate
-   * Query the Futures funding rate at each settlement time point within a certain time range.
-   */
-getHistoryFundingRate(
-    params: GetHistoryFundingRateRequestUTA,
-): Promise<APISuccessResponse<GetHistoryFundingRateResponseUTA>>
-⋮----
-/**
-   * Get Cross Margin Config
-   * Request the configure info of the 'spot cross margin' via this endpoint.
-   */
-getCrossMarginConfig(): Promise<
-    APISuccessResponse<GetCrossMarginConfigResponseUTA>
-  > {
-    return this.get('api/ua/v1/market/cross-config');
-⋮----
-/**
-   * Get Service Status
-   * Get the service status.
-   */
-getServiceStatus(
-    params: GetServiceStatusRequestUTA,
-): Promise<APISuccessResponse<GetServiceStatusResponseUTA>>
-⋮----
-/**
-   *
-   * REST - Unified Trading Account - Account
-   *
+   * Asks array, ordered from low to high.
+   * When rpiFilter=0 (or not set): each entry is [price, size]
+   * When rpiFilter=1: each entry is [price, noneRPISize, RPISize]
+   * As of 2026.01.17: All values are strings
    */
 ⋮----
-/**
-   * Get Account (Classic)
-   * Get information for Classic Account (FUNDING, SPOT, FUTURES, CROSS, ISOLATED).
-   * Note: AccountType enum value changed from TRADING to SPOT as of 2026.01.17.
-   */
-getClassicAccount(
-    params: GetClassicAccountRequestUTA,
-): Promise<APISuccessResponse<GetClassicAccountResponseUTA>>
+/** Timestamp in nanoseconds (Futures only) */
+⋮----
+export interface GetKlinesResponseUTA {
+  tradeType: string;
+  symbol: string;
+  list: string[][]; // [time, open, close, high, low, volume, turnover]
+}
+⋮----
+list: string[][]; // [time, open, close, high, low, volume, turnover]
+⋮----
+export interface GetCurrentFundingRateResponseUTA {
+  symbol: string;
+  nextFundingRate: number;
+  fundingTime: number;
+  fundingRateCap: number;
+  fundingRateFloor: number;
+}
+⋮----
+export interface FundingRateHistoryItemUTA {
+  fundingRate: number;
+  ts: number;
+}
+⋮----
+export interface GetHistoryFundingRateResponseUTA {
+  symbol: string;
+  list: FundingRateHistoryItemUTA[];
+}
+⋮----
+export interface GetCrossMarginConfigResponseUTA {
+  maxLeverage: number;
+  alertRiskRatio: string;
+  liquidationRiskRatio: string;
+  currencyList: string[];
+}
+⋮----
+export interface GetServiceStatusResponseUTA {
+  tradeType: string;
+  serverStatus: 'open' | 'close' | 'cancelonly';
+  msg: string;
+}
 ⋮----
 /**
-   * Get Account (UTA)
-   * Get information for Unified Trading Account.
-   */
-getAccount(): Promise<APISuccessResponse<GetClassicAccountResponseUTA>>
+ * Account Response Types
+ */
+⋮----
+export interface AccountCurrencyUTA {
+  currency: string;
+  hold: string;
+  available: string;
+  balance: string;
+  equity: string;
+  liability?: string;
+  totalCrossMargin?: string;
+  crossPosMargin?: string;
+  crossOrderMargin?: string;
+  crossUnPnl?: string;
+  isolatedPosMargin?: string;
+  isolatedOrderMargin?: string;
+  isolatedFundingFeeMargin?: string;
+  isolatedUnPnl?: string;
+  liabilityPrinciple?: string;
+  liabilityInterest?: string;
+  unrealisedPnl?: string;
+}
+⋮----
+export interface AccountDataUTA {
+  accountSubtype?: string; // For ISOLATED (trading pair) or FUTURES (settlement currency)
+  riskRatio?: string;
+  currencies: AccountCurrencyUTA[];
+}
+⋮----
+accountSubtype?: string; // For ISOLATED (trading pair) or FUTURES (settlement currency)
+⋮----
+export interface GetClassicAccountResponseUTA {
+  accountType: string;
+  ts: number;
+  accounts: AccountDataUTA[];
+}
+⋮----
+export interface GetAccountOverviewResponseUTA {
+  accountType: string;
+  riskRatio: string;
+  equity: string;
+  liability: string;
+  availableMargin: string;
+  adjustedEquity: string;
+  im: string;
+  mm: string;
+}
+⋮----
+export interface SubAccountUserUTA {
+  uid: number;
+  accountList: {
+    accountType:
+      | 'FUNDING'
+      | 'SPOT'
+      | 'FUTURES'
+      | 'CROSS'
+      | 'ISOLATED'
+      | 'OPTIONS'
+      | 'UNIFIED';
+    accountSubType: string | null;
+    currencyList: AccountCurrencyUTA[];
+  }[];
+}
+⋮----
+export interface GetSubAccountResponseUTA {
+  ts: number;
+  userList: SubAccountUserUTA[];
+}
+⋮----
+export interface GetTransferQuotasResponseUTA {
+  currency: string;
+  transferable: string;
+  accountType: string;
+}
+⋮----
+export interface FlexTransferResponseUTA {
+  orderId: string;
+  clientOid: string;
+}
+⋮----
+export interface SubAccountTransferPermissionUTA {
+  subUid: string;
+  subToSub: boolean;
+}
+⋮----
+export interface GetAccountModeResponseUTA {
+  selfAccountMode: 'CLASSIC' | 'UNIFIED';
+  unifiedSubAccount: number[];
+  classicSubAccount: number[];
+}
+⋮----
+export interface FeeRateItemUTA {
+  symbol: string;
+  takerFeeRate: string;
+  makerFeeRate: string;
+}
+⋮----
+export interface GetFeeRateResponseUTA {
+  tradeType: string;
+  list: FeeRateItemUTA[];
+}
+⋮----
+export interface AccountLedgerItemUTA {
+  accountType:
+    | 'FUNDING'
+    | 'SPOT'
+    | 'FUTURES'
+    | 'CROSS'
+    | 'ISOLATED'
+    | 'UNIFIED';
+  id: string;
+  currency: string;
+  direction: 'IN' | 'OUT';
+  businessType: string;
+  amount: string;
+  balance: string;
+  fee: string;
+  tax: string;
+  remark: string;
+  /** Timestamp in nanoseconds (standardized as of 2026.01.12) */
+  ts: number;
+}
+⋮----
+/** Timestamp in nanoseconds (standardized as of 2026.01.12) */
+⋮----
+export interface GetAccountLedgerResponseUTA {
+  lastId?: number;
+  items?: AccountLedgerItemUTA[];
+}
+⋮----
+export type GetAccountLedgerResponseClassicUTA = AccountLedgerItemUTA[];
+⋮----
+export interface InterestHistoryItemUTA {
+  liability: string;
+  interest: string;
+  hourlyInterestRate: string;
+  currency: string;
+  ts: number;
+  interestFreeLiability: string;
+}
+⋮----
+export interface GetInterestHistoryResponseUTA {
+  items: InterestHistoryItemUTA[];
+  lastId: number;
+}
+⋮----
+export interface DepositAddressUTA {
+  address: string;
+  memo: string;
+  chainId: string;
+  to: 'MAIN' | 'TRADE';
+  currency: string;
+  contractAddress: string;
+  chainName: string;
+  expirationDate: string;
+  remark: string;
+}
 ⋮----
 /**
-   * Get Account Overview (UTA)
-   * Get account overview for Unified Trading Account.
+ * Order Response Types
+ */
+⋮----
+export interface PlaceOrderResponseUTA {
+  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS';
+  orderId: string;
+  clientOid: string;
+  /** Timestamp when system completes order request in nanoseconds. Classic mode not supported */
+  ts?: number;
+  /** Borrow amount. Unified mode not supported */
+  borrowSize?: string;
+  /** Loan order ID. Unified mode not supported */
+  loanApplyId?: string;
+}
+⋮----
+/** Timestamp when system completes order request in nanoseconds. Classic mode not supported */
+⋮----
+/** Borrow amount. Unified mode not supported */
+⋮----
+/** Loan order ID. Unified mode not supported */
+⋮----
+export interface BatchPlaceOrderItemResponseUTA {
+  orderId?: string;
+  clientOid?: string;
+  symbol?: string;
+  code?: string;
+  msg?: string;
+}
+⋮----
+export interface BatchPlaceOrderResponseUTA {
+  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS';
+  items: BatchPlaceOrderItemResponseUTA[];
+}
+⋮----
+export interface OrderDetailsUTA {
+  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS';
+  orderId: string;
+  clientOid: string;
+  /**
+   * Order status:
+   * - 0: notTriggered (conditional order, not triggered)
+   * - 1: triggered (conditional order, triggered but not live)
+   * - 2: live (not filled)
+   * - 3: filled (fully filled)
+   * - 4: partial filled (partially filled, still active)
+   * - 5: canceled (no fills, fully canceled)
+   * - 6: partial canceled (partially filled, remainder canceled)
+   * Changed from String to Number for UTA as of 2026.01.17
    */
-getAccountOverview(): Promise<
-    APISuccessResponse<GetAccountOverviewResponseUTA>
-  > {
-    return this.getPrivate('api/ua/v1/unified/account/overview');
+  status: number;
+  filledSize: string;
+  avgPrice: string;
+  fee: string;
+  feeCurrency: string;
+  tax: string;
+  tradeId: string;
+  symbol: string;
+  side: 'BUY' | 'SELL';
+  positionSide?: 'BOTH' | 'LONG' | 'SHORT';
+  orderType: 'LIMIT' | 'MARKET';
+  size: string;
+  sizeUnit: 'BASECCY' | 'QUOTECCY' | 'UNIT';
+  price: string;
+  leverage?: string;
+  reduceOnly?: boolean;
+  marginMode?: 'ISOLATED' | 'CROSS';
+  stp?: 'DC' | 'CO' | 'CN' | 'CB' | '';
+  /**
+   * Time in Force. Added 'RPI' as of 2025.01.02
+   */
+  timeInForce: 'GTC' | 'IOC' | 'GTT' | 'FOK' | 'RPI';
+  cancelReason?: number;
+  cancelSize: string;
+  cancelAfter?: number;
+  triggerDirection?: 'UP' | 'DOWN';
+  triggerPrice?: string;
+  triggerPriceType?: 'TP' | 'IP' | 'MP';
+  tpTriggerPrice?: string;
+  tpTriggerPriceType?: 'TP' | 'IP' | 'MP';
+  tpOrderPrice?: string;
+  slTriggerPrice?: string;
+  slTriggerPriceType?: 'TP' | 'IP' | 'MP';
+  slOrderPrice?: string;
+  postOnly?: boolean;
+  tags?: string;
+  triggerOrderId?: string;
+  /** Order creation time in nanoseconds (standardized as of 2026.01.12) */
+  orderTime: number;
+  /** Latest order update time in nanoseconds (standardized as of 2026.01.12) */
+  updatedTime: number;
+}
 ⋮----
 /**
-   * Get Sub Account
-   * Request sub account info via this endpoint.
-   */
-getSubAccount(
-    params?: GetSubAccountRequestUTA,
-): Promise<APISuccessResponse<GetSubAccountResponseUTA>>
-⋮----
-/**
-   * Get Transfer Quotas
-   * This endpoint returns the transferable balance of a specified account.
-   * Note: AccountType enum value changed from TRADING to SPOT as of 2026.01.17.
-   */
-getTransferQuotas(
-    params: GetTransferQuotasRequestUTA,
-): Promise<APISuccessResponse<GetTransferQuotasResponseUTA>>
-⋮----
-/**
-   * Flex Transfer
-   * This interface can be used for transfers between master- and sub-accounts and transfers.
-   * Note: AccountType enum value changed from TRADING to SPOT as of 2026.01.17.
-   */
-flexTransfer(
-    params: FlexTransferRequestUTA,
-): Promise<APISuccessResponse<FlexTransferResponseUTA>>
-⋮----
-/**
-   * Set Sub Account Transfer Permission
-   * This endpoint supports setting whether the specified sub-account needs to open the SUB_TO_SUB transfer permission.
-   */
-setSubAccountTransferPermission(
-    params: SetSubAccountTransferPermissionRequestUTA,
-): Promise<APISuccessResponse<SubAccountTransferPermissionUTA[]>>
-⋮----
-/**
-   * Get Account Mode
-   * This interface supports query the list of unified and classic sub-accounts and current account mode.
-   */
-getAccountMode(): Promise<APISuccessResponse<GetAccountModeResponseUTA>>
-⋮----
-/**
-   * Set Account Mode
-   * This interface supports set account mode to UTA.
-   */
-setAccountMode(
-    params: SetAccountModeRequestUTA,
-): Promise<APISuccessResponse<null>>
-⋮----
-/**
-   * Get Fee Rate
-   * This interface is for the trading pair's actual fee rate.
-   * You can inquire about fee rates of 10 trading pairs each time at most for Spot.
-   * Futures only supports 1 symbol at a time.
-   */
-getFeeRate(
-    params: GetFeeRateRequestUTA,
-): Promise<APISuccessResponse<GetFeeRateResponseUTA>>
-⋮----
-/**
-   * Get Account Ledger
-   * This API endpoint returns all transfer (in and out) records and supports multi-coin queries.
-   * The query results are sorted in descending order by createdAt and ID.
-   * Note: AccountType enum value changed from TRADING to SPOT as of 2026.01.17.
-   * Note: direction values unified to uppercase IN/OUT as of 2026.01.17.
-   * Note: For Futures - id changed from Number to String, balance/amount changed from Number to String as of 2026.01.17.
-   * Note: ts standardized to nanoseconds as of 2026.01.12.
-   */
-getAccountLedger(
-    params: GetAccountLedgerRequestUTA,
-  ): Promise<
-    APISuccessResponse<
-      GetAccountLedgerResponseUTA | GetAccountLedgerResponseClassicUTA
-    >
-  > {
-    return this.getPrivate('api/ua/v1/account/ledger', params);
-⋮----
-/**
-   * Get Interest History (UTA)
-   * Request the interest records via this endpoint.
-   */
-getInterestHistory(
-    params: GetInterestHistoryRequestUTA,
-): Promise<APISuccessResponse<GetInterestHistoryResponseUTA>>
-⋮----
-/**
-   * Modify Leverage (UTA)
-   * This interface supports modify leverage of the specified symbol.
-   */
-modifyLeverage(
-    params: ModifyLeverageRequestUTA,
-): Promise<APISuccessResponse<null>>
-⋮----
-/**
-   * Get Deposit Address
-   * Return a deposit address; when both currency and chain are provided,
-   * the address will be created if it does not exist.
-   * URL unified to GET /api/ua/v1/asset/deposit/address as of 2026.01.17.
-   */
-getDepositAddress(
-    params: GetDepositAddressRequestUTA,
-): Promise<APISuccessResponse<DepositAddressUTA[]>>
-⋮----
-/**
-   *
-   * REST - Unified Trading Account - Orders
-   *
-   */
-⋮----
-/**
-   * Place Order
-   * This interface can be used to place orders.
-   * Supports RPI (Retail Price Improvement) orders for Futures as of 2025.01.02.
-   * Note: timeInForce supports 'RPI' value for Futures only (Phase 1).
-   * Note: For Classic mode, tradeType is required in query param.
-   * Note: For Unified mode, tradeType should not be in query param.
-   */
-placeOrder(
-    params: PlaceOrderRequestUTA,
-    accountMode: 'classic' | 'unified' = 'unified',
-): Promise<APISuccessResponse<PlaceOrderResponseUTA>>
-⋮----
-/**
-   * Batch Place Order (Classic)
-   * This interface can be used for placing batch orders.
-   * URL changed to /api/ua/v1/{accountMode}/order/place-batch as of 2026.01.17.
-   * Note: timeInForce supports 'RPI' value for Futures as of 2025.01.02.
-   */
-batchPlaceOrder(
-    params: BatchPlaceOrderRequestUTA,
-    accountMode: 'classic' | 'unified' = 'classic',
-): Promise<APISuccessResponse<BatchPlaceOrderResponseUTA>>
-⋮----
-/**
-   * Get Order Details
-   * This interface can be used getting single order details.
-   * Note: timeInForce returns 'RPI' value for Futures RPI orders as of 2025.01.02.
-   * Note: status changed from String to Number for UTA as of 2026.01.17.
-   * Note: orderTime/updatedTime standardized to nanoseconds as of 2026.01.12.
-   */
-getOrderDetails(
-    params: GetOrderDetailsRequestUTA,
-    accountMode: 'classic' | 'unified' = 'unified',
-): Promise<APISuccessResponse<OrderDetailsUTA>>
-⋮----
-/**
-   * Get Open Order List
-   * This interface can be used getting open order list.
-   * Note: timeInForce returns 'RPI' value for Futures RPI orders as of 2025.01.02.
-   * Note: status changed from String to Number for UTA as of 2026.01.17.
-   * Note: orderTime/updatedTime standardized to nanoseconds as of 2026.01.12.
-   */
-getOpenOrderList(
-    params: GetOpenOrderListRequestUTA,
-    accountMode: 'classic' | 'unified' = 'unified',
-): Promise<APISuccessResponse<GetOpenOrderListResponseUTA>>
-⋮----
-/**
-   * Get Order History
-   * This interface can be used for getting order history.
-   * Note: timeInForce returns 'RPI' value for Futures RPI orders as of 2025.01.02.
-   * Note: status changed from String to Number for UTA as of 2026.01.17.
-   * Note: orderTime/updatedTime standardized to nanoseconds as of 2026.01.12.
-   */
-getOrderHistory(
-    params: GetOrderHistoryRequestUTA,
-    accountMode: 'classic' | 'unified' = 'unified',
-): Promise<APISuccessResponse<GetOrderHistoryResponseUTA>>
-⋮----
-/**
-   * Get Trade History
-   * This interface can be used for getting trade execution history.
-   * Note: executionTime standardized to nanoseconds as of 2026.01.12.
-   * Note: isRpiTrade added for Futures as of 2025.01.02.
-   */
-getTradeHistory(
-    params: GetTradeHistoryRequestUTA,
-    accountMode: 'classic' | 'unified' = 'unified',
-): Promise<APISuccessResponse<GetTradeHistoryResponseUTA>>
-⋮----
-/**
-   * Cancel Order
-   * This interface can be used to cancel orders.
-   * Note: ts (timestamp in nanoseconds) only effective for unified account mode.
-   */
-cancelOrder(
-    params: CancelOrderRequestUTA,
-    accountMode: 'classic' | 'unified' = 'unified',
-): Promise<APISuccessResponse<CancelOrderResponseUTA>>
-⋮----
-/**
-   * Batch Cancel Orders
-   * This interface can be used for batch cancel orders (maximum 20 orders).
-   * Note: tradeType required for Classic accounts only; ignored in UTA (UNIFIED) mode.
-   * Note: ts (timestamp in nanoseconds) not supported for classic accounts.
-   */
-batchCancelOrders(
-    params: BatchCancelOrdersRequestUTA,
-    accountMode: 'classic' | 'unified' = 'unified',
-): Promise<APISuccessResponse<BatchCancelOrdersResponseUTA>>
-⋮----
-/**
-   * Set DCP (Disconnection Protect / Deadman Switch) - Classic Only
-   * Set automatic order cancellation after specified time.
-   * Call this interface to automatically cancel all orders of the set trading pair after the specified time.
-   * Note: Order cancellation delay is between 0 and 10 seconds.
-   * Note: timeout range: -1 (unset) or 5 <= timeout <= 86400 seconds.
-   */
-setDCP(
-    params: SetDCPRequestUTA,
-): Promise<APISuccessResponse<DCPResponseUTA>>
-⋮----
-/**
-   * Get DCP (Disconnection Protect / Deadman Switch) - Classic Only
-   * Get automatic order cancellation settings.
-   * If data is empty, it means DCP is not set.
-   */
-getDCP(
-    params: GetDCPRequestUTA,
-): Promise<APISuccessResponse<DCPResponseUTA>>
-⋮----
-/**
-   *
-   * REST - Unified Trading Account - Positions
-   *
+   * Order status:
+   * - 0: notTriggered (conditional order, not triggered)
+   * - 1: triggered (conditional order, triggered but not live)
+   * - 2: live (not filled)
+   * - 3: filled (fully filled)
+   * - 4: partial filled (partially filled, still active)
+   * - 5: canceled (no fills, fully canceled)
+   * - 6: partial canceled (partially filled, remainder canceled)
+   * Changed from String to Number for UTA as of 2026.01.17
    */
 ⋮----
 /**
-   * Get Position List (UTA)
-   * Get the position details of all open positions.
-   * Note: creationTime standardized to nanoseconds as of 2026.01.12.
+   * Time in Force. Added 'RPI' as of 2025.01.02
    */
-getPositionList(
-    params?: GetPositionListRequestUTA,
-): Promise<APISuccessResponse<PositionUTA[]>>
+⋮----
+/** Order creation time in nanoseconds (standardized as of 2026.01.12) */
+⋮----
+/** Latest order update time in nanoseconds (standardized as of 2026.01.12) */
+⋮----
+export interface GetOpenOrderListResponseUTA {
+  pageNumber: number;
+  pageSize?: number;
+  totalNum?: number;
+  totalPage?: number;
+  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS';
+  items: OrderDetailsUTA[];
+}
+⋮----
+export interface GetOrderHistoryResponseUTA {
+  lastId: number;
+  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS';
+  items: OrderDetailsUTA[];
+}
+⋮----
+export interface TradeHistoryItemUTA {
+  tradeId: string;
+  orderId: string;
+  symbol: string;
+  side: 'BUY' | 'SELL';
+  positionSide?: 'BOTH' | 'LONG' | 'SHORT';
+  type: 'LIMIT' | 'MARKET';
+  price: string;
+  size: string;
+  sizeUnit: 'BASECCY' | 'QUOTECCY' | 'UNIT';
+  value: string;
+  feeRate: string;
+  fee: string;
+  feeCurrency: string;
+  tax: string;
+  liquidity: 'TAKER' | 'MAKER';
+  /** Execution time in nanoseconds (standardized as of 2026.01.12) */
+  executionTime: number;
+  /** Whether it is an RPI trade (added 2025.01.02, Futures only) */
+  isRpiTrade?: boolean;
+}
+⋮----
+/** Execution time in nanoseconds (standardized as of 2026.01.12) */
+⋮----
+/** Whether it is an RPI trade (added 2025.01.02, Futures only) */
+⋮----
+export interface GetTradeHistoryResponseUTA {
+  lastId: number;
+  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS';
+  items: TradeHistoryItemUTA[];
+}
+⋮----
+export interface CancelOrderResponseUTA {
+  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS';
+  orderId?: string;
+  clientOid?: string;
+  /** Timestamp when system completes order cancellation request (nanoseconds). Only for unified accounts */
+  ts?: number;
+}
+⋮----
+/** Timestamp when system completes order cancellation request (nanoseconds). Only for unified accounts */
+⋮----
+export interface BatchCancelOrderItemResponseUTA {
+  code?: string;
+  msg?: string;
+  orderId?: string;
+  clientOid?: string;
+  /** Timestamp when system completes order cancellation request (nanoseconds). Not supported for classic accounts */
+  ts?: number;
+}
+⋮----
+/** Timestamp when system completes order cancellation request (nanoseconds). Not supported for classic accounts */
+⋮----
+export interface BatchCancelOrdersResponseUTA {
+  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS';
+  items: BatchCancelOrderItemResponseUTA[];
+}
+⋮----
+/** Batch cancel by symbol - Classic response (orderId list) */
+export interface BatchCancelOrdersBySymbolItemClassicUTA {
+  orderId: string;
+}
+⋮----
+/** Batch cancel by symbol - UTA response (full result per order) */
+export interface BatchCancelOrdersBySymbolItemUTA {
+  code?: string;
+  msg?: string;
+  orderId?: string;
+  ts?: number;
+  clientOid?: string | null;
+}
+⋮----
+export interface BatchCancelOrdersBySymbolResponseUTA {
+  tradeType: 'SPOT' | 'FUTURES' | 'MARGIN';
+  ts?: number;
+  items:
+    | BatchCancelOrdersBySymbolItemClassicUTA[]
+    | BatchCancelOrdersBySymbolItemUTA[];
+}
+⋮----
+export interface DCPResponseUTA {
+  tradeType: 'SPOT' | 'FUTURES' | 'MARGIN';
+  symbol: string[]; // Empty means effective for all symbols
+  systemTime: number; // Time when system received request (in seconds)
+  triggerTime: number; // Trigger cancellation time (in seconds)
+}
+⋮----
+symbol: string[]; // Empty means effective for all symbols
+systemTime: number; // Time when system received request (in seconds)
+triggerTime: number; // Trigger cancellation time (in seconds)
 ⋮----
 /**
-   * Get Positions History (UTA)
-   * Query position history information records.
-   * Note: Data retained for up to 3 months.
-   * Note: Each query limited to 7 days time range.
-   * Note: creationTime and closingTime standardized to nanoseconds as of 2026.01.12.
-   */
-getPositionsHistory(
-    params?: GetPositionsHistoryRequestUTA,
-): Promise<APISuccessResponse<GetPositionsHistoryResponseUTA>>
+ * Position Response Types
+ */
+⋮----
+export interface PositionUTA {
+  id: string;
+  symbol: string;
+  marginMode: 'CROSS' | 'ISOLATED';
+  size: string; // Positive = long, negative = short
+  entryPrice: string;
+  positionValue: string;
+  markPrice: string;
+  leverage: string;
+  unrealizedPnL: string;
+  realizedPnL: string;
+  initialMargin: string;
+  mmr: string; // Maintenance Margin Rate
+  maintenanceMargin: string;
+  /** Timestamp when position was first opened (nanoseconds, standardized as of 2026.01.12) */
+  creationTime: number;
+}
+⋮----
+size: string; // Positive = long, negative = short
+⋮----
+mmr: string; // Maintenance Margin Rate
+⋮----
+/** Timestamp when position was first opened (nanoseconds, standardized as of 2026.01.12) */
+⋮----
+export interface PositionHistoryItemUTA {
+  closeId: string;
+  symbol: string;
+  marginMode: 'CROSS' | 'ISOLATED';
+  side: 'LONG' | 'SHORT';
+  entryPrice: string;
+  closePrice: string;
+  avgClosePrice: string;
+  maxSize: string;
+  leverage: string;
+  realizedPnL: string;
+  fee: string;
+  tax: string;
+  fundingFee: string;
+  /** Position opening timestamp (nanoseconds, standardized as of 2026.01.12) */
+  creationTime: number;
+  /** Position closing timestamp (nanoseconds, standardized as of 2026.01.12) */
+  closingTime: number;
+}
+⋮----
+/** Position opening timestamp (nanoseconds, standardized as of 2026.01.12) */
+⋮----
+/** Position closing timestamp (nanoseconds, standardized as of 2026.01.12) */
+⋮----
+export interface GetPositionsHistoryResponseUTA {
+  items: PositionHistoryItemUTA[];
+  lastId?: number;
+}
+⋮----
+export interface PositionTierUTA {
+  symbol: string;
+  tier: number; // Current tier of user
+  maxSize: string; // Upper limit (USDT) (included)
+  minSize: string; // Lower limit (USDT)
+  maxLeverage: string;
+  initialMarginRate: string;
+  maintainMarginRate: string;
+}
+⋮----
+tier: number; // Current tier of user
+maxSize: string; // Upper limit (USDT) (included)
+minSize: string; // Lower limit (USDT)
+
+================
+File: src/index.ts
+================
+
+
+================
+File: examples/WebSockets/ws-private-pro-v2.ts
+================
+import {
+  WebsocketClient,
+  WS_KEY_MAP,
+  WsTopicRequest,
+} from '../../src/index.js';
+// import { DefaultLogger, WebsocketClient } from 'kucoin-api';
+// normally you should install this module via npm: `npm install kucoin-api`
+⋮----
+async function start()
+⋮----
+// Optional: inject a custom logger to override internal logging behaviour
+// const logger: typeof DefaultLogger = {
+//   ...DefaultLogger,
+//   trace: (...params) => {
+//     // Simple way to exclude certain messages from trace logs
+//     if (
+//       [
+//         'Sending ping',
+//         // 'Sending upstream ws message: ',
+//         'Received pong',
+//         'Decompressed message event from buffer',
+//       ].includes(params[0])
+//     ) {
+//       return;
+//     }
+//     console.log('trace', JSON.stringify(params, null, 2));
+//   },
+// };
+⋮----
+passphrase: process.env.API_PASSPHRASE || 'apiPassPhraseHere', // This is NOT your account password
+⋮----
+// logger,
+⋮----
+// Data received
+⋮----
+// Something happened, attempting to reconenct
+⋮----
+// Reconnect successful
+⋮----
+// Connection closed. If unexpected, expect reconnect -> reconnected.
+⋮----
+// Reply to a request, e.g. "subscribe"/"unsubscribe"/"authenticate"
+⋮----
+// throw new Error('res?');
 ⋮----
 /**
-   * Get Account Position Tiers
-   * Request account position tiers (risk limit) info.
-   * Note: Currently only queries of classic - futures isolated margin are supported.
+   * The below examples demonstrate consuming private V2 (Pro) WebSocket topics.
+   * For V1 private WebSocket examples, see ws-private-spot-v1.ts and ws-private-futures-v1.ts
    */
-getAccountPositionTiers(
-    params: GetAccountPositionTiersRequestUTA,
-    accountMode: 'classic' | 'unified' = 'classic',
-): Promise<APISuccessResponse<PositionTierUTA[]>>
+⋮----
+// Optional: await a connection to be ready before subscribing (this is not necessary)
+// await client.connect(WS_KEY_MAP.privateProV2);
+// console.log('connected');
+⋮----
+/**
+     * Structure your requests into the following format. The below example will be sent as per the example in the docs. The parameters are automatically merged into the request. Just follow the example below:
+     * {
+     *   "id": "1545910660739", // OPTIONAL
+     *   "action": "SUBSCRIBE", // or UNSUBSCRIBE
+     *   "channel":"orderAll", //
+     *   "tradeType": "SPOT" // SPOT / FUTURES / ISOLATED / CROSS / UNIFIED
+     * }
+     *
+     * https://www.kucoin.com/docs-new/3470228w0
+     */
+⋮----
+/**
+       * Anything in the payload will be merged into the subscribe "request", allowing you to send misc parameters supported by the exchange.
+       * For more info on parameters, see: https://www.kucoin.com/docs-new/websocket-api/base-info/introduction-uta#5-subscribe
+       */
+⋮----
+tradeType: 'SPOT', // SPOT / FUTURES / ISOLATED / CROSS / UNIFIED
+⋮----
+// Or, subscribe to multiple topics at once:
+⋮----
+// Other markets for orderAll topic:
+// https://www.kucoin.com/docs-new/3470228w0
+⋮----
+tradeType: 'FUTURES', // SPOT / FUTURES / ISOLATED / CROSS / UNIFIED
+⋮----
+// Specific order updates for a given symbol:
+// https://www.kucoin.com/docs-new/3470228w0
+⋮----
+tradeType: 'SPOT', // SPOT / FUTURES / ISOLATED / CROSS / UNIFIED
+⋮----
+// Futures positions:
+// https://www.kucoin.com/docs-new/3470233w0
+⋮----
+tradeType: 'FUTURES', //  FUTURES / UNIFIED
+⋮----
+tradeType: 'FUTURES', //  FUTURES / UNIFIED
+⋮----
+// Account balance updates:
+// https://www.kucoin.com/docs-new/3470231w0
+⋮----
+accountType: 'TRADING', // TRADING / ISOLATED / CROSS / FUTURES / UNIFIED
+⋮----
+// Execution/trade updates:
+// https://www.kucoin.com/docs-new/3470232w0
+⋮----
+tradeType: 'SPOT', // SPOT / ISOLATED / CROSS / FUTURES / UNIFIED
+⋮----
+// Liquidation warnings:
+// https://www.kucoin.com/docs-new/3470236w0
+⋮----
+// Leverage updates:
+// https://www.kucoin.com/docs-new/3470237w0
+
+================
+File: examples/WebSockets/ws-public-futures-pro-v2.ts
+================
+/* eslint-disable no-unused-vars */
+import {
+  WebsocketClient,
+  WS_KEY_MAP,
+  WsTopicRequest,
+} from '../../src/index.js';
+// import { DefaultLogger, WebsocketClient, WsTopicRequest } from 'kucoin-api';
+// normally you should install this module via npm: `npm install kucoin-api`
+⋮----
+async function start()
+⋮----
+// Optional: fully customise the logging experience by injecting a custom logger
+// const logger: typeof DefaultLogger = {
+//   ...DefaultLogger,
+//   trace: (...params) => {
+//     if (
+//       [
+//         'Sending ping',
+//         'Sending upstream ws message: ',
+//         'Received pong',
+//         'Decompressed message event from buffer',
+//       ].includes(params[0])
+//     ) {
+//       return;
+//     }
+//     console.log('trace', params);
+//   },
+// };
+⋮----
+// const client = new WebsocketClient({}, logger);
+⋮----
+// Data received
+⋮----
+// Something happened, attempting to reconenct
+⋮----
+// Reconnect successful
+⋮----
+// Connection closed. If unexpected, expect reconnect -> reconnected.
+⋮----
+// Reply to a request, e.g. "subscribe"/"unsubscribe"/"authenticate"
+⋮----
+// throw new Error('res?');
+⋮----
+/**
+   * The following example demonstrates the ways to consume data from the V2 (Pro) WebSockets. For the V1 examples, ws-public-futures-v1.ts
+   */
+⋮----
+// Optional: await a connection to be ready before subscribing (this is not necessary)
+// await client.connect(WS_KEY_MAP.futuresPublicProV2);
+⋮----
+/**
+     * Structure your requests into the following format. The below example will be sent as per the example in the docs. The parameters are automatically merged into the request. Just follow the example below:
+     * {
+     *    "id": "1545910660739", // automatically generated by SDK
+     *    "action": "SUBSCRIBE", // automatically added by SDK
+     *    "channel":"kline",
+     *    "tradeType": "FUTURES",       // SPOT / FUTURES
+     *    "symbol": "XBTUSDTM",
+     *    "interval": "1min"
+     * }
+     *
+     * https://www.kucoin.com/docs-new/3470223w0
+     */
+⋮----
+/**
+       * Anything in the payload will be merged into the subscribe "request", allowing you to send misc parameters supported by the exchange.
+       * For more info on parameters, see: https://www.kucoin.com/docs-new/websocket-api/base-info/introduction-uta#5-subscribe
+       */
+⋮----
+// this needs to match the WsKey below.
+// tradeType: SPOT ==> spotPublicProV2
+// tradeType: FUTURES ==> futuresPublicProV2
+⋮----
+/**
+     * Or, send an array of structured objects with parameters, if you wanted to send multiple in one request
+     *
+     */
+⋮----
+// BTCUSDT tickers for FUTURES market
+// https://www.kucoin.com/docs-new/3470222w0
+⋮----
+// BTCUSDT orderbook updates for FUTURES market
+// https://www.kucoin.com/docs-new/3470221w0
+⋮----
+depth: '5', // 1 / 5 / 50 / increment
+rpiFilter: 0, // 0：Only NoneRPI orders [Default]  1(Only Support Futures)：NoneRPI+ RPI Orders. When rpiFilter=1, "depth" only supports 5/50.
+⋮----
+// BTCUSDT trades for spot market
+// https://www.kucoin.com/docs-new/3470224w0
+
+================
+File: examples/WebSockets/ws-public-spot-pro-v2.ts
+================
+/* eslint-disable no-unused-vars */
+import {
+  WebsocketClient,
+  WS_KEY_MAP,
+  WsTopicRequest,
+} from '../../src/index.js';
+// import { DefaultLogger, WebsocketClient, WsTopicRequest } from 'kucoin-api';
+// normally you should install this module via npm: `npm install kucoin-api`
+⋮----
+async function start()
+⋮----
+// Optional: fully customise the logging experience by injecting a custom logger
+// const logger: typeof DefaultLogger = {
+//   ...DefaultLogger,
+//   trace: (...params) => {
+//     if (
+//       [
+//         'Sending ping',
+//         'Sending upstream ws message: ',
+//         'Received pong',
+//       ].includes(params[0])
+//     ) {
+//       return;
+//     }
+//     console.log('trace', params);
+//   },
+// };
+⋮----
+// const client = new WebsocketClient({}, logger);
+⋮----
+// Data received
+⋮----
+// Something happened, attempting to reconenct
+⋮----
+// Reconnect successful
+⋮----
+// Connection closed. If unexpected, expect reconnect -> reconnected.
+⋮----
+// Reply to a request, e.g. "subscribe"/"unsubscribe"/"authenticate"
+⋮----
+// throw new Error('res?');
+⋮----
+/**
+   * The following example demonstrates the ways to consume data from the V2 (Pro) WebSockets. For the V1 examples, ws-private-spot-v1.ts
+   */
+⋮----
+// Optional: await a connection to be ready before subscribing (this is not necessary)
+// await client.connect(WS_KEY_MAP.spotPublicProV2);
+⋮----
+/**
+     * Structure your requests into the following format. The below example will be sent as per the example in the docs. The parameters are automatically merged into the request. Just follow the example below:
+     * {
+     *    "id": "1545910660739", // automatically generated by SDK
+     *    "action": "SUBSCRIBE", // automatically added by SDK
+     *    "channel":"kline",
+     *    "tradeType": "SPOT",       // SPOT / FUTURES
+     *    "symbol": "BTC-USDT",
+     *    "interval": "1min"
+     * }
+     *
+     * https://www.kucoin.com/docs-new/3470223w0
+     */
+⋮----
+/**
+       * Anything in the payload will be merged into the subscribe "request", allowing you to send misc parameters supported by the exchange.
+       * For more info on parameters, see: https://www.kucoin.com/docs-new/websocket-api/base-info/introduction-uta#5-subscribe
+       */
+⋮----
+// this needs to match the WsKey below.
+// tradeType: SPOT ==> spotPublicProV2
+// tradeType: FUTURES ==> futuresPublicProV2
+⋮----
+/**
+     * Or, send an array of structured objects with parameters, if you wanted to send multiple in one request
+     *
+     */
+⋮----
+// BTCUSDT tickers for spot market
+// https://www.kucoin.com/docs-new/3470222w0
+⋮----
+// BTCUSDT orderbook updates for spot market
+// https://www.kucoin.com/docs-new/3470221w0
+⋮----
+depth: '5', // 1 / 5 / 50 / increment
+rpiFilter: 0, // 0：Only NoneRPI orders [Default]  1(Only Support Futures)：NoneRPI+ RPI Orders. When rpiFilter=1, "depth" only supports 5/50.
+⋮----
+// BTCUSDT trades for spot market
+// https://www.kucoin.com/docs-new/3470224w0
+
+================
+File: src/types/request/futures.types.ts
+================
+/**
+ * REST - ACCOUNT  - BASIC INFO
+ * Get Account Ledgers - Futures
+ */
+⋮----
+export interface GetTransactionsRequest {
+  startAt?: number;
+  endAt?: number;
+  type?:
+    | 'RealisedPNL'
+    | 'Deposit'
+    | 'Withdrawal'
+    | 'Transferin'
+    | 'TransferOut';
+  offset?: number;
+  maxCount?: number;
+  currency?: string;
+  forward?: boolean;
+}
+⋮----
+/**
+ * REST - ACCOUNT  - SUBACCOUNT API
+ */
+⋮----
+export interface GetSubAPIsRequest {
+  apiKey?: string;
+  subName: string;
+}
+⋮----
+export interface CreateSubAPIRequest {
+  subName: string;
+  passphrase: string;
+  remark: string;
+  permission?: string;
+  ipWhitelist?: string;
+  expire?: string;
+}
+⋮----
+export interface UpdateSubAPIRequest {
+  subName: string;
+  apiKey: string;
+  passphrase: string;
+  permission?: string;
+  ipWhitelist?: string;
+  expire?: string;
+}
+⋮----
+export interface DeleteSubAPIRequest {
+  apiKey: string;
+  passphrase: string;
+  subName: string;
+}
+⋮----
+/**
+ * REST - FUNDING - FUNDING OVERVIEW
+ */
+⋮----
+/**
+ * REST - FUNDING - TRANSFER
+ */
+⋮----
+export interface SubmitTransfer {
+  amount: number;
+  currency: string;
+  recAccountType: 'MAIN' | 'TRADE';
+}
+⋮----
+export interface GetTransfersRequest {
+  startAt?: number;
+  endAt?: number;
+  status?: 'PROCESSING' | 'SUCCESS' | 'FAILURE';
+  queryStatus?: 'PROCESSING' | 'SUCCESS' | 'FAILURE'[];
+  currency?: string;
+  currentPage?: number;
+  pageSize?: number;
+}
+⋮----
+/**
+ *
+ * Futures Market Data
+ *
+ */
+⋮----
+export interface GetKlinesRequest {
+  symbol: string;
+  granularity: number;
+  from?: number;
+  to?: number;
+}
+⋮----
+export interface GetInterestRatesRequest {
+  symbol: string;
+  startAt?: number;
+  endAt?: number;
+  reverse?: boolean;
+  offset?: number;
+  forward?: boolean;
+  maxCount?: number;
+}
+⋮----
+/**
+ *
+ ***********
+ * Account
+ ***********
+ *
+ */
+⋮----
+/**
+ *
+ * Orders
+ *
+ */
+⋮----
+export interface Order {
+  clientOid: string;
+  side: 'buy' | 'sell';
+  symbol: string;
+  leverage?: number;
+  type?: 'limit' | 'market';
+  remark?: string;
+  stop?: 'down' | 'up';
+  stopPriceType?: 'TP' | 'MP' | 'IP';
+  stopPrice?: string;
+  reduceOnly?: boolean;
+  closeOrder?: boolean;
+  forceHold?: boolean;
+  stp?: 'CN' | 'CO' | 'CB';
+  marginMode?: 'ISOLATED' | 'CROSS';
+  price?: string;
+  size?: number;
+  qty?: string;
+  valueQty?: string;
+  /**
+   * Time in Force. Added 'RPI' as of 2025.01.02
+   * - GTC: Good Till Cancel (default)
+   * - IOC: Immediate Or Cancel
+   * - RPI: Retail Price Improvement Order (Phase 1: Futures only)
+   */
+  timeInForce?: 'GTC' | 'IOC' | 'RPI';
+  postOnly?: boolean;
+  hidden?: boolean;
+  iceberg?: boolean;
+  visibleSize?: string;
+  positionSide?: 'BOTH' | 'LONG' | 'SHORT';
+}
+⋮----
+/**
+   * Time in Force. Added 'RPI' as of 2025.01.02
+   * - GTC: Good Till Cancel (default)
+   * - IOC: Immediate Or Cancel
+   * - RPI: Retail Price Improvement Order (Phase 1: Futures only)
+   */
+⋮----
+export interface SLTPOrder {
+  clientOid: string;
+  side: 'buy' | 'sell';
+  symbol: string;
+  leverage?: number;
+  type: 'limit' | 'market';
+  remark?: string;
+  triggerStopUpPrice?: string;
+  stopPriceType?: 'TP' | 'MP' | 'IP';
+  triggerStopDownPrice?: string;
+  reduceOnly?: boolean;
+  closeOrder?: boolean;
+  forceHold?: boolean;
+  stp?: 'CN' | 'CO' | 'CB';
+  marginMode?: 'ISOLATED' | 'CROSS';
+  price?: string;
+  size?: number;
+  qty?: string;
+  valueQty?: string;
+  /**
+   * Time in Force. Added 'RPI' as of 2025.01.02
+   * - GTC: Good Till Cancel (default)
+   * - IOC: Immediate Or Cancel
+   * - RPI: Retail Price Improvement Order (Phase 1: Futures only)
+   */
+  timeInForce?: 'GTC' | 'IOC' | 'RPI';
+  postOnly?: boolean;
+  hidden?: boolean;
+  iceberg?: boolean;
+  visibleSize?: string;
+}
+⋮----
+/**
+   * Time in Force. Added 'RPI' as of 2025.01.02
+   * - GTC: Good Till Cancel (default)
+   * - IOC: Immediate Or Cancel
+   * - RPI: Retail Price Improvement Order (Phase 1: Futures only)
+   */
+⋮----
+export interface GetOrdersRequest {
+  status: 'active' | 'done';
+  symbol?: string;
+  side: 'buy' | 'sell';
+  type: 'limit' | 'market' | 'limit_stop' | 'market_stop';
+  startAt?: number;
+  endAt?: number;
+  currentPage?: number;
+  pageSize?: number;
+}
+⋮----
+export interface GetStopOrdersRequest {
+  symbol?: string;
+  side?: 'buy' | 'sell';
+  type?: 'limit' | 'market';
+  startAt?: number;
+  endAt?: number;
+  currentPage?: number;
+  pageSize?: number;
+}
+⋮----
+// Note: Either orderIdsList or clientOidsList must be provided, but not both.
+// When both are provided, orderIdsList takes precedence.
+export interface BatchCancelOrdersRequest {
+  orderIdsList?: string[];
+  clientOidsList?: {
+    symbol: string;
+    clientOid: string;
+  }[];
+}
+⋮----
+/**
+ *
+ * Futures Fills
+ *
+ */
+⋮----
+export interface AccountFillsRequest {
+  orderId?: string;
+  symbol?: string;
+  side?: 'buy' | 'sell';
+  type?: 'limit' | 'market' | 'limit_stop' | 'market_stop';
+  startAt?: number;
+  endAt?: number;
+  currentPage?: number;
+  pageSize?: number;
+  tradeTypes?: string;
+}
+⋮----
+/**
+ *
+ * Futures Positions
+ *
+ */
+⋮----
+export interface MaxOpenSizeRequest {
+  symbol: string;
+  price: string;
+  leverage: number;
+}
+⋮----
+/**
+ *
+ * Futures risk limit
+ *
+ */
+⋮----
+/**
+ *
+ * Futures funding fees
+ *
+ */
+⋮----
+export interface GetFundingRatesRequest {
+  symbol: string;
+  from: number;
+  to: number;
+}
+⋮----
+export interface GetFundingHistoryRequest {
+  symbol: string;
+  from?: number;
+  to?: number;
+  reverse?: boolean;
+  offset?: number;
+  forward?: boolean;
+  maxCount?: number;
+}
+⋮----
+/**
+ *
+ * Futures Copy Trading
+ *
+ */
+⋮----
+export interface CopyTradeOrderRequest {
+  clientOid: string;
+  side: 'buy' | 'sell';
+  symbol: string;
+  type: 'limit' | 'market';
+  leverage?: number;
+  remark?: string;
+  stop?: 'up' | 'down';
+  stopPriceType?: 'TP' | 'MP' | 'IP';
+  stopPrice?: string;
+  reduceOnly?: boolean;
+  closeOrder?: boolean;
+  forceHold?: boolean;
+  marginMode?: 'ISOLATED' | 'CROSS';
+  positionSide?: 'BOTH' | 'LONG' | 'SHORT';
+  price?: string;
+  size: number;
+  /**
+   * Time in Force. Added 'RPI' as of 2025.01.02
+   * - GTC: Good Till Cancel (default)
+   * - IOC: Immediate Or Cancel
+   * - RPI: Retail Price Improvement Order (Phase 1: Futures only)
+   */
+  timeInForce?: 'GTC' | 'IOC' | 'RPI';
+  postOnly?: boolean;
+  hidden?: boolean;
+  iceberg?: boolean;
+  visibleSize?: string;
+}
+⋮----
+/**
+   * Time in Force. Added 'RPI' as of 2025.01.02
+   * - GTC: Good Till Cancel (default)
+   * - IOC: Immediate Or Cancel
+   * - RPI: Retail Price Improvement Order (Phase 1: Futures only)
+   */
+⋮----
+export interface CopyTradeSLTPOrderRequest extends CopyTradeOrderRequest {
+  triggerStopUpPrice?: string; // Take profit price
+  triggerStopDownPrice?: string; // Stop loss price
+  stopPriceType?: 'TP' | 'MP' | 'IP';
+}
+⋮----
+triggerStopUpPrice?: string; // Take profit price
+triggerStopDownPrice?: string; // Stop loss price
+⋮----
+/**
+ * Switch Margin Mode (Copy Trading)
+ */
+export interface CopyTradeSwitchMarginModeRequest {
+  symbol: string;
+  marginMode: 'ISOLATED' | 'CROSS';
+}
+⋮----
+/**
+ * Modify Cross Margin Leverage (Copy Trading)
+ */
+export interface CopyTradeChangeCrossMarginLeverageRequest {
+  symbol: string;
+  leverage: string;
+}
+⋮----
+/**
+ * Get Cross Margin Requirement (Copy Trading)
+ */
+export interface CopyTradeGetCrossMarginRequirementRequest {
+  symbol: string;
+  positionValue: string;
+  leverage?: string;
+}
+⋮----
+/**
+ * Switch Position Mode (Copy Trading)
+ */
+export interface CopyTradeSwitchPositionModeRequest {
+  positionMode: '0' | '1'; // 0 = one-way mode, 1 = hedge mode
+}
+⋮----
+positionMode: '0' | '1'; // 0 = one-way mode, 1 = hedge mode
 
 ================
 File: src/types/websockets/ws-general.ts
@@ -9105,7 +8879,7 @@ import { AxiosRequestConfig } from 'axios';
 import type { ClientRequestArgs } from 'http';
 import WebSocket from 'isomorphic-ws';
 ⋮----
-import { RestClientOptions } from '../../lib/requestUtils.js';
+import { APIRegion, RestClientOptions } from '../../lib/requestUtils.js';
 ⋮----
 /** General configuration for the WebsocketClient */
 export interface WSClientConfigurableOptions {
@@ -9117,6 +8891,20 @@ export interface WSClientConfigurableOptions {
 
   /** Your API passphrase (can be anything) that you included when creating this API key */
   apiPassphrase?: string;
+
+  /**
+   * The API region you would like to work with:
+   * - Global (default)
+   *   - API Docs: https://www.kucoin.com/docs-new/introduction
+   * - EU:
+   *   - API Docs: https://www.kucoin.com/en-eu/docs-new/introduction/eu
+   *   - Behaves the same as global, but keep in mind that futures may not be available at this time for EU users.
+   * - AU:
+   *   - API Docs: https://www.kucoin.com/en-au/docs-new/introduction/au
+   *   - Ensures regional market data is retrieved (e.g. correct trading pairs, correct tickers, etc).
+   *   - Also ensures requests for AU users include the required extra header (X-SITE-TYPE: australia).
+   */
+  apiRegion?: APIRegion;
 
   /** Define a recv window when preparing a private websocket signature. This is in milliseconds, so 5000 == 5 seconds */
   recvWindow?: number;
@@ -9158,6 +8946,19 @@ export interface WSClientConfigurableOptions {
 /** Your API secret */
 ⋮----
 /** Your API passphrase (can be anything) that you included when creating this API key */
+⋮----
+/**
+   * The API region you would like to work with:
+   * - Global (default)
+   *   - API Docs: https://www.kucoin.com/docs-new/introduction
+   * - EU:
+   *   - API Docs: https://www.kucoin.com/en-eu/docs-new/introduction/eu
+   *   - Behaves the same as global, but keep in mind that futures may not be available at this time for EU users.
+   * - AU:
+   *   - API Docs: https://www.kucoin.com/en-au/docs-new/introduction/au
+   *   - Ensures regional market data is retrieved (e.g. correct trading pairs, correct tickers, etc).
+   *   - Also ensures requests for AU users include the required extra header (X-SITE-TYPE: australia).
+   */
 ⋮----
 /** Define a recv window when preparing a private websocket signature. This is in milliseconds, so 5000 == 5 seconds */
 ⋮----
@@ -9213,965 +9014,369 @@ export type WsMarket = 'spot' | 'futures';
 export type WsEventInternalSrc = 'event' | 'function';
 
 ================
-File: src/FuturesClient.ts
+File: src/lib/BaseRestClient.ts
 ================
-import { AxiosRequestConfig } from 'axios';
-import { nanoid } from 'nanoid';
+/* eslint-disable no-unused-vars */
+import axios, { AxiosRequestConfig, AxiosResponse, Method } from 'axios';
+// NOTE: https.Agent is Node.js-only and not available in browser environments
+// Browser builds (via webpack) exclude this module - see webpack.config.js fallback settings
+import https from 'https';
 ⋮----
-import { BaseRestClient } from './lib/BaseRestClient.js';
+import { neverGuard } from './misc-util.js';
 import {
+  APIIDFutures,
+  APIIDFuturesSign,
+  APIIDMain,
+  APIIDMainSign,
+  getRestBaseUrl,
   REST_CLIENT_TYPE_ENUM,
   RestClientOptions,
   RestClientType,
-} from './lib/requestUtils.js';
+  serializeParams,
+} from './requestUtils.js';
 import {
-  AccountFillsRequest,
-  BatchCancelOrdersRequest,
-  CopyTradeChangeCrossMarginLeverageRequest,
-  CopyTradeGetCrossMarginRequirementRequest,
-  CopyTradeOrderRequest,
-  CopyTradeSLTPOrderRequest,
-  CopyTradeSwitchMarginModeRequest,
-  CopyTradeSwitchPositionModeRequest,
-  GetFundingHistoryRequest,
-  GetFundingRatesRequest,
-  GetInterestRatesRequest,
-  GetKlinesRequest,
-  GetOrdersRequest,
-  GetStopOrdersRequest,
-  GetTransactionsRequest,
-  MaxOpenSizeRequest,
-  Order,
-  SLTPOrder,
-} from './types/request/futures.types.js';
-import {
-  AccountBalance,
-  AccountSummary,
-  AddMargin,
-  BatchCancelOrderResult,
-  BatchMarginModeUpdateResponse,
-  CopyTradeCrossMarginRequirement,
-  CopyTradePosition,
-  CopyTradeSwitchMarginModeResponse,
-  CopyTradeSwitchPositionModeResponse,
-  CrossMarginRequirement,
-  CrossMarginRiskLimit,
-  FullOrderBookDetail,
-  FuturesAccountFundingRateHistory,
-  FuturesAccountTransaction,
-  FuturesActiveOrder,
-  FuturesClosedPositions,
-  FuturesCurrentFundingRate,
-  FuturesFill,
-  FuturesFills,
-  FuturesHistoricFundingRate,
-  FuturesKline,
-  FuturesMarkPrice,
-  FuturesOrder,
-  FuturesOrders,
-  FuturesPosition,
-  FuturesRiskLimit,
-  FuturesSubAccount,
-  FuturesSymbolInfo,
-  GetPositionModeResponse,
-  IndexListItem,
-  InterestRateItem,
-  MarketTradeDetail,
-  MaxOpenSize,
-  PremiumIndexItem,
-  SubmitMultipleOrdersFuturesResponse,
-  TickerDetail,
-} from './types/response/futures.types.js';
-import {
-  APISuccessResponse,
-  ServiceStatus,
-} from './types/response/shared.types.js';
-import { WsConnectionInfo } from './types/response/ws.js';
+  checkWebCryptoAPISupported,
+  SignAlgorithm,
+  SignEncodeMethod,
+  signMessage,
+} from './webCryptoAPI.js';
+⋮----
+export interface SignedRequest<T extends object | undefined = {}> {
+  originalParams: T;
+  paramsWithSign?: T & { sign: string };
+  serializedParams: string;
+  sign: string;
+  queryParamsWithSign: string;
+  timestamp: number;
+  recvWindow: number;
+}
+⋮----
+interface UnsignedRequest<T extends object | undefined = {}> {
+  originalParams: T;
+  paramsWithSign: T;
+}
+⋮----
+type SignMethod = 'kucoin';
+⋮----
+// request: {
+//   url: response.config.url,
+//   method: response.config.method,
+//   data: response.config.data,
+//   headers: response.config.headers,
+// },
+⋮----
+export abstract class BaseRestClient
+⋮----
+/** Defines the client type (affecting how requests & signatures behave) */
+abstract getClientType(): RestClientType;
 ⋮----
 /**
- *
- */
-export class FuturesClient extends BaseRestClient
-⋮----
+   * Create an instance of the REST client. Pass API credentials in the object in the first parameter.
+   * @param {RestClientOptions} [restClientOptions={}] options to configure REST API connectivity
+   * @param {AxiosRequestConfig} [networkOptions={}] HTTP networking options for axios
+   */
 constructor(
     restClientOptions: RestClientOptions = {},
-    requestOptions: AxiosRequestConfig = {},
+    networkOptions: AxiosRequestConfig = {},
 )
 ⋮----
-getClientType(): RestClientType
+/** Throw errors if any request params are empty */
+⋮----
+/** in ms == 5 minutes by default */
+⋮----
+/** inject custom rquest options based on axios specs - see axios docs for more guidance on AxiosRequestConfig: https://github.com/axios/axios#request-config */
+⋮----
+// If AU market, this ensures market data API calls return correct AU-specific data (e.g. correct trading pairs, tickers, etc).
+⋮----
+// If enabled, configure a https agent with keepAlive enabled
+// NOTE: This is Node.js-only functionality. In browser environments, this code is skipped
+// as the 'https' module is excluded via webpack fallback configuration.
+// Browser connection pooling is handled automatically by the browser itself.
+⋮----
+// Extract existing https agent parameters, if provided, to prevent the keepAlive flag from overwriting an existing https agent completely
+⋮----
+// For more advanced configuration, raise an issue on GitHub or use the "networkOptions"
+// parameter to define a custom httpsAgent with the desired properties
+⋮----
+// Check Web Crypto API support when credentials are provided
+⋮----
+// Throw if one of the 3 values is missing, but at least one of them is set
 ⋮----
 /**
+   * Generates a timestamp for signing API requests.
    *
-   * Misc Utility Methods
-   *
+   * This method can be overridden or customized using `customTimestampFn`
+   * to implement a custom timestamp synchronization mechanism.
+   * If no custom function is provided, it defaults to the current system time.
    */
+private getSignTimestampMs(): number
 ⋮----
-generateNewOrderID(): string
+private hasValidCredentials()
 ⋮----
-/**
-   *
-   * REST - ACCOUNT INFO - Account & Funding
-   *
-   */
-⋮----
-/**
-   * Get Account - Futures
-   * Request via this endpoint to get the info of the futures account.
-   */
-getBalance(params?: {
-    currency?: string;
-}): Promise<APISuccessResponse<AccountBalance>>
-⋮----
-/**
-   * Get Account Ledgers - Futures
-   * This endpoint can query the ledger records of the futures business line
-   */
-getTransactions(params: GetTransactionsRequest): Promise<
-    APISuccessResponse<{
-      hasMore: boolean; // Whether there are more pages
-      dataList: FuturesAccountTransaction[];
-    }>
-  > {
-    return this.getPrivate('api/v1/transaction-history', params);
-⋮----
-hasMore: boolean; // Whether there are more pages
-⋮----
-/**
-   *
-   * REST - ACCOUNT INFO - Sub Account
-   *
-   */
-⋮----
-/**
-   * Get SubAccount List - Futures Balance(V2)
-   * This endpoint can be used to get Futures sub-account information.
-   */
-getSubBalances(params?: { currency?: string }): Promise<
-    APISuccessResponse<{
-      summary: AccountSummary;
-      accounts: FuturesSubAccount[];
-    }>
-  > {
-    return this.getPrivate('api/v1/account-overview-all', params);
-⋮----
-/**
-   *
-   * REST - Account Info - Trade Fee
-   *
-   */
-⋮----
-/**
-   * Get Actual Fee - Futures
-   * This endpoint is for the actual futures fee rate of the trading pair. The fee rate of your sub-account is the same as that of the master account.
-   */
-getTradingPairFee(params: { symbol: string }): Promise<
-    APISuccessResponse<{
-      symbol: string;
-      takerFeeRate: string;
-      makerFeeRate: string;
-    }>
-  > {
-    return this.getPrivate('api/v1/trade-fees', params);
-⋮----
-/**
-   *
-   * REST - Futures Trading - Market Data
-   *
-   */
-⋮----
-/**
-   * Get Symbol
-   * Get information of specified contracts that can be traded.
-   * This API will return a list of tradable contracts, including some key parameters of the contract such as the symbol name, tick size, mark price,etc.
-   */
-getSymbol(params: {
-    symbol: string;
-}): Promise<APISuccessResponse<FuturesSymbolInfo>>
-⋮----
-/**
-   * Get Symbol
-   * Get information of specified contracts that can be traded.
-   * This API will return a list of tradable contracts, including some key parameters of the contract such as the symbol name, tick size, mark price,etc.
-   */
-getSymbols(): Promise<APISuccessResponse<FuturesSymbolInfo[]>>
-⋮----
-/**
-   * Get Ticker
-   * This endpoint returns "last traded price/size"、"best bid/ask price/size" etc. of a single symbol.
-   */
-getTicker(params: {
-    symbol: string;
-}): Promise<APISuccessResponse<TickerDetail>>
-⋮----
-/**
-   * Get All Tickers
-   * This endpoint returns "last traded price/size"、"best bid/ask price/size" etc. of all symbol.
-   */
-getTickers(): Promise<APISuccessResponse<TickerDetail[]>>
-⋮----
-/**
-   * Get Full OrderBook
-   * Query for Full orderbook depth data. (aggregated by price)
-   */
-getFullOrderBookLevel2(params: {
-    symbol: string;
-}): Promise<APISuccessResponse<FullOrderBookDetail>>
-⋮----
-/**
-   * Get Part OrderBook
-   * Query for part orderbook depth data. (aggregated by price)
-   */
-getPartOrderBookLevel2Depth20(params: {
-    symbol: string;
-}): Promise<APISuccessResponse<FullOrderBookDetail>>
-⋮----
-/**
-   * Get Part OrderBook
-   * Query for part orderbook depth data. (aggregated by price)
-   */
-getPartOrderBookLevel2Depth100(params: {
-    symbol: string;
-}): Promise<APISuccessResponse<FullOrderBookDetail>>
-⋮----
-/**
-   * Get Trade History
-   * Request via this endpoint to get the trade history of the specified symbol, the returned quantity is the last 100 transaction records.
-   */
-getMarketTrades(params: {
-    symbol: string;
-}): Promise<APISuccessResponse<MarketTradeDetail>>
-⋮----
-/**
-   * Get Klines
-   * Get the Kline of the symbol. Data are returned in grouped buckets based on requested type.
-   */
-getKlines(
-    params: GetKlinesRequest,
-): Promise<APISuccessResponse<FuturesKline[]>>
-⋮----
-/**
-   * Get Mark Price
-   * Get the mark price of the symbol.
-   */
-getMarkPrice(params: {
-    symbol: string;
-}): Promise<APISuccessResponse<FuturesMarkPrice>>
-⋮----
-/**
-   * Get Spot Index Price
-   * This endpoint returns the index price of the specified symbol.
-   */
-getIndex(params: GetInterestRatesRequest): Promise<
-    APISuccessResponse<{
-      dataList: IndexListItem[];
-      hasMore: boolean; // Whether there are more pages
-    }>
-  > {
-    return this.get('api/v1/index/query', params);
-⋮----
-hasMore: boolean; // Whether there are more pages
-⋮----
-/**
-   * Get Interest Rate Index
-   * This endpoint returns the interest rate index of the specified symbol.
-   */
-getInterestRates(params: GetInterestRatesRequest): Promise<
-    APISuccessResponse<{
-      dataList: InterestRateItem[];
-      hasMore: boolean; // Whether there are more pages
-    }>
-  > {
-    return this.get('api/v1/interest/query', params);
-⋮----
-hasMore: boolean; // Whether there are more pages
-⋮----
-/**
-   * Get Premium Index
-   * This endpoint returns the premium index of the specified symbol.
-   */
-getPremiumIndex(params: GetInterestRatesRequest): Promise<
-    APISuccessResponse<{
-      dataList: PremiumIndexItem[];
-      hasMore: boolean; // Whether there are more pages
-    }>
-  > {
-    return this.get('api/v1/premium/query', params);
-⋮----
-hasMore: boolean; // Whether there are more pages
-⋮----
-/**
-   * Get 24hr Stats
-   * Get the statistics of the platform futures trading volume in the last 24 hours.
-   */
-get24HourTransactionVolume(): Promise<
-    APISuccessResponse<{
-      turnoverOf24h: number;
-    }>
-  > {
-    return this.get('api/v1/trade-statistics');
-⋮----
-/**
-   * Get Server Time
-   * Get the API server time. This is the Unix timestamp.
-   */
-getServerTime(): Promise<APISuccessResponse<number>>
-⋮----
-/**
-   * Get Service Status
-   * This endpoint returns the status of the API service.
-   */
-getServiceStatus(): Promise<APISuccessResponse<ServiceStatus>>
-⋮----
-/**
-   *
-   * REST - Futures Trading - Orders
-   *
-   */
-⋮----
-/**
-   * Add Order
-   * Place order to the futures trading system
-   */
-submitOrder(params: Order): Promise<
-    APISuccessResponse<{
-      orderId?: string;
-      clientOid?: string;
-    }>
-  > {
-    return this.postPrivate('api/v1/orders', params);
-⋮----
-/**
-   * Add Order Test
-   * Order test endpoint, the request parameters and return parameters of this endpoint are exactly the same as the order endpoint, and can be used to verify whether the signature is correct and other operations.
-   */
-submitNewOrderTest(params: Order): Promise<
-⋮----
-/**
-   * Batch Add Orders
-   * Place multiple order to the futures trading system
-   */
-submitMultipleOrders(
-    params: Order[],
-): Promise<APISuccessResponse<SubmitMultipleOrdersFuturesResponse[]>>
-⋮----
-/**
-   * Add Take Profit And Stop Loss Order
-   * Place take profit and stop loss order supports both take-profit and stop-loss functions, and other functions are exactly the same as the place order endpoint.
-   */
-submitSLTPOrder(params: SLTPOrder): Promise<
-    APISuccessResponse<{
-      orderId?: string;
-      clientOid?: string;
-    }>
-  > {
-    return this.postPrivate('api/v1/st-orders', params);
-⋮----
-/**
-   * Cancel Order By OrderId
-   * Cancel an order (including a stop order).
-   */
-cancelOrderById(params: {
-    orderId: string;
-}): Promise<APISuccessResponse<
-⋮----
-/**
-   * Cancel Order By Client Order Id
-   * Cancel an order (including a stop order) by client order id.
-   */
-cancelOrderByClientOid(params: {
-    clientOid: string;
-    symbol: string;
-}): Promise<APISuccessResponse<
-⋮----
-/**
-   * Batch Cancel Orders
-   * Cancel multiple orders.
-   */
-batchCancelOrders(
-    params: BatchCancelOrdersRequest,
-): Promise<APISuccessResponse<BatchCancelOrderResult[]>>
-⋮----
-/**
-   * Cancel All Orders
-   * Using this endpoint, all open orders (excluding stop orders) can be canceled in batches.
-   */
-cancelAllOrdersV3(params: {
-    symbol: string;
-}): Promise<APISuccessResponse<
-⋮----
-/**
-   * Cancel All Stop orders
-   * Using this endpoint, all untriggered stop orders can be canceled in batches.
-   */
-cancelAllStopOrders(params?: {
-    symbol?: string;
-}): Promise<APISuccessResponse<
-⋮----
-/**
-   * Get Order By OrderId
-   * Get order details by order id.
-   */
-getOrderByOrderId(params: {
-    orderId: string;
-}): Promise<APISuccessResponse<FuturesOrder>>
-⋮----
-/**
-   * Get Order By Client Order Id
-   * Get order details by client order id.
-   */
-getOrderByClientOrderId(params: {
-    clientOid: string;
-}): Promise<APISuccessResponse<FuturesOrder>>
-⋮----
-/**
-   * Get Order List
-   * List your current orders. Any limit order on the exchange order book is in active status.
-   */
-getOrders(
-    params?: GetOrdersRequest,
-): Promise<APISuccessResponse<FuturesOrders>>
-⋮----
-/**
-   * Get Recent Closed Orders
-   * Get a list of recent 1000 closed orders in the last 24 hours.
-   */
-getRecentOrders(params?: {
-    symbol?: string;
-}): Promise<APISuccessResponse<FuturesOrder[]>>
-⋮----
-/**
-   * Get Stop Order List
-   * Get the un-triggered stop orders list. Stop orders that have been triggered can be queried through the general order endpoint
-   */
-getStopOrders(
-    params?: GetStopOrdersRequest,
-): Promise<APISuccessResponse<FuturesOrders>>
-⋮----
-/**
-   * Get Open Order Value
-   * You can query this endpoint to get the the total number and value of the all your active orders.
-   */
-getOpenOrderStatistics(params: {
-    symbol: string;
-}): Promise<APISuccessResponse<FuturesActiveOrder>>
-⋮----
-/**
-   * Get Recent Trade History
-   * Get a list of recent 1000 fills in the last 24 hours.
-   */
-getRecentFills(params?: {
-    symbol?: string;
-}): Promise<APISuccessResponse<FuturesFill[]>>
-⋮----
-/**
-   * Get Trade History
-   * Get a list of recent fills.
-   * If you need to get your recent trade history with low latency, please query endpoint Get List of Orders Completed in 24h. The requested data is not real-time.
-   */
-getFills(
-    params?: AccountFillsRequest,
-): Promise<APISuccessResponse<FuturesFills>>
-⋮----
-/**
-   *
-   * REST - Futures Trading - Positions
-   *
-   */
-⋮----
-/**
-   * Get Margin Mode
-   * This endpoint can query the margin mode of the current symbol.
-   */
-getMarginMode(params: { symbol: string }): Promise<
-    APISuccessResponse<{
-      symbol: string;
-      marginMode: 'ISOLATED' | 'CROSS';
-    }>
-  > {
-    return this.getPrivate('api/v2/position/getMarginMode', params);
-⋮----
-/**
-   * Switch Margin Mode
-   * Modify the margin mode of the current symbol.
-   */
-updateMarginMode(params: {
-    symbol: string;
-    marginMode: 'ISOLATED' | 'CROSS';
-  }): Promise<
-    APISuccessResponse<{
-      symbol: string;
-      marginMode: 'ISOLATED' | 'CROSS';
-    }>
-  > {
-    return this.postPrivate('api/v2/position/changeMarginMode', params);
-⋮----
-/**
-   * Batch Switch Margin Mode
-   * Batch modify the margin mode of the symbols.
-   */
-batchSwitchMarginMode(params: {
-    marginMode: 'ISOLATED' | 'CROSS';
-    symbols: string[];
-}): Promise<APISuccessResponse<BatchMarginModeUpdateResponse>>
-⋮----
-/**
-   * Get Max Open Size
-   * Get Maximum Open Position Size.
-   */
-getMaxOpenSize(
-    params: MaxOpenSizeRequest,
-): Promise<APISuccessResponse<MaxOpenSize>>
-⋮----
-/**
-   * Get Position Details
-   * Get the position details of a specified position.
-   * @deprecated Use getPositionV2 instead
-   */
-getPosition(params: {
-    symbol: string;
-}): Promise<APISuccessResponse<FuturesPosition>>
-⋮----
-/**
-   * Get Position Details
-   * Get the position details of a specified position.
-   */
-getPositionV2(params: {
-    symbol: string;
-}): Promise<APISuccessResponse<FuturesPosition>>
-⋮----
-/**
-   * Get Position List
-   * Get the position details of a specified position.
-   */
-getPositions(params?: {
-    currency?: string;
-}): Promise<APISuccessResponse<FuturesPosition[]>>
-⋮----
-/**
-   * Get Positions History
-   * This endpoint can query position history information records.
-   */
-getHistoryPositions(params?: {
-    symbol?: string;
-    from?: number;
-    to?: number;
-    limit?: number;
-    pageId?: number;
-}): Promise<APISuccessResponse<FuturesClosedPositions>>
-⋮----
-/**
-   * Get Max Withdraw Margin
-   * This endpoint can query the maximum amount of margin that the current position supports withdrawal.
-   */
-getMaxWithdrawMargin(params: {
-    symbol: string;
-}): Promise<APISuccessResponse<string>>
-⋮----
-/**
-   * Get Cross Margin Leverage
-   * This endpoint can query the current symbol's cross-margin leverage multiple.
-   */
-getCrossMarginLeverage(params: { symbol: string }): Promise<
-    APISuccessResponse<{
-      symbol: string;
-      leverage: string;
-    }>
-  > {
-    return this.getPrivate('api/v2/getCrossUserLeverage', params);
-⋮----
-/**
-   * Modify Cross Margin Leverage
-   * This endpoint can modify the current symbol's cross-margin leverage multiple.
-   */
-changeCrossMarginLeverage(params: {
-    symbol: string;
-    leverage: string;
-  }): Promise<
-    APISuccessResponse<{
-      symbol: string;
-      leverage: string;
-    }>
-  > {
-    return this.postPrivate('api/v2/changeCrossUserLeverage', params);
-⋮----
-/**
-   * Add Isolated Margin
-   * Add Isolated Margin Manually.
-   */
-depositMargin(params: {
-    symbol: string;
-    margin: number;
-    bizNo: string;
-}): Promise<APISuccessResponse<AddMargin>>
-⋮----
-/**
-   * Get Cross Margin Risk Limit
-   * Batch get cross margin risk limit. (It should be noted that the risk limit of cross margin does not have a fixed gear, but is a smooth curve)
-   */
-getCrossMarginRiskLimit(params: {
-    symbol: string;
-    totalMargin?: string;
-    leverage?: number;
-}): Promise<APISuccessResponse<CrossMarginRiskLimit[]>>
-⋮----
-/**
-   * Remove Isolated Margin
-   * Remove Isolated Margin Manually.
-   */
-withdrawMargin(params: {
-    symbol: string;
-    withdrawAmount: string;
-}): Promise<APISuccessResponse<string>>
-⋮----
-/**
-   * Get Cross Margin Requirement
-   * This endpoint supports querying the cross margin requirements of a symbol by position value.
-   */
-getCrossMarginRequirement(params: {
-    symbol: string;
-    positionValue: string;
-    leverage?: string;
-}): Promise<APISuccessResponse<CrossMarginRequirement>>
-⋮----
-/**
-   * Get Isolated Margin Risk Limit
-   * This endpoint can be used to obtain information about risk limit level of a specific contract(Only valid for isolated Margin).
-   */
-getRiskLimitLevel(params: {
-    symbol: string;
-}): Promise<APISuccessResponse<FuturesRiskLimit[]>>
-⋮----
-/**
-   * Modify Isolated Margin Risk Limit
-   * This endpoint is for the adjustment of the risk limit level(Only valid for isolated Margin).
-   */
-updateRiskLimitLevel(params: {
-    symbol: string;
-    level: number;
-}): Promise<boolean>
-⋮----
-/**
-   * Get Position Mode
-   * This interface can query the position mode of this account.
-   */
-getPositionMode(): Promise<APISuccessResponse<GetPositionModeResponse>>
-⋮----
-/**
-   * Switch Position Mode
-   * This endpoint can switch the position mode of the current symbol.
-   */
-updatePositionMode(params: { positionMode: '0' | '1' }): Promise<
-    APISuccessResponse<{
-      positionMode: '0' | '1';
-    }>
-  > {
-    return this.postPrivate('api/v2/position/switchPositionMode', params);
-⋮----
-/**
-   *
-   * REST - Futures Trading - Funding Fees
-   *
-   */
-⋮----
-/**
-   * Get Current Funding Rate
-   * This endpoint can be used to obtain the current funding rate of the specified symbol.
-   */
-getFundingRate(params: {
-    symbol: string;
-}): Promise<APISuccessResponse<FuturesCurrentFundingRate>>
-⋮----
-/**
-   * Get Public Funding History
-   * Query the funding rate at each settlement time point within a certain time range of the corresponding contract
-   */
-getFundingRates(
-    params: GetFundingRatesRequest,
-): Promise<APISuccessResponse<FuturesHistoricFundingRate[]>>
-⋮----
-/**
-   * Get Private Funding History
-   * Submit request to get the funding history.
-   */
-getFundingHistory(params: GetFundingHistoryRequest): Promise<
-    APISuccessResponse<{
-      dataList: FuturesAccountFundingRateHistory[];
-      hasMore: boolean; // Whether there are more pages
-    }>
-  > {
-    return this.getPrivate('api/v1/funding-history', params);
-⋮----
-hasMore: boolean; // Whether there are more pages
-⋮----
-/**
-   *
-   * REST - Futures Trading - CopyTrading
-   *
-   */
-⋮----
-/**
-   * Add Order (Copy Trading)
-   * Place order to the futures trading system for copy trading.
-   * Max leverage is set to 20x, and marginMode supports both ISOLATED and CROSS.
-   */
-submitCopyTradeOrder(params: CopyTradeOrderRequest): Promise<
-    APISuccessResponse<{
-      orderId: string;
-      clientOid: string;
-    }>
-  > {
-    return this.postPrivate('api/v1/copy-trade/futures/orders', params);
-⋮----
-/**
-   * Add Order Test (Copy Trading)
-   * Order test endpoint, the request parameters and return parameters of this endpoint are exactly the same as the order endpoint,
-   * and can be used to verify whether the signature is correct and other operations.
-   * Max leverage is set to 20x, and marginMode supports both ISOLATED and CROSS.
-   */
-submitCopyTradeOrderTest(params: CopyTradeOrderRequest): Promise<
-    APISuccessResponse<{
-      orderId: string;
-      clientOid: string;
-    }>
-  > {
-    return this.postPrivate('api/v1/copy-trade/futures/orders/test', params);
+setAccessToken(newAccessToken: string)
 ⋮----
-/**
-   * Add Take Profit And Stop Loss Order (Copy Trading)
-   * Place take profit and stop loss order supports both take-profit and stop-loss functions, and other functions are exactly the same as the place order endpoint.
-   * Max leverage is set to 20x, and marginMode supports both ISOLATED and CROSS.
-   */
-submitCopyTradeSLTPOrder(params: CopyTradeSLTPOrderRequest): Promise<
-    APISuccessResponse<{
-      orderId: string;
-      clientOid: string;
-    }>
-  > {
-    return this.postPrivate('api/v1/copy-trade/futures/st-orders', params);
+hasAccessToken(): boolean
 ⋮----
-/**
-   * Cancel Order By OrderId
-   * Cancel an order (including a stop order) in copy trading.
-   */
-cancelCopyTradeOrderById(params: {
-    orderId: string;
-}): Promise<APISuccessResponse<
+get(endpoint: string, params?: any)
 ⋮----
-/**
-   * Cancel Order By Client Order Id
-   * Cancel an order (including a stop order) in copy trading by client order id.
-   */
-cancelCopyTradeOrderByClientOid(params: {
-    clientOid?: string;
-    symbol: string;
-}): Promise<APISuccessResponse<
+post(endpoint: string, params?: any)
 ⋮----
-/**
-   * Get Max Open Size
-   * Get Maximum Open Position Size.
-   */
-getCopyTradeMaxOpenSize(params: {
-    symbol: string;
-    maxBuyOpenSize: string;
-    maxSellOpenSize: string;
-  }): Promise<
-    APISuccessResponse<{
-      symbol: string;
-      price: string;
-      leverage: number;
-    }>
-  > {
-    return this.getPrivate(
-      'api/v1/copy-trade/futures/get-max-open-size',
-      params,
-    );
+getPrivate(endpoint: string, params?: any)
 ⋮----
-/**
-   * Get Max Withdraw Margin (Copy Trading)
-   * This endpoint can query the maximum amount of margin that the current position supports withdrawal.
-   */
-getCopyTradeMaxWithdrawMargin(params: {
-    symbol: string;
-    positionSide?: 'BOTH' | 'LONG' | 'SHORT';
-}): Promise<APISuccessResponse<string>>
+postPrivate(endpoint: string, params?: any)
 ⋮----
-/**
-   * Add Isolated Margin (Copy Trading)
-   * Add Isolated Margin Manually.
-   */
-addCopyTradeIsolatedMargin(params: {
-    symbol: string;
-    margin: number;
-    bizNo: string;
-    positionSide?: 'BOTH' | 'LONG' | 'SHORT';
-}): Promise<APISuccessResponse<CopyTradePosition>>
+deletePrivate(endpoint: string, params?: any)
 ⋮----
 /**
-   * Remove Isolated Margin (Copy Trading)
-   * Remove Isolated Margin Manually.
+   * @private Make a HTTP request to a specific endpoint. Private endpoint API calls are automatically signed.
    */
-removeCopyTradeIsolatedMargin(params: {
-    symbol: string;
-    withdrawAmount: string;
-    positionSide?: 'BOTH' | 'LONG' | 'SHORT';
-}): Promise<APISuccessResponse<string>>
+private async _call(
+    method: Method,
+    endpoint: string,
+    params?: any,
+    isPublicApi?: boolean,
+): Promise<any>
 ⋮----
-/**
-   * Modify Isolated Margin Risk Limit
-   * This endpoint is for the adjustment of the risk limit level(Only valid for isolated Margin).
-   * To adjust the level will cancel the open order, the response can only indicate whether the submit of the adjustment request is successful or not.
-   */
-modifyCopyTradeRiskLimitLevel(params: {
-    symbol: string;
-    level: number;
-}): Promise<APISuccessResponse<boolean>>
+// Sanity check to make sure it's only ever prefixed by one forward slash
 ⋮----
-/**
-   * Modify Isolated Margin Auto-Deposit Status (Copy Trading)
-   * This endpoint is only applicable to isolated margin and is no longer recommended. It is recommended to use cross margin instead.
-   * @deprecated - It is recommended to use cross margin instead
-   */
-updateCopyTradeAutoDepositStatus(params: {
-    symbol: string;
-    status: boolean;
-    positionSide?: 'BOTH' | 'LONG' | 'SHORT';
-}): Promise<APISuccessResponse<boolean>>
+// Build a request and handle signature process
 ⋮----
-/**
-   * Switch Margin Mode (Copy Trading)
-   * Modify the margin mode of the current symbol.
-   */
-switchCopyTradeMarginMode(
-    params: CopyTradeSwitchMarginModeRequest,
-): Promise<APISuccessResponse<CopyTradeSwitchMarginModeResponse>>
+// Dispatch request
 ⋮----
-/**
-   * Modify Cross Margin Leverage (Copy Trading)
-   * This interface can modify the current symbol's cross-margin leverage multiple.
-   */
-updateCopyTradeCrossMarginLeverage(
-    params: CopyTradeChangeCrossMarginLeverageRequest,
-): Promise<APISuccessResponse<boolean>>
+// Throw if API returns an error (e.g. insufficient balance)
 ⋮----
 /**
-   * Get Cross Margin Requirement (Copy Trading)
-   * This endpoint supports querying the cross margin requirements of a symbol by position value.
+   * @private generic handler to parse request exceptions
    */
-getCopyTradeCrossMarginRequirement(
-    params: CopyTradeGetCrossMarginRequirementRequest,
-): Promise<APISuccessResponse<CopyTradeCrossMarginRequirement[]>>
+parseException(e: any, requestParams: any): unknown
 ⋮----
-/**
-   * Switch Position Mode (Copy Trading)
-   * This interface is used to toggle between one-way mode and hedge mode for the position mode.
-   * Applies to all futures trading pairs.
-   */
-switchCopyTradePositionMode(
-    params: CopyTradeSwitchPositionModeRequest,
-): Promise<APISuccessResponse<CopyTradeSwitchPositionModeResponse>>
-/**
-   *
-   * REST - Futures - Broker
-   *
-   */
+// Something happened in setting up the request that triggered an error
 ⋮----
-/**
-   * Get download link for broker rebate orders
-   *
-   * trade type 1 = spot, trade type 2 = futures
-   * @deprecated Use getBrokerRebateOrderDownloadLinkV2 instead
-   */
-getBrokerRebateOrderDownloadLink(params: {
-    begin: string;
-    end: string;
-    tradeType: 1 | 2;
-}): Promise<APISuccessResponse<any>>
+// request made but no response received
 ⋮----
-/**
-   * Get download link for broker rebate orders
-   *
-   * trade type SPOT = spot, FUTURE = futures
-   */
-getBrokerRebateOrderDownloadLinkV2(params: {
-    begin: string;
-    end: string;
-    tradeType: 'SPOT' | 'FUTURE';
-}): Promise<APISuccessResponse<any>>
+// The request was made and the server responded with a status code
+// that falls out of the range of 2xx
 ⋮----
-/**
-   *
-   * WebSockets
-   *
-   */
+// console.error('err: ', response?.data);
 ⋮----
-/**
-   * Public V1 WS Connection Token & URL
-   */
-getPublicWSConnectionToken(): Promise<APISuccessResponse<WsConnectionInfo>>
+// Prevent credentials from leaking into error messages
 ⋮----
-/**
-   * Private V1 WS Connection Token & URL
-   */
-getPrivateWSConnectionToken(): Promise<APISuccessResponse<WsConnectionInfo>>
+private async signMessage(
+    paramsStr: string,
+    secret: string,
+    method: SignEncodeMethod,
+    algorithm: SignAlgorithm,
+): Promise<string>
 ⋮----
 /**
-   * Fetch connection token for V2 (Pro) private connections. Not needed for public.
-   * Only returns token, no URL.
+   * @private sign request and set recv window
    */
-getPrivateWSConnectionTokenV2(): Promise<
-    APISuccessResponse<WsConnectionInfo>
-  > {
-    return this.postPrivate('api/v2/bullet-private');
+private async signRequest<T extends object | undefined = {}>(
+    data: T,
+    endpoint: string,
+    method: Method,
+    signMethod: SignMethod,
+): Promise<SignedRequest<T>>
 ⋮----
-/*
-   *
-   * DEPRECATED
-   *
-   */
+// Only sign when no access token is provided
 ⋮----
-/**
-   * @deprecated - please use universal transfer from SpotClient
-   */
-submitTransferOut(params: {
-    currency: string;
-    amount: number;
-    recAccountType: 'MAIN' | 'TRADE';
-}): Promise<APISuccessResponse<any>>
+private async prepareSignParams<TParams extends object | undefined>(
+    method: Method,
+    endpoint: string,
+    signMethod: SignMethod,
+    params?: TParams,
+    isPublicApi?: true,
+  ): Promise<UnsignedRequest<TParams>>;
 ⋮----
-/**
-   * @deprecated - please use universal transfer from SpotClient
-   */
-submitTransferIn(params: {
-    currency: string;
-    amount: number;
-    payAccountType: 'MAIN' | 'TRADE';
-}): Promise<APISuccessResponse<any>>
+private async prepareSignParams<TParams extends object | undefined>(
+    method: Method,
+    endpoint: string,
+    signMethod: SignMethod,
+    params?: TParams,
+    isPublicApi?: false | undefined,
+  ): Promise<SignedRequest<TParams>>;
 ⋮----
-/**
-   * @deprecated - please use universal transfer from SpotClient
-   */
-getTransfers(params?: {
-    currency?: string;
-    type?: 'MAIN' | 'TRADE' | 'MARGIN' | 'ISOLATED';
-    tag?: string[];
-    startAt?: number;
-    endAt?: number;
-    currentPage?: number;
-    pageSize?: number;
-}): Promise<APISuccessResponse<any>>
+private async prepareSignParams<TParams extends object | undefined>(
+    method: Method,
+    endpoint: string,
+    signMethod: SignMethod,
+    params?: TParams,
+    isPublicApi?: boolean,
+)
 ⋮----
-/**
-   * @deprecated - please use updateMarginMode() instead
-   */
-updateAutoDepositStatus(params: {
-    symbol: string;
-    status: boolean;
-}): Promise<APISuccessResponse<any>>
+/** Returns an axios request object. Handles signing process automatically if this is a private API call */
+private async buildRequest(
+    method: Method,
+    endpoint: string,
+    url: string,
+    params?: any,
+    isPublicApi?: boolean,
+): Promise<AxiosRequestConfig>
+⋮----
+// Support for Authorization header, if provided:
+// https://github.com/tiagosiebler/kucoin-api/issues/2
+// Use restClient.setAccessToken(newToken), if you need to store a new access token
 
 ================
-File: src/index.ts
+File: src/lib/requestUtils.ts
 ================
+import { neverGuard } from './misc-util.js';
+⋮----
+/**
+ * Used to switch how authentication/requests work under the hood
+ */
+⋮----
+/** Global & AU: Spot & Margin */
+⋮----
+/** Global & AU: Futures */
+⋮----
+/** Global: Broker */
+⋮----
+/** Global: Unified Trading Account */
+⋮----
+/** Dedicated EU: main (Spot & Margin). No futures at this time. */
+⋮----
+export type RestClientType =
+  (typeof REST_CLIENT_TYPE_ENUM)[keyof typeof REST_CLIENT_TYPE_ENUM];
+⋮----
+// https://www.kucoin.com/en-eu/docs-new/introduction/eu
+⋮----
+export type APIRegion = 'global' | 'EU' | 'AU';
+⋮----
+export interface RestClientOptions {
+  /** Your API key */
+  apiKey?: string;
 
+  /** Your API secret */
+  apiSecret?: string;
+
+  /** Your API passphrase (can be anything) that you set when creating this API key (NOT your account password) */
+  apiPassphrase?: string;
+
+  /**
+   * Use access token instead of sign, if this is provided.
+   * For guidance refer to: https://github.com/tiagosiebler/kucoin-api/issues/2
+   */
+  apiAccessToken?: string;
+
+  /** The API key version. Defaults to "2" right now. You can see this in your API management page */
+  apiKeyVersion?: number | string;
+
+  /**
+   * The API region you would like to work with:
+   * - Global (default)
+   *   - API Docs: https://www.kucoin.com/docs-new/introduction
+   * - EU:
+   *   - API Docs: https://www.kucoin.com/en-eu/docs-new/introduction/eu
+   *   - Behaves the same as global, but keep in mind that futures may not be available at this time for EU users.
+   * - AU:
+   *   - API Docs: https://www.kucoin.com/en-au/docs-new/introduction/au
+   *   - Ensures regional market data is retrieved (e.g. correct trading pairs, correct tickers, etc).
+   *   - Also ensures requests for AU users include the required extra header (X-SITE-TYPE: australia).
+   */
+  apiRegion?: APIRegion;
+
+  /** Default: false. If true, we'll throw errors if any params are undefined */
+  strictParamValidation?: boolean;
+
+  /**
+   * Optionally override API protocol + domain. This will override any domain influence from the apiRegion parameter.
+   * e.g baseUrl: 'https://api.kucoin.com'
+   **/
+  baseUrl?: string;
+
+  /** Default: true. whether to try and post-process request exceptions (and throw them). */
+  parseExceptions?: boolean;
+
+  customTimestampFn?: () => number;
+
+  /**
+   * Enable keep alive for REST API requests (via axios).
+   */
+  keepAlive?: boolean;
+
+  /**
+   * When using HTTP KeepAlive, how often to send TCP KeepAlive packets over sockets being kept alive. Default = 1000.
+   * Only relevant if keepAlive is set to true.
+   * Default: 1000 (defaults comes from https agent)
+   */
+  keepAliveMsecs?: number;
+
+  /**
+   * Allows you to provide a custom "signMessage" function, e.g. to use node's much faster createHmac method
+   *
+   * Look in the examples folder for a demonstration on using node's createHmac instead.
+   */
+  customSignMessageFn?: (message: string, secret: string) => Promise<string>;
+}
+⋮----
+/** Your API key */
+⋮----
+/** Your API secret */
+⋮----
+/** Your API passphrase (can be anything) that you set when creating this API key (NOT your account password) */
+⋮----
+/**
+   * Use access token instead of sign, if this is provided.
+   * For guidance refer to: https://github.com/tiagosiebler/kucoin-api/issues/2
+   */
+⋮----
+/** The API key version. Defaults to "2" right now. You can see this in your API management page */
+⋮----
+/**
+   * The API region you would like to work with:
+   * - Global (default)
+   *   - API Docs: https://www.kucoin.com/docs-new/introduction
+   * - EU:
+   *   - API Docs: https://www.kucoin.com/en-eu/docs-new/introduction/eu
+   *   - Behaves the same as global, but keep in mind that futures may not be available at this time for EU users.
+   * - AU:
+   *   - API Docs: https://www.kucoin.com/en-au/docs-new/introduction/au
+   *   - Ensures regional market data is retrieved (e.g. correct trading pairs, correct tickers, etc).
+   *   - Also ensures requests for AU users include the required extra header (X-SITE-TYPE: australia).
+   */
+⋮----
+/** Default: false. If true, we'll throw errors if any params are undefined */
+⋮----
+/**
+   * Optionally override API protocol + domain. This will override any domain influence from the apiRegion parameter.
+   * e.g baseUrl: 'https://api.kucoin.com'
+   **/
+⋮----
+/** Default: true. whether to try and post-process request exceptions (and throw them). */
+⋮----
+/**
+   * Enable keep alive for REST API requests (via axios).
+   */
+⋮----
+/**
+   * When using HTTP KeepAlive, how often to send TCP KeepAlive packets over sockets being kept alive. Default = 1000.
+   * Only relevant if keepAlive is set to true.
+   * Default: 1000 (defaults comes from https agent)
+   */
+⋮----
+/**
+   * Allows you to provide a custom "signMessage" function, e.g. to use node's much faster createHmac method
+   *
+   * Look in the examples folder for a demonstration on using node's createHmac instead.
+   */
+⋮----
+export function serializeParams<T extends Record<string, any> | undefined = {}>(
+  params: T,
+  strict_validation: boolean | undefined,
+  encodeValues: boolean,
+  prefixWith: string,
+): string
+⋮----
+// Only prefix if there's a value
+⋮----
+export function getRestBaseUrl(
+  useTestnet: boolean,
+  restOptions: RestClientOptions,
+  restClientType: RestClientType,
+): string
+⋮----
+// Override to EU URL for EU regional users
 
 ================
 File: src/types/response/futures.types.ts
@@ -11132,17 +10337,1735 @@ export interface CopyTradeSwitchPositionModeResponse {
 positionMode: '0' | '1'; // 0 = one-way mode, 1 = hedge mode
 
 ================
-File: src/SpotClient.ts
+File: src/lib/websocket/websocket-util.ts
 ================
-import { AxiosRequestConfig } from 'axios';
+import WebSocket from 'isomorphic-ws';
+⋮----
+import { WsRequestOperationKucoin } from '../../types/websockets/ws-api.js';
+import { MessageEventLike } from '../../types/websockets/ws-events.js';
+⋮----
+/** Should be one WS key per unique URL */
+⋮----
+/** Dedicated V2 (Pro) connection for push of public spot market data */
+⋮----
+/** Dedicated V2 (Pro) connection for push of public futures market data */
+⋮----
+/** Shared (spot & futures) V2 (Pro) connection for all private data */
+⋮----
+/** This is used to differentiate between each of the available websocket streams */
+export type WsKey = (typeof WS_KEY_MAP)[keyof typeof WS_KEY_MAP];
+export type WSAPIWsKey =
+  | typeof WS_KEY_MAP.wsApiFuturesV1
+  | typeof WS_KEY_MAP.wsApiSpotV1;
+⋮----
+/**
+ * Normalised internal format for a request (subscribe/unsubscribe/etc) on a topic, with optional parameters.
+ *
+ * - Topic: the topic this event is for
+ * - Payload: the parameters to include, optional. E.g. auth requires key + sign. Some topics allow configurable parameters.
+ */
+export interface WsTopicRequest<
+  TWSTopic extends string = string,
+  TWSPayload = any,
+> {
+  topic: TWSTopic;
+  payload?: TWSPayload;
+}
+⋮----
+/**
+ * Conveniently allow users to request a topic either as string topics or objects (containing string topic + params)
+ */
+export type WsTopicRequestOrStringTopic<
+  TWSTopic extends string,
+  TWSPayload = any,
+> = WsTopicRequest<TWSTopic, TWSPayload> | string;
+⋮----
+/**
+ * #305: ws.terminate() is undefined in browsers.
+ * This only works in node.js, not in browsers.
+ * Does nothing if `ws` is undefined. Does nothing in browsers.
+ */
+export function safeTerminateWs(
+  ws?: WebSocket | any,
+  fallbackToClose?: boolean,
+): boolean
+⋮----
+/**
+ * WS API promises are stored using a primary key. This key is constructed using
+ * properties found in every request & reply.
+ *
+ * The counterpart to this is in resolveEmittableEvents
+ */
+export function getPromiseRefForWSAPIRequest(
+  wsKey: WsKey,
+  requestEvent: WsRequestOperationKucoin<string>,
+): string
+⋮----
+export function isWSAPIWsKey(wsKey: WsKey): wsKey is WSAPIWsKey
+⋮----
+export function isBufferMessageEvent(
+  msg: unknown,
+): msg is MessageEventLike<Buffer>
+⋮----
+export function bufferLooksLikeText(
+  data?: Buffer | ArrayBufferLike | null,
+): boolean
+⋮----
+// '{' '[' or '"' are common JSON prefixes; fast heuristic to detect plaintext
+⋮----
+export async function decompressMessageEvent(
+  event: MessageEventLike<Buffer<ArrayBufferLike>>,
+): Promise<MessageEventLike<any>>
+⋮----
+// Some KuCoin streams (notably newer spot public v2) send JSON in a binary
+// frame without compression. If the payload already looks like UTF-8 text,
+// skip decompression and just decode it so the message can be processed.
+⋮----
+start(controller)
+
+================
+File: src/FuturesClient.ts
+================
 import { nanoid } from 'nanoid';
 ⋮----
 import { BaseRestClient } from './lib/BaseRestClient.js';
+import { REST_CLIENT_TYPE_ENUM, RestClientType } from './lib/requestUtils.js';
 import {
-  REST_CLIENT_TYPE_ENUM,
-  RestClientOptions,
-  RestClientType,
-} from './lib/requestUtils.js';
+  AccountFillsRequest,
+  BatchCancelOrdersRequest,
+  CopyTradeChangeCrossMarginLeverageRequest,
+  CopyTradeGetCrossMarginRequirementRequest,
+  CopyTradeOrderRequest,
+  CopyTradeSLTPOrderRequest,
+  CopyTradeSwitchMarginModeRequest,
+  CopyTradeSwitchPositionModeRequest,
+  GetFundingHistoryRequest,
+  GetFundingRatesRequest,
+  GetInterestRatesRequest,
+  GetKlinesRequest,
+  GetOrdersRequest,
+  GetStopOrdersRequest,
+  GetTransactionsRequest,
+  MaxOpenSizeRequest,
+  Order,
+  SLTPOrder,
+} from './types/request/futures.types.js';
+import {
+  AccountBalance,
+  AccountSummary,
+  AddMargin,
+  BatchCancelOrderResult,
+  BatchMarginModeUpdateResponse,
+  CopyTradeCrossMarginRequirement,
+  CopyTradePosition,
+  CopyTradeSwitchMarginModeResponse,
+  CopyTradeSwitchPositionModeResponse,
+  CrossMarginRequirement,
+  CrossMarginRiskLimit,
+  FullOrderBookDetail,
+  FuturesAccountFundingRateHistory,
+  FuturesAccountTransaction,
+  FuturesActiveOrder,
+  FuturesClosedPositions,
+  FuturesCurrentFundingRate,
+  FuturesFill,
+  FuturesFills,
+  FuturesHistoricFundingRate,
+  FuturesKline,
+  FuturesMarkPrice,
+  FuturesOrder,
+  FuturesOrders,
+  FuturesPosition,
+  FuturesRiskLimit,
+  FuturesSubAccount,
+  FuturesSymbolInfo,
+  GetPositionModeResponse,
+  IndexListItem,
+  InterestRateItem,
+  MarketTradeDetail,
+  MaxOpenSize,
+  PremiumIndexItem,
+  SubmitMultipleOrdersFuturesResponse,
+  TickerDetail,
+} from './types/response/futures.types.js';
+import {
+  APISuccessResponse,
+  ServiceStatus,
+} from './types/response/shared.types.js';
+import { WsConnectionInfo } from './types/response/ws.js';
+⋮----
+/**
+ *
+ */
+export class FuturesClient extends BaseRestClient
+⋮----
+getClientType(): RestClientType
+⋮----
+/**
+   *
+   * Misc Utility Methods
+   *
+   */
+⋮----
+generateNewOrderID(): string
+⋮----
+/**
+   *
+   * REST - ACCOUNT INFO - Account & Funding
+   *
+   */
+⋮----
+/**
+   * Get Account - Futures
+   * Request via this endpoint to get the info of the futures account.
+   */
+getBalance(params?: {
+    currency?: string;
+}): Promise<APISuccessResponse<AccountBalance>>
+⋮----
+/**
+   * Get Account Ledgers - Futures
+   * This endpoint can query the ledger records of the futures business line
+   */
+getTransactions(params: GetTransactionsRequest): Promise<
+    APISuccessResponse<{
+      hasMore: boolean; // Whether there are more pages
+      dataList: FuturesAccountTransaction[];
+    }>
+  > {
+    return this.getPrivate('api/v1/transaction-history', params);
+⋮----
+hasMore: boolean; // Whether there are more pages
+⋮----
+/**
+   *
+   * REST - ACCOUNT INFO - Sub Account
+   *
+   */
+⋮----
+/**
+   * Get SubAccount List - Futures Balance(V2)
+   * This endpoint can be used to get Futures sub-account information.
+   */
+getSubBalances(params?: { currency?: string }): Promise<
+    APISuccessResponse<{
+      summary: AccountSummary;
+      accounts: FuturesSubAccount[];
+    }>
+  > {
+    return this.getPrivate('api/v1/account-overview-all', params);
+⋮----
+/**
+   *
+   * REST - Account Info - Trade Fee
+   *
+   */
+⋮----
+/**
+   * Get Actual Fee - Futures
+   * This endpoint is for the actual futures fee rate of the trading pair. The fee rate of your sub-account is the same as that of the master account.
+   */
+getTradingPairFee(params: { symbol: string }): Promise<
+    APISuccessResponse<{
+      symbol: string;
+      takerFeeRate: string;
+      makerFeeRate: string;
+    }>
+  > {
+    return this.getPrivate('api/v1/trade-fees', params);
+⋮----
+/**
+   *
+   * REST - Futures Trading - Market Data
+   *
+   */
+⋮----
+/**
+   * Get Symbol
+   * Get information of specified contracts that can be traded.
+   * This API will return a list of tradable contracts, including some key parameters of the contract such as the symbol name, tick size, mark price,etc.
+   */
+getSymbol(params: {
+    symbol: string;
+}): Promise<APISuccessResponse<FuturesSymbolInfo>>
+⋮----
+/**
+   * Get Symbol
+   * Get information of specified contracts that can be traded.
+   * This API will return a list of tradable contracts, including some key parameters of the contract such as the symbol name, tick size, mark price,etc.
+   */
+getSymbols(): Promise<APISuccessResponse<FuturesSymbolInfo[]>>
+⋮----
+/**
+   * Get Ticker
+   * This endpoint returns "last traded price/size"、"best bid/ask price/size" etc. of a single symbol.
+   */
+getTicker(params: {
+    symbol: string;
+}): Promise<APISuccessResponse<TickerDetail>>
+⋮----
+/**
+   * Get All Tickers
+   * This endpoint returns "last traded price/size"、"best bid/ask price/size" etc. of all symbol.
+   */
+getTickers(): Promise<APISuccessResponse<TickerDetail[]>>
+⋮----
+/**
+   * Get Full OrderBook
+   * Query for Full orderbook depth data. (aggregated by price)
+   */
+getFullOrderBookLevel2(params: {
+    symbol: string;
+}): Promise<APISuccessResponse<FullOrderBookDetail>>
+⋮----
+/**
+   * Get Part OrderBook
+   * Query for part orderbook depth data. (aggregated by price)
+   */
+getPartOrderBookLevel2Depth20(params: {
+    symbol: string;
+}): Promise<APISuccessResponse<FullOrderBookDetail>>
+⋮----
+/**
+   * Get Part OrderBook
+   * Query for part orderbook depth data. (aggregated by price)
+   */
+getPartOrderBookLevel2Depth100(params: {
+    symbol: string;
+}): Promise<APISuccessResponse<FullOrderBookDetail>>
+⋮----
+/**
+   * Get Trade History
+   * Request via this endpoint to get the trade history of the specified symbol, the returned quantity is the last 100 transaction records.
+   */
+getMarketTrades(params: {
+    symbol: string;
+}): Promise<APISuccessResponse<MarketTradeDetail>>
+⋮----
+/**
+   * Get Klines
+   * Get the Kline of the symbol. Data are returned in grouped buckets based on requested type.
+   */
+getKlines(
+    params: GetKlinesRequest,
+): Promise<APISuccessResponse<FuturesKline[]>>
+⋮----
+/**
+   * Get Mark Price
+   * Get the mark price of the symbol.
+   */
+getMarkPrice(params: {
+    symbol: string;
+}): Promise<APISuccessResponse<FuturesMarkPrice>>
+⋮----
+/**
+   * Get Spot Index Price
+   * This endpoint returns the index price of the specified symbol.
+   */
+getIndex(params: GetInterestRatesRequest): Promise<
+    APISuccessResponse<{
+      dataList: IndexListItem[];
+      hasMore: boolean; // Whether there are more pages
+    }>
+  > {
+    return this.get('api/v1/index/query', params);
+⋮----
+hasMore: boolean; // Whether there are more pages
+⋮----
+/**
+   * Get Interest Rate Index
+   * This endpoint returns the interest rate index of the specified symbol.
+   */
+getInterestRates(params: GetInterestRatesRequest): Promise<
+    APISuccessResponse<{
+      dataList: InterestRateItem[];
+      hasMore: boolean; // Whether there are more pages
+    }>
+  > {
+    return this.get('api/v1/interest/query', params);
+⋮----
+hasMore: boolean; // Whether there are more pages
+⋮----
+/**
+   * Get Premium Index
+   * This endpoint returns the premium index of the specified symbol.
+   */
+getPremiumIndex(params: GetInterestRatesRequest): Promise<
+    APISuccessResponse<{
+      dataList: PremiumIndexItem[];
+      hasMore: boolean; // Whether there are more pages
+    }>
+  > {
+    return this.get('api/v1/premium/query', params);
+⋮----
+hasMore: boolean; // Whether there are more pages
+⋮----
+/**
+   * Get 24hr Stats
+   * Get the statistics of the platform futures trading volume in the last 24 hours.
+   */
+get24HourTransactionVolume(): Promise<
+    APISuccessResponse<{
+      turnoverOf24h: number;
+    }>
+  > {
+    return this.get('api/v1/trade-statistics');
+⋮----
+/**
+   * Get Server Time
+   * Get the API server time. This is the Unix timestamp.
+   */
+getServerTime(): Promise<APISuccessResponse<number>>
+⋮----
+/**
+   * Get Service Status
+   * This endpoint returns the status of the API service.
+   */
+getServiceStatus(): Promise<APISuccessResponse<ServiceStatus>>
+⋮----
+/**
+   *
+   * REST - Futures Trading - Orders
+   *
+   */
+⋮----
+/**
+   * Add Order
+   * Place order to the futures trading system
+   */
+submitOrder(params: Order): Promise<
+    APISuccessResponse<{
+      orderId?: string;
+      clientOid?: string;
+    }>
+  > {
+    return this.postPrivate('api/v1/orders', params);
+⋮----
+/**
+   * Add Order Test
+   * Order test endpoint, the request parameters and return parameters of this endpoint are exactly the same as the order endpoint, and can be used to verify whether the signature is correct and other operations.
+   */
+submitNewOrderTest(params: Order): Promise<
+⋮----
+/**
+   * Batch Add Orders
+   * Place multiple order to the futures trading system
+   */
+submitMultipleOrders(
+    params: Order[],
+): Promise<APISuccessResponse<SubmitMultipleOrdersFuturesResponse[]>>
+⋮----
+/**
+   * Add Take Profit And Stop Loss Order
+   * Place take profit and stop loss order supports both take-profit and stop-loss functions, and other functions are exactly the same as the place order endpoint.
+   */
+submitSLTPOrder(params: SLTPOrder): Promise<
+    APISuccessResponse<{
+      orderId?: string;
+      clientOid?: string;
+    }>
+  > {
+    return this.postPrivate('api/v1/st-orders', params);
+⋮----
+/**
+   * Cancel Order By OrderId
+   * Cancel an order (including a stop order).
+   */
+cancelOrderById(params: {
+    orderId: string;
+}): Promise<APISuccessResponse<
+⋮----
+/**
+   * Cancel Order By Client Order Id
+   * Cancel an order (including a stop order) by client order id.
+   */
+cancelOrderByClientOid(params: {
+    clientOid: string;
+    symbol: string;
+}): Promise<APISuccessResponse<
+⋮----
+/**
+   * Batch Cancel Orders
+   * Cancel multiple orders.
+   */
+batchCancelOrders(
+    params: BatchCancelOrdersRequest,
+): Promise<APISuccessResponse<BatchCancelOrderResult[]>>
+⋮----
+/**
+   * Cancel All Orders
+   * Using this endpoint, all open orders (excluding stop orders) can be canceled in batches.
+   */
+cancelAllOrdersV3(params: {
+    symbol: string;
+}): Promise<APISuccessResponse<
+⋮----
+/**
+   * Cancel All Stop orders
+   * Using this endpoint, all untriggered stop orders can be canceled in batches.
+   */
+cancelAllStopOrders(params?: {
+    symbol?: string;
+}): Promise<APISuccessResponse<
+⋮----
+/**
+   * Get Order By OrderId
+   * Get order details by order id.
+   */
+getOrderByOrderId(params: {
+    orderId: string;
+}): Promise<APISuccessResponse<FuturesOrder>>
+⋮----
+/**
+   * Get Order By Client Order Id
+   * Get order details by client order id.
+   */
+getOrderByClientOrderId(params: {
+    clientOid: string;
+}): Promise<APISuccessResponse<FuturesOrder>>
+⋮----
+/**
+   * Get Order List
+   * List your current orders. Any limit order on the exchange order book is in active status.
+   */
+getOrders(
+    params?: GetOrdersRequest,
+): Promise<APISuccessResponse<FuturesOrders>>
+⋮----
+/**
+   * Get Recent Closed Orders
+   * Get a list of recent 1000 closed orders in the last 24 hours.
+   */
+getRecentOrders(params?: {
+    symbol?: string;
+}): Promise<APISuccessResponse<FuturesOrder[]>>
+⋮----
+/**
+   * Get Stop Order List
+   * Get the un-triggered stop orders list. Stop orders that have been triggered can be queried through the general order endpoint
+   */
+getStopOrders(
+    params?: GetStopOrdersRequest,
+): Promise<APISuccessResponse<FuturesOrders>>
+⋮----
+/**
+   * Get Open Order Value
+   * You can query this endpoint to get the the total number and value of the all your active orders.
+   */
+getOpenOrderStatistics(params: {
+    symbol: string;
+}): Promise<APISuccessResponse<FuturesActiveOrder>>
+⋮----
+/**
+   * Get Recent Trade History
+   * Get a list of recent 1000 fills in the last 24 hours.
+   */
+getRecentFills(params?: {
+    symbol?: string;
+}): Promise<APISuccessResponse<FuturesFill[]>>
+⋮----
+/**
+   * Get Trade History
+   * Get a list of recent fills.
+   * If you need to get your recent trade history with low latency, please query endpoint Get List of Orders Completed in 24h. The requested data is not real-time.
+   */
+getFills(
+    params?: AccountFillsRequest,
+): Promise<APISuccessResponse<FuturesFills>>
+⋮----
+/**
+   *
+   * REST - Futures Trading - Positions
+   *
+   */
+⋮----
+/**
+   * Get Margin Mode
+   * This endpoint can query the margin mode of the current symbol.
+   */
+getMarginMode(params: { symbol: string }): Promise<
+    APISuccessResponse<{
+      symbol: string;
+      marginMode: 'ISOLATED' | 'CROSS';
+    }>
+  > {
+    return this.getPrivate('api/v2/position/getMarginMode', params);
+⋮----
+/**
+   * Switch Margin Mode
+   * Modify the margin mode of the current symbol.
+   */
+updateMarginMode(params: {
+    symbol: string;
+    marginMode: 'ISOLATED' | 'CROSS';
+  }): Promise<
+    APISuccessResponse<{
+      symbol: string;
+      marginMode: 'ISOLATED' | 'CROSS';
+    }>
+  > {
+    return this.postPrivate('api/v2/position/changeMarginMode', params);
+⋮----
+/**
+   * Batch Switch Margin Mode
+   * Batch modify the margin mode of the symbols.
+   */
+batchSwitchMarginMode(params: {
+    marginMode: 'ISOLATED' | 'CROSS';
+    symbols: string[];
+}): Promise<APISuccessResponse<BatchMarginModeUpdateResponse>>
+⋮----
+/**
+   * Get Max Open Size
+   * Get Maximum Open Position Size.
+   */
+getMaxOpenSize(
+    params: MaxOpenSizeRequest,
+): Promise<APISuccessResponse<MaxOpenSize>>
+⋮----
+/**
+   * Get Position Details
+   * Get the position details of a specified position.
+   * @deprecated Use getPositionV2 instead
+   */
+getPosition(params: {
+    symbol: string;
+}): Promise<APISuccessResponse<FuturesPosition>>
+⋮----
+/**
+   * Get Position Details
+   * Get the position details of a specified position.
+   */
+getPositionV2(params: {
+    symbol: string;
+}): Promise<APISuccessResponse<FuturesPosition>>
+⋮----
+/**
+   * Get Position List
+   * Get the position details of a specified position.
+   */
+getPositions(params?: {
+    currency?: string;
+}): Promise<APISuccessResponse<FuturesPosition[]>>
+⋮----
+/**
+   * Get Positions History
+   * This endpoint can query position history information records.
+   */
+getHistoryPositions(params?: {
+    symbol?: string;
+    from?: number;
+    to?: number;
+    limit?: number;
+    pageId?: number;
+}): Promise<APISuccessResponse<FuturesClosedPositions>>
+⋮----
+/**
+   * Get Max Withdraw Margin
+   * This endpoint can query the maximum amount of margin that the current position supports withdrawal.
+   */
+getMaxWithdrawMargin(params: {
+    symbol: string;
+}): Promise<APISuccessResponse<string>>
+⋮----
+/**
+   * Get Cross Margin Leverage
+   * This endpoint can query the current symbol's cross-margin leverage multiple.
+   */
+getCrossMarginLeverage(params: { symbol: string }): Promise<
+    APISuccessResponse<{
+      symbol: string;
+      leverage: string;
+    }>
+  > {
+    return this.getPrivate('api/v2/getCrossUserLeverage', params);
+⋮----
+/**
+   * Modify Cross Margin Leverage
+   * This endpoint can modify the current symbol's cross-margin leverage multiple.
+   */
+changeCrossMarginLeverage(params: {
+    symbol: string;
+    leverage: string;
+  }): Promise<
+    APISuccessResponse<{
+      symbol: string;
+      leverage: string;
+    }>
+  > {
+    return this.postPrivate('api/v2/changeCrossUserLeverage', params);
+⋮----
+/**
+   * Add Isolated Margin
+   * Add Isolated Margin Manually.
+   */
+depositMargin(params: {
+    symbol: string;
+    margin: number;
+    bizNo: string;
+}): Promise<APISuccessResponse<AddMargin>>
+⋮----
+/**
+   * Get Cross Margin Risk Limit
+   * Batch get cross margin risk limit. (It should be noted that the risk limit of cross margin does not have a fixed gear, but is a smooth curve)
+   */
+getCrossMarginRiskLimit(params: {
+    symbol: string;
+    totalMargin?: string;
+    leverage?: number;
+}): Promise<APISuccessResponse<CrossMarginRiskLimit[]>>
+⋮----
+/**
+   * Remove Isolated Margin
+   * Remove Isolated Margin Manually.
+   */
+withdrawMargin(params: {
+    symbol: string;
+    withdrawAmount: string;
+}): Promise<APISuccessResponse<string>>
+⋮----
+/**
+   * Get Cross Margin Requirement
+   * This endpoint supports querying the cross margin requirements of a symbol by position value.
+   */
+getCrossMarginRequirement(params: {
+    symbol: string;
+    positionValue: string;
+    leverage?: string;
+}): Promise<APISuccessResponse<CrossMarginRequirement>>
+⋮----
+/**
+   * Get Isolated Margin Risk Limit
+   * This endpoint can be used to obtain information about risk limit level of a specific contract(Only valid for isolated Margin).
+   */
+getRiskLimitLevel(params: {
+    symbol: string;
+}): Promise<APISuccessResponse<FuturesRiskLimit[]>>
+⋮----
+/**
+   * Modify Isolated Margin Risk Limit
+   * This endpoint is for the adjustment of the risk limit level(Only valid for isolated Margin).
+   */
+updateRiskLimitLevel(params: {
+    symbol: string;
+    level: number;
+}): Promise<boolean>
+⋮----
+/**
+   * Get Position Mode
+   * This interface can query the position mode of this account.
+   */
+getPositionMode(): Promise<APISuccessResponse<GetPositionModeResponse>>
+⋮----
+/**
+   * Switch Position Mode
+   * This endpoint can switch the position mode of the current symbol.
+   */
+updatePositionMode(params: { positionMode: '0' | '1' }): Promise<
+    APISuccessResponse<{
+      positionMode: '0' | '1';
+    }>
+  > {
+    return this.postPrivate('api/v2/position/switchPositionMode', params);
+⋮----
+/**
+   *
+   * REST - Futures Trading - Funding Fees
+   *
+   */
+⋮----
+/**
+   * Get Current Funding Rate
+   * This endpoint can be used to obtain the current funding rate of the specified symbol.
+   */
+getFundingRate(params: {
+    symbol: string;
+}): Promise<APISuccessResponse<FuturesCurrentFundingRate>>
+⋮----
+/**
+   * Get Public Funding History
+   * Query the funding rate at each settlement time point within a certain time range of the corresponding contract
+   */
+getFundingRates(
+    params: GetFundingRatesRequest,
+): Promise<APISuccessResponse<FuturesHistoricFundingRate[]>>
+⋮----
+/**
+   * Get Private Funding History
+   * Submit request to get the funding history.
+   */
+getFundingHistory(params: GetFundingHistoryRequest): Promise<
+    APISuccessResponse<{
+      dataList: FuturesAccountFundingRateHistory[];
+      hasMore: boolean; // Whether there are more pages
+    }>
+  > {
+    return this.getPrivate('api/v1/funding-history', params);
+⋮----
+hasMore: boolean; // Whether there are more pages
+⋮----
+/**
+   *
+   * REST - Futures Trading - CopyTrading
+   *
+   */
+⋮----
+/**
+   * Add Order (Copy Trading)
+   * Place order to the futures trading system for copy trading.
+   * Max leverage is set to 20x, and marginMode supports both ISOLATED and CROSS.
+   */
+submitCopyTradeOrder(params: CopyTradeOrderRequest): Promise<
+    APISuccessResponse<{
+      orderId: string;
+      clientOid: string;
+    }>
+  > {
+    return this.postPrivate('api/v1/copy-trade/futures/orders', params);
+⋮----
+/**
+   * Add Order Test (Copy Trading)
+   * Order test endpoint, the request parameters and return parameters of this endpoint are exactly the same as the order endpoint,
+   * and can be used to verify whether the signature is correct and other operations.
+   * Max leverage is set to 20x, and marginMode supports both ISOLATED and CROSS.
+   */
+submitCopyTradeOrderTest(params: CopyTradeOrderRequest): Promise<
+    APISuccessResponse<{
+      orderId: string;
+      clientOid: string;
+    }>
+  > {
+    return this.postPrivate('api/v1/copy-trade/futures/orders/test', params);
+⋮----
+/**
+   * Add Take Profit And Stop Loss Order (Copy Trading)
+   * Place take profit and stop loss order supports both take-profit and stop-loss functions, and other functions are exactly the same as the place order endpoint.
+   * Max leverage is set to 20x, and marginMode supports both ISOLATED and CROSS.
+   */
+submitCopyTradeSLTPOrder(params: CopyTradeSLTPOrderRequest): Promise<
+    APISuccessResponse<{
+      orderId: string;
+      clientOid: string;
+    }>
+  > {
+    return this.postPrivate('api/v1/copy-trade/futures/st-orders', params);
+⋮----
+/**
+   * Cancel Order By OrderId
+   * Cancel an order (including a stop order) in copy trading.
+   */
+cancelCopyTradeOrderById(params: {
+    orderId: string;
+}): Promise<APISuccessResponse<
+⋮----
+/**
+   * Cancel Order By Client Order Id
+   * Cancel an order (including a stop order) in copy trading by client order id.
+   */
+cancelCopyTradeOrderByClientOid(params: {
+    clientOid?: string;
+    symbol: string;
+}): Promise<APISuccessResponse<
+⋮----
+/**
+   * Get Max Open Size
+   * Get Maximum Open Position Size.
+   */
+getCopyTradeMaxOpenSize(params: {
+    symbol: string;
+    maxBuyOpenSize: string;
+    maxSellOpenSize: string;
+  }): Promise<
+    APISuccessResponse<{
+      symbol: string;
+      price: string;
+      leverage: number;
+    }>
+  > {
+    return this.getPrivate(
+      'api/v1/copy-trade/futures/get-max-open-size',
+      params,
+    );
+⋮----
+/**
+   * Get Max Withdraw Margin (Copy Trading)
+   * This endpoint can query the maximum amount of margin that the current position supports withdrawal.
+   */
+getCopyTradeMaxWithdrawMargin(params: {
+    symbol: string;
+    positionSide?: 'BOTH' | 'LONG' | 'SHORT';
+}): Promise<APISuccessResponse<string>>
+⋮----
+/**
+   * Add Isolated Margin (Copy Trading)
+   * Add Isolated Margin Manually.
+   */
+addCopyTradeIsolatedMargin(params: {
+    symbol: string;
+    margin: number;
+    bizNo: string;
+    positionSide?: 'BOTH' | 'LONG' | 'SHORT';
+}): Promise<APISuccessResponse<CopyTradePosition>>
+⋮----
+/**
+   * Remove Isolated Margin (Copy Trading)
+   * Remove Isolated Margin Manually.
+   */
+removeCopyTradeIsolatedMargin(params: {
+    symbol: string;
+    withdrawAmount: string;
+    positionSide?: 'BOTH' | 'LONG' | 'SHORT';
+}): Promise<APISuccessResponse<string>>
+⋮----
+/**
+   * Modify Isolated Margin Risk Limit
+   * This endpoint is for the adjustment of the risk limit level(Only valid for isolated Margin).
+   * To adjust the level will cancel the open order, the response can only indicate whether the submit of the adjustment request is successful or not.
+   */
+modifyCopyTradeRiskLimitLevel(params: {
+    symbol: string;
+    level: number;
+}): Promise<APISuccessResponse<boolean>>
+⋮----
+/**
+   * Modify Isolated Margin Auto-Deposit Status (Copy Trading)
+   * This endpoint is only applicable to isolated margin and is no longer recommended. It is recommended to use cross margin instead.
+   * @deprecated - It is recommended to use cross margin instead
+   */
+updateCopyTradeAutoDepositStatus(params: {
+    symbol: string;
+    status: boolean;
+    positionSide?: 'BOTH' | 'LONG' | 'SHORT';
+}): Promise<APISuccessResponse<boolean>>
+⋮----
+/**
+   * Switch Margin Mode (Copy Trading)
+   * Modify the margin mode of the current symbol.
+   */
+switchCopyTradeMarginMode(
+    params: CopyTradeSwitchMarginModeRequest,
+): Promise<APISuccessResponse<CopyTradeSwitchMarginModeResponse>>
+⋮----
+/**
+   * Modify Cross Margin Leverage (Copy Trading)
+   * This interface can modify the current symbol's cross-margin leverage multiple.
+   */
+updateCopyTradeCrossMarginLeverage(
+    params: CopyTradeChangeCrossMarginLeverageRequest,
+): Promise<APISuccessResponse<boolean>>
+⋮----
+/**
+   * Get Cross Margin Requirement (Copy Trading)
+   * This endpoint supports querying the cross margin requirements of a symbol by position value.
+   */
+getCopyTradeCrossMarginRequirement(
+    params: CopyTradeGetCrossMarginRequirementRequest,
+): Promise<APISuccessResponse<CopyTradeCrossMarginRequirement[]>>
+⋮----
+/**
+   * Switch Position Mode (Copy Trading)
+   * This interface is used to toggle between one-way mode and hedge mode for the position mode.
+   * Applies to all futures trading pairs.
+   */
+switchCopyTradePositionMode(
+    params: CopyTradeSwitchPositionModeRequest,
+): Promise<APISuccessResponse<CopyTradeSwitchPositionModeResponse>>
+/**
+   *
+   * REST - Futures - Broker
+   *
+   */
+⋮----
+/**
+   * Get download link for broker rebate orders
+   *
+   * trade type 1 = spot, trade type 2 = futures
+   * @deprecated Use getBrokerRebateOrderDownloadLinkV2 instead
+   */
+getBrokerRebateOrderDownloadLink(params: {
+    begin: string;
+    end: string;
+    tradeType: 1 | 2;
+}): Promise<APISuccessResponse<any>>
+⋮----
+/**
+   * Get download link for broker rebate orders
+   *
+   * trade type SPOT = spot, FUTURE = futures
+   */
+getBrokerRebateOrderDownloadLinkV2(params: {
+    begin: string;
+    end: string;
+    tradeType: 'SPOT' | 'FUTURE';
+}): Promise<APISuccessResponse<any>>
+⋮----
+/**
+   *
+   * WebSockets
+   *
+   */
+⋮----
+/**
+   * Public V1 WS Connection Token & URL
+   */
+getPublicWSConnectionToken(): Promise<APISuccessResponse<WsConnectionInfo>>
+⋮----
+/**
+   * Private V1 WS Connection Token & URL
+   */
+getPrivateWSConnectionToken(): Promise<APISuccessResponse<WsConnectionInfo>>
+⋮----
+/**
+   * Fetch connection token for V2 (Pro) private connections. Not needed for public.
+   * Only returns token, no URL.
+   */
+getPrivateWSConnectionTokenV2(): Promise<
+    APISuccessResponse<WsConnectionInfo>
+  > {
+    return this.postPrivate('api/v2/bullet-private');
+⋮----
+/*
+   *
+   * DEPRECATED
+   *
+   */
+⋮----
+/**
+   * @deprecated - please use universal transfer from SpotClient
+   */
+submitTransferOut(params: {
+    currency: string;
+    amount: number;
+    recAccountType: 'MAIN' | 'TRADE';
+}): Promise<APISuccessResponse<any>>
+⋮----
+/**
+   * @deprecated - please use universal transfer from SpotClient
+   */
+submitTransferIn(params: {
+    currency: string;
+    amount: number;
+    payAccountType: 'MAIN' | 'TRADE';
+}): Promise<APISuccessResponse<any>>
+⋮----
+/**
+   * @deprecated - please use universal transfer from SpotClient
+   */
+getTransfers(params?: {
+    currency?: string;
+    type?: 'MAIN' | 'TRADE' | 'MARGIN' | 'ISOLATED';
+    tag?: string[];
+    startAt?: number;
+    endAt?: number;
+    currentPage?: number;
+    pageSize?: number;
+}): Promise<APISuccessResponse<any>>
+⋮----
+/**
+   * @deprecated - please use updateMarginMode() instead
+   */
+updateAutoDepositStatus(params: {
+    symbol: string;
+    status: boolean;
+}): Promise<APISuccessResponse<any>>
+
+================
+File: src/UnifiedAPIClient.ts
+================
+import { BaseRestClient } from './lib/BaseRestClient.js';
+import { REST_CLIENT_TYPE_ENUM, RestClientType } from './lib/requestUtils.js';
+import {
+  BatchCancelOrdersBySymbolRequestUTA,
+  BatchCancelOrdersRequestUTA,
+  BatchPlaceOrderRequestUTA,
+  CancelOrderRequestUTA,
+  FlexTransferRequestUTA,
+  GetAccountLedgerRequestUTA,
+  GetAccountPositionTiersRequestUTA,
+  GetAnnouncementsRequestUTA,
+  GetClassicAccountRequestUTA,
+  GetCurrencyRequestUTA,
+  GetCurrentFundingRateRequestUTA,
+  GetDCPRequestUTA,
+  GetDepositAddressRequestUTA,
+  GetFeeRateRequestUTA,
+  GetHistoryFundingRateRequestUTA,
+  GetInterestHistoryRequestUTA,
+  GetKlinesRequestUTA,
+  GetOpenOrderListRequestUTA,
+  GetOrderBookRequestUTA,
+  GetOrderDetailsRequestUTA,
+  GetOrderHistoryRequestUTA,
+  GetPositionListRequestUTA,
+  GetPositionsHistoryRequestUTA,
+  GetServiceStatusRequestUTA,
+  GetSubAccountRequestUTA,
+  GetSymbolRequestUTA,
+  GetTickerRequestUTA,
+  GetTradeHistoryRequestUTA,
+  GetTradesRequestUTA,
+  GetTransferQuotasRequestUTA,
+  ModifyLeverageRequestUTA,
+  PlaceOrderRequestUTA,
+  SetAccountModeRequestUTA,
+  SetDCPRequestUTA,
+  SetSubAccountTransferPermissionRequestUTA,
+} from './types/request/uta-types.js';
+import { APISuccessResponse } from './types/response/shared.types.js';
+import {
+  BatchCancelOrdersBySymbolResponseUTA,
+  BatchCancelOrdersResponseUTA,
+  BatchPlaceOrderResponseUTA,
+  CancelOrderResponseUTA,
+  DCPResponseUTA,
+  DepositAddressUTA,
+  FlexTransferResponseUTA,
+  GetAccountLedgerResponseClassicUTA,
+  GetAccountLedgerResponseUTA,
+  GetAccountModeResponseUTA,
+  GetAccountOverviewResponseUTA,
+  GetAnnouncementsResponseUTA,
+  GetClassicAccountResponseUTA,
+  GetCrossMarginConfigResponseUTA,
+  GetCurrencyResponseUTA,
+  GetCurrentFundingRateResponseUTA,
+  GetFeeRateResponseUTA,
+  GetHistoryFundingRateResponseUTA,
+  GetInterestHistoryResponseUTA,
+  GetKlinesResponseUTA,
+  GetOpenOrderListResponseUTA,
+  GetOrderBookResponseUTA,
+  GetOrderHistoryResponseUTA,
+  GetPositionsHistoryResponseUTA,
+  GetServiceStatusResponseUTA,
+  GetSubAccountResponseUTA,
+  GetSymbolResponseUTA,
+  GetTickerResponseUTA,
+  GetTradeHistoryResponseUTA,
+  GetTradesResponseUTA,
+  GetTransferQuotasResponseUTA,
+  OrderDetailsUTA,
+  PlaceOrderResponseUTA,
+  PositionTierUTA,
+  PositionUTA,
+  SubAccountTransferPermissionUTA,
+} from './types/response/uta-types.js';
+⋮----
+/**
+ * Unified Trading Account Client
+ *
+ * This client provides access to the Unified Trading Account API endpoints
+ * that unify market data access across Spot, Futures, and Margin trading.
+ */
+export class UnifiedAPIClient extends BaseRestClient
+⋮----
+getClientType(): RestClientType
+⋮----
+/**
+   *
+   * REST - Unified Trading Account - Market Data
+   *
+   */
+⋮----
+/**
+   * Get Announcements
+   * This interface can obtain the latest news announcements, and the default
+   * page search is for announcements within a month.
+   */
+getAnnouncements(
+    params?: GetAnnouncementsRequestUTA,
+): Promise<APISuccessResponse<GetAnnouncementsResponseUTA>>
+⋮----
+/**
+   * Get Currency
+   * Request the currency details of a specified currency via this endpoint.
+   */
+getCurrency(
+    params?: GetCurrencyRequestUTA,
+): Promise<APISuccessResponse<GetCurrencyResponseUTA>>
+⋮----
+/**
+   * Get Symbol
+   * Request a list of available currency pairs for trading via this endpoint.
+   */
+getSymbols(
+    params: GetSymbolRequestUTA,
+): Promise<APISuccessResponse<GetSymbolResponseUTA>>
+⋮----
+/**
+   * Get Ticker
+   * Request market tickers for the trading pairs in the market (including 24h volume).
+   */
+getTickers(
+    params: GetTickerRequestUTA,
+): Promise<APISuccessResponse<GetTickerResponseUTA>>
+⋮----
+/**
+   * Get Trades
+   * Request via this endpoint to get the latest 100 public trades of the specified symbol.
+   */
+getTrades(
+    params: GetTradesRequestUTA,
+): Promise<APISuccessResponse<GetTradesResponseUTA>>
+⋮----
+/**
+   * Get OrderBook
+   * Query order book depth information (aggregated by price).
+   */
+getOrderBook(
+    params: GetOrderBookRequestUTA,
+): Promise<APISuccessResponse<GetOrderBookResponseUTA>>
+⋮----
+/**
+   * Get Klines
+   * Get the Kline of the symbol. Data are returned in grouped buckets based on requested type.
+   */
+getKlines(
+    params: GetKlinesRequestUTA,
+): Promise<APISuccessResponse<GetKlinesResponseUTA>>
+⋮----
+/**
+   * Get Current Funding Rate
+   * Get current Futures funding fee rate.
+   */
+getCurrentFundingRate(
+    params: GetCurrentFundingRateRequestUTA,
+): Promise<APISuccessResponse<GetCurrentFundingRateResponseUTA>>
+⋮----
+/**
+   * Get History Funding Rate
+   * Query the Futures funding rate at each settlement time point within a certain time range.
+   */
+getHistoryFundingRate(
+    params: GetHistoryFundingRateRequestUTA,
+): Promise<APISuccessResponse<GetHistoryFundingRateResponseUTA>>
+⋮----
+/**
+   * Get Cross Margin Config
+   * Request the configure info of the 'spot cross margin' via this endpoint.
+   */
+getCrossMarginConfig(): Promise<
+    APISuccessResponse<GetCrossMarginConfigResponseUTA>
+  > {
+    return this.get('api/ua/v1/market/cross-config');
+⋮----
+/**
+   * Get Service Status
+   * Get the service status.
+   */
+getServiceStatus(
+    params: GetServiceStatusRequestUTA,
+): Promise<APISuccessResponse<GetServiceStatusResponseUTA>>
+⋮----
+/**
+   *
+   * REST - Unified Trading Account - Account
+   *
+   */
+⋮----
+/**
+   * Get Account (Classic)
+   * Get information for Classic Account (FUNDING, SPOT, FUTURES, CROSS, ISOLATED).
+   * Note: AccountType enum value changed from TRADING to SPOT as of 2026.01.17.
+   */
+getClassicAccount(
+    params: GetClassicAccountRequestUTA,
+): Promise<APISuccessResponse<GetClassicAccountResponseUTA>>
+⋮----
+/**
+   * Get Account (UTA)
+   * Get information for Unified Trading Account.
+   */
+getAccount(): Promise<APISuccessResponse<GetClassicAccountResponseUTA>>
+⋮----
+/**
+   * Get Account Overview (UTA)
+   * Get account overview for Unified Trading Account.
+   */
+getAccountOverview(): Promise<
+    APISuccessResponse<GetAccountOverviewResponseUTA>
+  > {
+    return this.getPrivate('api/ua/v1/unified/account/overview');
+⋮----
+/**
+   * Get Sub Account
+   * Request sub account info via this endpoint.
+   */
+getSubAccount(
+    params?: GetSubAccountRequestUTA,
+): Promise<APISuccessResponse<GetSubAccountResponseUTA>>
+⋮----
+/**
+   * Get Transfer Quotas
+   * This endpoint returns the transferable balance of a specified account.
+   * Note: AccountType enum value changed from TRADING to SPOT as of 2026.01.17.
+   */
+getTransferQuotas(
+    params: GetTransferQuotasRequestUTA,
+): Promise<APISuccessResponse<GetTransferQuotasResponseUTA>>
+⋮----
+/**
+   * Flex Transfer
+   * This interface can be used for transfers between master- and sub-accounts and transfers.
+   * Note: AccountType enum value changed from TRADING to SPOT as of 2026.01.17.
+   */
+flexTransfer(
+    params: FlexTransferRequestUTA,
+): Promise<APISuccessResponse<FlexTransferResponseUTA>>
+⋮----
+/**
+   * Set Sub Account Transfer Permission
+   * This endpoint supports setting whether the specified sub-account needs to open the SUB_TO_SUB transfer permission.
+   */
+setSubAccountTransferPermission(
+    params: SetSubAccountTransferPermissionRequestUTA,
+): Promise<APISuccessResponse<SubAccountTransferPermissionUTA[]>>
+⋮----
+/**
+   * Get Account Mode
+   * This interface supports query the list of unified and classic sub-accounts and current account mode.
+   */
+getAccountMode(): Promise<APISuccessResponse<GetAccountModeResponseUTA>>
+⋮----
+/**
+   * Set Account Mode
+   * This interface supports set account mode to UTA.
+   */
+setAccountMode(
+    params: SetAccountModeRequestUTA,
+): Promise<APISuccessResponse<null>>
+⋮----
+/**
+   * Get Fee Rate
+   * This interface is for the trading pair's actual fee rate.
+   * You can inquire about fee rates of 10 trading pairs each time at most for Spot.
+   * Futures only supports 1 symbol at a time.
+   */
+getFeeRate(
+    params: GetFeeRateRequestUTA,
+): Promise<APISuccessResponse<GetFeeRateResponseUTA>>
+⋮----
+/**
+   * Get Account Ledger
+   * This API endpoint returns all transfer (in and out) records and supports multi-coin queries.
+   * The query results are sorted in descending order by createdAt and ID.
+   * Note: AccountType enum value changed from TRADING to SPOT as of 2026.01.17.
+   * Note: direction values unified to uppercase IN/OUT as of 2026.01.17.
+   * Note: For Futures - id changed from Number to String, balance/amount changed from Number to String as of 2026.01.17.
+   * Note: ts standardized to nanoseconds as of 2026.01.12.
+   */
+getAccountLedger(
+    params: GetAccountLedgerRequestUTA,
+  ): Promise<
+    APISuccessResponse<
+      GetAccountLedgerResponseUTA | GetAccountLedgerResponseClassicUTA
+    >
+  > {
+    return this.getPrivate('api/ua/v1/account/ledger', params);
+⋮----
+/**
+   * Get Interest History (UTA)
+   * Request the interest records via this endpoint.
+   */
+getInterestHistory(
+    params: GetInterestHistoryRequestUTA,
+): Promise<APISuccessResponse<GetInterestHistoryResponseUTA>>
+⋮----
+/**
+   * Modify Leverage (UTA)
+   * This interface supports modify leverage of the specified symbol.
+   */
+modifyLeverage(
+    params: ModifyLeverageRequestUTA,
+): Promise<APISuccessResponse<null>>
+⋮----
+/**
+   * Get Deposit Address
+   * Return a deposit address; when both currency and chain are provided,
+   * the address will be created if it does not exist.
+   * URL unified to GET /api/ua/v1/asset/deposit/address as of 2026.01.17.
+   */
+getDepositAddress(
+    params: GetDepositAddressRequestUTA,
+): Promise<APISuccessResponse<DepositAddressUTA[]>>
+⋮----
+/**
+   *
+   * REST - Unified Trading Account - Orders
+   *
+   */
+⋮----
+/**
+   * Place Order
+   * This interface can be used to place orders.
+   * Supports RPI (Retail Price Improvement) orders for Futures as of 2025.01.02.
+   * Note: timeInForce supports 'RPI' value for Futures only (Phase 1).
+   * Note: For Classic mode, tradeType is required in query param.
+   * Note: For Unified mode, tradeType should not be in query param.
+   */
+placeOrder(
+    params: PlaceOrderRequestUTA,
+    accountMode: 'classic' | 'unified' = 'unified',
+): Promise<APISuccessResponse<PlaceOrderResponseUTA>>
+⋮----
+/**
+   * Batch Place Order (Classic)
+   * This interface can be used for placing batch orders.
+   * URL changed to /api/ua/v1/{accountMode}/order/place-batch as of 2026.01.17.
+   * Note: timeInForce supports 'RPI' value for Futures as of 2025.01.02.
+   */
+batchPlaceOrder(
+    params: BatchPlaceOrderRequestUTA,
+    accountMode: 'classic' | 'unified' = 'classic',
+): Promise<APISuccessResponse<BatchPlaceOrderResponseUTA>>
+⋮----
+/**
+   * Get Order Details
+   * This interface can be used getting single order details.
+   * Note: timeInForce returns 'RPI' value for Futures RPI orders as of 2025.01.02.
+   * Note: status changed from String to Number for UTA as of 2026.01.17.
+   * Note: orderTime/updatedTime standardized to nanoseconds as of 2026.01.12.
+   */
+getOrderDetails(
+    params: GetOrderDetailsRequestUTA,
+    accountMode: 'classic' | 'unified' = 'unified',
+): Promise<APISuccessResponse<OrderDetailsUTA>>
+⋮----
+/**
+   * Get Open Order List
+   * This interface can be used getting open order list.
+   * Note: timeInForce returns 'RPI' value for Futures RPI orders as of 2025.01.02.
+   * Note: status changed from String to Number for UTA as of 2026.01.17.
+   * Note: orderTime/updatedTime standardized to nanoseconds as of 2026.01.12.
+   */
+getOpenOrderList(
+    params: GetOpenOrderListRequestUTA,
+    accountMode: 'classic' | 'unified' = 'unified',
+): Promise<APISuccessResponse<GetOpenOrderListResponseUTA>>
+⋮----
+/**
+   * Get Order History
+   * This interface can be used for getting order history.
+   * Note: timeInForce returns 'RPI' value for Futures RPI orders as of 2025.01.02.
+   * Note: status changed from String to Number for UTA as of 2026.01.17.
+   * Note: orderTime/updatedTime standardized to nanoseconds as of 2026.01.12.
+   */
+getOrderHistory(
+    params: GetOrderHistoryRequestUTA,
+    accountMode: 'classic' | 'unified' = 'unified',
+): Promise<APISuccessResponse<GetOrderHistoryResponseUTA>>
+⋮----
+/**
+   * Get Trade History
+   * This interface can be used for getting trade execution history.
+   * Note: executionTime standardized to nanoseconds as of 2026.01.12.
+   * Note: isRpiTrade added for Futures as of 2025.01.02.
+   */
+getTradeHistory(
+    params: GetTradeHistoryRequestUTA,
+    accountMode: 'classic' | 'unified' = 'unified',
+): Promise<APISuccessResponse<GetTradeHistoryResponseUTA>>
+⋮----
+/**
+   * Cancel Order
+   * This interface can be used to cancel orders.
+   * Note: ts (timestamp in nanoseconds) only effective for unified account mode.
+   */
+cancelOrder(
+    params: CancelOrderRequestUTA,
+    accountMode: 'classic' | 'unified' = 'unified',
+): Promise<APISuccessResponse<CancelOrderResponseUTA>>
+⋮----
+/**
+   * Batch Cancel Orders
+   * This interface can be used for batch cancel orders (maximum 20 orders).
+   * Note: tradeType required for Classic accounts only; ignored in UTA (UNIFIED) mode.
+   * Note: ts (timestamp in nanoseconds) not supported for classic accounts.
+   */
+batchCancelOrders(
+    params: BatchCancelOrdersRequestUTA,
+    accountMode: 'classic' | 'unified' = 'unified',
+): Promise<APISuccessResponse<BatchCancelOrdersResponseUTA>>
+⋮----
+/**
+   * Batch Cancel Orders By Symbol
+   * Cancels orders in batch by symbol. UTA only. Supports SPOT (non-margin) and Futures Cross Margin.
+   */
+batchCancelOrdersBySymbol(
+    params: BatchCancelOrdersBySymbolRequestUTA,
+): Promise<APISuccessResponse<BatchCancelOrdersBySymbolResponseUTA>>
+⋮----
+/**
+   * Set DCP (Disconnection Protect / Deadman Switch) - Classic Only
+   * Set automatic order cancellation after specified time.
+   * Call this interface to automatically cancel all orders of the set trading pair after the specified time.
+   * Note: Order cancellation delay is between 0 and 10 seconds.
+   * Note: timeout range: -1 (unset) or 5 <= timeout <= 86400 seconds.
+   */
+setDCP(
+    params: SetDCPRequestUTA,
+): Promise<APISuccessResponse<DCPResponseUTA>>
+⋮----
+/**
+   * Get DCP (Disconnection Protect / Deadman Switch) - Classic Only
+   * Get automatic order cancellation settings.
+   * If data is empty, it means DCP is not set.
+   */
+getDCP(
+    params: GetDCPRequestUTA,
+): Promise<APISuccessResponse<DCPResponseUTA>>
+⋮----
+/**
+   *
+   * REST - Unified Trading Account - Positions
+   *
+   */
+⋮----
+/**
+   * Get Position List (UTA)
+   * Get the position details of all open positions.
+   * Note: creationTime standardized to nanoseconds as of 2026.01.12.
+   */
+getPositionList(
+    params?: GetPositionListRequestUTA,
+): Promise<APISuccessResponse<PositionUTA[]>>
+⋮----
+/**
+   * Get Positions History (UTA)
+   * Query position history information records.
+   * Note: Data retained for up to 3 months.
+   * Note: Each query limited to 7 days time range.
+   * Note: creationTime and closingTime standardized to nanoseconds as of 2026.01.12.
+   */
+getPositionsHistory(
+    params?: GetPositionsHistoryRequestUTA,
+): Promise<APISuccessResponse<GetPositionsHistoryResponseUTA>>
+⋮----
+/**
+   * Get Account Position Tiers
+   * Request account position tiers (risk limit) info.
+   * Note: Currently only queries of classic - futures isolated margin are supported.
+   */
+getAccountPositionTiers(
+    params: GetAccountPositionTiersRequestUTA,
+    accountMode: 'classic' | 'unified' = 'classic',
+): Promise<APISuccessResponse<PositionTierUTA[]>>
+
+================
+File: src/WebsocketAPIClient.ts
+================
+import { DefaultLogger } from './lib/websocket/logger.js';
+import { WS_KEY_MAP, WSAPIWsKey } from './lib/websocket/websocket-util.js';
+import {
+  BatchCancelOrdersRequest,
+  Order,
+} from './types/request/futures.types.js';
+import { SubmitHFMarginOrderRequest } from './types/request/spot-margin-trading.js';
+import {
+  ModifyHFOrderRequest,
+  SubmitHFOrderRequest,
+} from './types/request/spot-trading.js';
+import {
+  BatchCancelOrderResult,
+  SubmitMultipleOrdersFuturesResponse,
+} from './types/response/futures.types.js';
+import { MarginSubmitOrderV3Response } from './types/response/spot-margin-trading.js';
+import {
+  SubmitHFOrderSyncResponse,
+  SyncCancelHFOrderResponse,
+} from './types/response/spot-trading.js';
+import {
+  WSAPICancelOrderRequest,
+  WSAPIOrderResponse,
+  WSAPIResponse,
+} from './types/websockets/ws-api.js';
+import { WSClientConfigurableOptions } from './types/websockets/ws-general.js';
+import { WebsocketClient } from './WebsocketClient.js';
+⋮----
+/**
+ * Configurable options specific to only the REST-like WebsocketAPIClient
+ */
+export interface WSAPIClientConfigurableOptions {
+  /**
+   * Default: true
+   *
+   * Attach default event listeners, which will console log any high level
+   * events (opened/reconnecting/reconnected/etc).
+   *
+   * If you disable this, you should set your own event listeners
+   * on the embedded WS Client `wsApiClient.getWSClient().on(....)`.
+   */
+  attachEventListeners: boolean;
+}
+⋮----
+/**
+   * Default: true
+   *
+   * Attach default event listeners, which will console log any high level
+   * events (opened/reconnecting/reconnected/etc).
+   *
+   * If you disable this, you should set your own event listeners
+   * on the embedded WS Client `wsApiClient.getWSClient().on(....)`.
+   */
+⋮----
+/**
+ * This is a minimal Websocket API wrapper around the WebsocketClient.
+ *
+ * Some methods support passing in a custom "wsKey". This is a reference to which WS connection should
+ * be used to transmit that message. This is only useful if you wish to use an alternative wss
+ * domain that is supported by the SDK.
+ *
+ * Note: To use testnet, don't set the wsKey - use `testnet: true` in
+ * the constructor instead.
+ *
+ * Note: You can also directly use the sendWSAPIRequest() method to make WS API calls, but some
+ * may find the below methods slightly more intuitive.
+ *
+ * Refer to the WS API promises example for a more detailed example on using sendWSAPIRequest() directly:
+ * https://github.com/tiagosiebler/binance/blob/master/examples/WebSockets/ws-api-raw-promises.ts#L108
+ */
+export class WebsocketAPIClient
+⋮----
+constructor(
+    options?: WSClientConfigurableOptions &
+      Partial<WSAPIClientConfigurableOptions>,
+    logger?: DefaultLogger,
+)
+⋮----
+public getWSClient(): WebsocketClient
+⋮----
+/**
+   * Submit a spot order
+   */
+submitNewSpotOrder(
+    params: SubmitHFOrderRequest,
+    wsKey?: WSAPIWsKey,
+): Promise<WSAPIResponse<WSAPIOrderResponse>>
+⋮----
+/**
+   * Modify a spot order
+   */
+modifySpotOrder(
+    params: ModifyHFOrderRequest,
+    wsKey?: WSAPIWsKey,
+): Promise<WSAPIResponse<
+⋮----
+/**
+   * Cancel a spot order
+   */
+cancelSpotOrder(
+    params: WSAPICancelOrderRequest,
+    wsKey?: WSAPIWsKey,
+): Promise<WSAPIResponse<WSAPIOrderResponse>>
+⋮----
+/**
+   * Submit a sync spot order
+   */
+submitSyncSpotOrder(
+    params: SubmitHFOrderRequest,
+    wsKey?: WSAPIWsKey,
+): Promise<WSAPIResponse<SubmitHFOrderSyncResponse>>
+⋮----
+/**
+   * Cancel a sync spot order
+   */
+cancelSyncSpotOrder(
+    params: WSAPICancelOrderRequest,
+    wsKey?: WSAPIWsKey,
+): Promise<WSAPIResponse<SyncCancelHFOrderResponse>>
+⋮----
+/**
+   * Submit a margin order
+   */
+submitMarginOrder(
+    params: SubmitHFMarginOrderRequest,
+    wsKey?: WSAPIWsKey,
+): Promise<WSAPIResponse<MarginSubmitOrderV3Response>>
+⋮----
+/**
+   * Cancel a margin order
+   */
+cancelMarginOrder(
+    params: WSAPICancelOrderRequest,
+    wsKey?: WSAPIWsKey,
+): Promise<WSAPIResponse<WSAPIOrderResponse>>
+⋮----
+/**
+   * Submit a futures order
+   */
+submitFuturesOrder(
+    params: Order,
+    wsKey?: WSAPIWsKey,
+): Promise<WSAPIResponse<WSAPIOrderResponse>>
+⋮----
+/**
+   * Cancel a futures order
+   */
+cancelFuturesOrder(
+    params: { orderId: string } | { clientOid: string; symbol: string },
+    wsKey?: WSAPIWsKey,
+  ): Promise<
+    WSAPIResponse<{ cancelledOrderIds: string[] } | { clientOid: string }>
+  > {
+    return this.wsClient.sendWSAPIRequest(
+      wsKey || WS_KEY_MAP.wsApiFuturesV1,
+      'futures.cancel',
+      params,
+    );
+⋮----
+/**
+   * Submit multiple futures orders
+   */
+submitMultipleFuturesOrders(
+    params: Order[],
+    wsKey?: WSAPIWsKey,
+): Promise<WSAPIResponse<SubmitMultipleOrdersFuturesResponse[]>>
+⋮----
+/**
+   * Cancel multiple futures orders
+   */
+cancelMultipleFuturesOrders(
+    params: BatchCancelOrdersRequest,
+    wsKey?: WSAPIWsKey,
+): Promise<WSAPIResponse<BatchCancelOrderResult[]>>
+⋮----
+/**
+   *
+   *
+   *
+   *
+   *
+   *
+   *
+   * Private methods for handling some of the convenience/automation provided by the WS API Client
+   *
+   *
+   *
+   *
+   *
+   *
+   *
+   */
+⋮----
+public connectWSAPI(wsKey: WSAPIWsKey)
+⋮----
+private setupDefaultEventListeners()
+⋮----
+/**
+       * General event handlers for monitoring the WebsocketClient
+       */
+⋮----
+// Blind JSON.stringify can fail on circular references
+⋮----
+// JSON.stringify({ ...data, target: 'WebSocket' }),
+
+================
+File: src/SpotClient.ts
+================
+import { nanoid } from 'nanoid';
+⋮----
+import { BaseRestClient } from './lib/BaseRestClient.js';
+import { REST_CLIENT_TYPE_ENUM, RestClientType } from './lib/requestUtils.js';
 import {
   AccountHFMarginTransactionsRequest,
   AccountHFTransactionsRequest,
@@ -11384,11 +12307,6 @@ import { WsConnectionInfo } from './types/response/ws.js';
  */
 export class SpotClient extends BaseRestClient
 ⋮----
-constructor(
-    restClientOptions: RestClientOptions = {},
-    requestOptions: AxiosRequestConfig = {},
-)
-⋮----
 getClientType(): RestClientType
 ⋮----
 /**
@@ -11480,7 +12398,7 @@ getAccountDetail(params: {
 /**
    * Get Account - Cross Margin
    *
-   * Request via this endpoint to get the info of the cross margin account.
+   * Request cross margin account info. Preferred queryType: MARGIN. MARGIN_V2 phased out gradually.
    */
 getMarginBalance(
     params?: GetMarginBalanceRequest,
@@ -11489,7 +12407,7 @@ getMarginBalance(
 /**
    * Get Account - Isolated Margin
    *
-   * Request via this endpoint to get the info of the isolated margin account.
+   * Request isolated margin account info. Preferred queryType: ISOLATED. ISOLATED_V2 phased out gradually.
    */
 getIsolatedMarginBalance(
     params?: GetIsolatedMarginBalanceRequest,
@@ -11737,6 +12655,7 @@ getWithdrawalById(params: {
    * Get Transfer Quotas
    *
    * This endpoint returns the transferable balance of a specified account.
+   * Preferred type: MARGIN, ISOLATED. V2 (MARGIN_V2, ISOLATED_V2) phased out gradually.
    */
 getTransferable(
     params: GetTransferableRequest,
@@ -11745,7 +12664,8 @@ getTransferable(
 /**
    * Flex Transfer
    *
-   * This endpoint can be used for transfers between master and sub accounts and inner transfers
+   * Transfers between master/sub accounts and inner transfers.
+   * Preferred account types: MARGIN, ISOLATED. For non-INTERNAL type, use MARGIN/ISOLATED (not MARGIN_V2/ISOLATED_V2).
    */
 submitFlexTransfer(params: FlexTransferRequest): Promise<
     APISuccessResponse<{
@@ -13300,8 +14220,9 @@ getSubAccountBalancesV1(): Promise<APISuccessResponse<SubAccountBalance>>
    */
 ⋮----
 /**
-   * @deprecated This method is deprecated.
-   * It is recommended to use the getMarginBalance() endpoint instead of this endpoint
+   * @deprecated SPOT Margin LF endpoint no longer available (2026.03.04).
+   * Use getMarginBalance() instead.
+   * @see https://www.kucoin.com/announcement/kucoin-margin-notice-250702
    */
 getMarginBalances(): Promise<
     APISuccessResponse<{
@@ -13525,16 +14446,18 @@ getRecentFills(): Promise<APISuccessResponse<SpotOrderFill[]>>
    */
 ⋮----
 /**
-   * @deprecated This method is deprecated.
-   * It is recommended to use the submitHFMarginOrder() endpoint instead of this endpoint
+   * @deprecated SPOT Margin LF endpoint no longer available (2026.03.04).
+   * Use submitHFMarginOrder() instead.
+   * @see https://www.kucoin.com/announcement/kucoin-margin-notice-250702
    */
 submitMarginOrder(
     params: SubmitMarginOrderRequest,
 ): Promise<APISuccessResponse<SubmitMarginOrderResponse>>
 ⋮----
 /**
-   * @deprecated This method is deprecated.
-   * It is recommended to use the submitHFMarginOrderTest() endpoint instead of this endpoint
+   * @deprecated SPOT Margin LF endpoint no longer available (2026.03.04).
+   * Use submitHFMarginOrderTest() instead.
+   * @see https://www.kucoin.com/announcement/kucoin-margin-notice-250702
    */
 submitMarginOrderTest(): Promise<any>
 ⋮----
@@ -13545,1038 +14468,22 @@ submitMarginOrderTest(): Promise<any>
    */
 ⋮----
 /**
-   * @deprecated This method is deprecated.
-   * It is recommended to use the getMarginBalance() endpoint instead of this endpoint
+   * @deprecated SPOT Margin LF endpoint no longer available (2026.03.04).
+   * Use getIsolatedMarginBalance() instead.
+   * @see https://www.kucoin.com/announcement/kucoin-margin-notice-250702
    */
 getIsolatedMarginAccounts(params?: {
     balanceCurrency?: 'USDT' | 'KCS' | 'BTC';
 }): Promise<APISuccessResponse<IsolatedMarginAccountInfo>>
 ⋮----
 /**
-   * @deprecated This method is deprecated.
-   * It is recommended to use the getIsolatedMarginBalance() endpoint instead of this endpoint
+   * @deprecated SPOT Margin LF endpoint no longer available (2026.03.04).
+   * Use getIsolatedMarginBalance() instead.
+   * @see https://www.kucoin.com/announcement/kucoin-margin-notice-250702
    */
 getIsolatedMarginAccount(params: {
     symbol: string;
 }): Promise<APISuccessResponse<SingleIsolatedMarginAccountInfo>>
-
-================
-File: src/WebsocketAPIClient.ts
-================
-import { DefaultLogger } from './lib/websocket/logger.js';
-import { WS_KEY_MAP, WSAPIWsKey } from './lib/websocket/websocket-util.js';
-import {
-  BatchCancelOrdersRequest,
-  Order,
-} from './types/request/futures.types.js';
-import { SubmitHFMarginOrderRequest } from './types/request/spot-margin-trading.js';
-import {
-  ModifyHFOrderRequest,
-  SubmitHFOrderRequest,
-} from './types/request/spot-trading.js';
-import {
-  BatchCancelOrderResult,
-  SubmitMultipleOrdersFuturesResponse,
-} from './types/response/futures.types.js';
-import { MarginSubmitOrderV3Response } from './types/response/spot-margin-trading.js';
-import {
-  SubmitHFOrderSyncResponse,
-  SyncCancelHFOrderResponse,
-} from './types/response/spot-trading.js';
-import {
-  WSAPICancelOrderRequest,
-  WSAPIOrderResponse,
-  WSAPIResponse,
-} from './types/websockets/ws-api.js';
-import { WSClientConfigurableOptions } from './types/websockets/ws-general.js';
-import { WebsocketClient } from './WebsocketClient.js';
-⋮----
-/**
- * Configurable options specific to only the REST-like WebsocketAPIClient
- */
-export interface WSAPIClientConfigurableOptions {
-  /**
-   * Default: true
-   *
-   * Attach default event listeners, which will console log any high level
-   * events (opened/reconnecting/reconnected/etc).
-   *
-   * If you disable this, you should set your own event listeners
-   * on the embedded WS Client `wsApiClient.getWSClient().on(....)`.
-   */
-  attachEventListeners: boolean;
-}
-⋮----
-/**
-   * Default: true
-   *
-   * Attach default event listeners, which will console log any high level
-   * events (opened/reconnecting/reconnected/etc).
-   *
-   * If you disable this, you should set your own event listeners
-   * on the embedded WS Client `wsApiClient.getWSClient().on(....)`.
-   */
-⋮----
-/**
- * This is a minimal Websocket API wrapper around the WebsocketClient.
- *
- * Some methods support passing in a custom "wsKey". This is a reference to which WS connection should
- * be used to transmit that message. This is only useful if you wish to use an alternative wss
- * domain that is supported by the SDK.
- *
- * Note: To use testnet, don't set the wsKey - use `testnet: true` in
- * the constructor instead.
- *
- * Note: You can also directly use the sendWSAPIRequest() method to make WS API calls, but some
- * may find the below methods slightly more intuitive.
- *
- * Refer to the WS API promises example for a more detailed example on using sendWSAPIRequest() directly:
- * https://github.com/tiagosiebler/binance/blob/master/examples/WebSockets/ws-api-raw-promises.ts#L108
- */
-export class WebsocketAPIClient
-⋮----
-constructor(
-    options?: WSClientConfigurableOptions &
-      Partial<WSAPIClientConfigurableOptions>,
-    logger?: DefaultLogger,
-)
-⋮----
-public getWSClient(): WebsocketClient
-⋮----
-/**
-   * Submit a spot order
-   */
-submitNewSpotOrder(
-    params: SubmitHFOrderRequest,
-    wsKey?: WSAPIWsKey,
-): Promise<WSAPIResponse<WSAPIOrderResponse>>
-⋮----
-/**
-   * Modify a spot order
-   */
-modifySpotOrder(
-    params: ModifyHFOrderRequest,
-    wsKey?: WSAPIWsKey,
-): Promise<WSAPIResponse<
-⋮----
-/**
-   * Cancel a spot order
-   */
-cancelSpotOrder(
-    params: WSAPICancelOrderRequest,
-    wsKey?: WSAPIWsKey,
-): Promise<WSAPIResponse<WSAPIOrderResponse>>
-⋮----
-/**
-   * Submit a sync spot order
-   */
-submitSyncSpotOrder(
-    params: SubmitHFOrderRequest,
-    wsKey?: WSAPIWsKey,
-): Promise<WSAPIResponse<SubmitHFOrderSyncResponse>>
-⋮----
-/**
-   * Cancel a sync spot order
-   */
-cancelSyncSpotOrder(
-    params: WSAPICancelOrderRequest,
-    wsKey?: WSAPIWsKey,
-): Promise<WSAPIResponse<SyncCancelHFOrderResponse>>
-⋮----
-/**
-   * Submit a margin order
-   */
-submitMarginOrder(
-    params: SubmitHFMarginOrderRequest,
-    wsKey?: WSAPIWsKey,
-): Promise<WSAPIResponse<MarginSubmitOrderV3Response>>
-⋮----
-/**
-   * Cancel a margin order
-   */
-cancelMarginOrder(
-    params: WSAPICancelOrderRequest,
-    wsKey?: WSAPIWsKey,
-): Promise<WSAPIResponse<WSAPIOrderResponse>>
-⋮----
-/**
-   * Submit a futures order
-   */
-submitFuturesOrder(
-    params: Order,
-    wsKey?: WSAPIWsKey,
-): Promise<WSAPIResponse<WSAPIOrderResponse>>
-⋮----
-/**
-   * Cancel a futures order
-   */
-cancelFuturesOrder(
-    params: { orderId: string } | { clientOid: string; symbol: string },
-    wsKey?: WSAPIWsKey,
-  ): Promise<
-    WSAPIResponse<{ cancelledOrderIds: string[] } | { clientOid: string }>
-  > {
-    return this.wsClient.sendWSAPIRequest(
-      wsKey || WS_KEY_MAP.wsApiFuturesV1,
-      'futures.cancel',
-      params,
-    );
-⋮----
-/**
-   * Submit multiple futures orders
-   */
-submitMultipleFuturesOrders(
-    params: Order[],
-    wsKey?: WSAPIWsKey,
-): Promise<WSAPIResponse<SubmitMultipleOrdersFuturesResponse[]>>
-⋮----
-/**
-   * Cancel multiple futures orders
-   */
-cancelMultipleFuturesOrders(
-    params: BatchCancelOrdersRequest,
-    wsKey?: WSAPIWsKey,
-): Promise<WSAPIResponse<BatchCancelOrderResult[]>>
-⋮----
-/**
-   *
-   *
-   *
-   *
-   *
-   *
-   *
-   * Private methods for handling some of the convenience/automation provided by the WS API Client
-   *
-   *
-   *
-   *
-   *
-   *
-   *
-   */
-⋮----
-public connectWSAPI(wsKey: WSAPIWsKey)
-⋮----
-private setupDefaultEventListeners()
-⋮----
-/**
-       * General event handlers for monitoring the WebsocketClient
-       */
-⋮----
-// Blind JSON.stringify can fail on circular references
-⋮----
-// JSON.stringify({ ...data, target: 'WebSocket' }),
-
-================
-File: src/lib/websocket/websocket-util.ts
-================
-import WebSocket from 'isomorphic-ws';
-⋮----
-import { WsRequestOperationKucoin } from '../../types/websockets/ws-api.js';
-import { MessageEventLike } from '../../types/websockets/ws-events.js';
-⋮----
-/** Should be one WS key per unique URL */
-⋮----
-/** Dedicated V2 (Pro) connection for push of public spot market data */
-⋮----
-/** Dedicated V2 (Pro) connection for push of public futures market data */
-⋮----
-/** Shared (spot & futures) V2 (Pro) connection for all private data */
-⋮----
-/** This is used to differentiate between each of the available websocket streams */
-export type WsKey = (typeof WS_KEY_MAP)[keyof typeof WS_KEY_MAP];
-export type WSAPIWsKey =
-  | typeof WS_KEY_MAP.wsApiFuturesV1
-  | typeof WS_KEY_MAP.wsApiSpotV1;
-⋮----
-/**
- * Normalised internal format for a request (subscribe/unsubscribe/etc) on a topic, with optional parameters.
- *
- * - Topic: the topic this event is for
- * - Payload: the parameters to include, optional. E.g. auth requires key + sign. Some topics allow configurable parameters.
- */
-export interface WsTopicRequest<
-  TWSTopic extends string = string,
-  TWSPayload = any,
-> {
-  topic: TWSTopic;
-  payload?: TWSPayload;
-}
-⋮----
-/**
- * Conveniently allow users to request a topic either as string topics or objects (containing string topic + params)
- */
-export type WsTopicRequestOrStringTopic<
-  TWSTopic extends string,
-  TWSPayload = any,
-> = WsTopicRequest<TWSTopic, TWSPayload> | string;
-⋮----
-/**
- * #305: ws.terminate() is undefined in browsers.
- * This only works in node.js, not in browsers.
- * Does nothing if `ws` is undefined. Does nothing in browsers.
- */
-export function safeTerminateWs(
-  ws?: WebSocket | any,
-  fallbackToClose?: boolean,
-): boolean
-⋮----
-/**
- * WS API promises are stored using a primary key. This key is constructed using
- * properties found in every request & reply.
- *
- * The counterpart to this is in resolveEmittableEvents
- */
-export function getPromiseRefForWSAPIRequest(
-  wsKey: WsKey,
-  requestEvent: WsRequestOperationKucoin<string>,
-): string
-⋮----
-export function isWSAPIWsKey(wsKey: WsKey): wsKey is WSAPIWsKey
-⋮----
-export function isBufferMessageEvent(
-  msg: unknown,
-): msg is MessageEventLike<Buffer>
-⋮----
-export function bufferLooksLikeText(
-  data?: Buffer | ArrayBufferLike | null,
-): boolean
-⋮----
-// '{' '[' or '"' are common JSON prefixes; fast heuristic to detect plaintext
-⋮----
-export async function decompressMessageEvent(
-  event: MessageEventLike<Buffer<ArrayBufferLike>>,
-): Promise<MessageEventLike<any>>
-⋮----
-// Some KuCoin streams (notably newer spot public v2) send JSON in a binary
-// frame without compression. If the payload already looks like UTF-8 text,
-// skip decompression and just decode it so the message can be processed.
-⋮----
-start(controller)
-
-================
-File: src/types/websockets/ws-api.ts
-================
-import { WS_KEY_MAP, WsKey } from '../../lib/websocket/websocket-util.js';
-import { BatchCancelOrdersRequest, Order } from '../request/futures.types.js';
-import { SubmitHFMarginOrderRequest } from '../request/spot-margin-trading.js';
-import {
-  ModifyHFOrderRequest,
-  SubmitHFOrderRequest,
-} from '../request/spot-trading.js';
-import {
-  BatchCancelOrderResult,
-  SubmitMultipleOrdersFuturesResponse,
-} from '../response/futures.types.js';
-import { MarginSubmitOrderV3Response } from '../response/spot-margin-trading.js';
-import {
-  SubmitHFOrderSyncResponse,
-  SyncCancelHFOrderResponse,
-} from '../response/spot-trading.js';
-⋮----
-export type WsOperation =
-  | 'subscribe'
-  | 'unsubscribe'
-  | 'login'
-  | 'access'
-  | 'request'
-  | 'ping';
-⋮----
-/**
- * Kucoin's format for WS request operations with the V1 WebSockets
- */
-export interface WsRequestOperationV1<TWSTopic extends string> {
-  id: number;
-  type: WsOperation;
-  topic: TWSTopic;
-  privateChannel: boolean;
-  response: boolean;
-}
-/**
- * Kucoin's format for WS request operations with the V2 (Pro) WebSockets
- */
-export interface WsRequestOperationV2<TWSTopic extends string> {
-  id: string;
-  action: WsOperation;
-  channel: TWSTopic;
-}
-⋮----
-export type Exact<T> = {
-  // This part says: if there's any key that's not in T, it's an error
-  // This conflicts sometimes for some reason...
-  // [K: string]: never;
-} & {
-  [K in keyof T]: T[K];
-};
-⋮----
-// This part says: if there's any key that's not in T, it's an error
-// This conflicts sometimes for some reason...
-// [K: string]: never;
-⋮----
-/**
- * WS API commands (for sending requests via WS)
- */
-⋮----
-export type WsAPIOperation = (typeof WS_API_Operations)[number];
-⋮----
-export interface WsRequestOperationKucoin<
-  TWSTopic extends string,
-  TWSParams extends object = any,
-> {
-  id: string;
-  op: WsOperation | WsAPIOperation;
-  args?: (TWSTopic | string | number)[] | TWSParams; // Business parameters, same as RestAPI
-}
-⋮----
-args?: (TWSTopic | string | number)[] | TWSParams; // Business parameters, same as RestAPI
-⋮----
-export interface WSAPIResponse<
-  TResponseData extends object = object,
-  TWSAPIOperation = WsAPIOperation,
-> {
-  /** Auto-generated */
-  id: string;
-
-  op: TWSAPIOperation;
-
-  msg?: string;
-  code: '200000' | string;
-
-  data: TResponseData;
-  inTime: number; //Gateway in time(ms)
-  outTime: number; //Gateway out time(ms)
-  rateLimit?: { limit: number; reset: number; remaining: number };
-
-  wsKey: WsKey;
-  isWSAPIResponse: boolean;
-
-  request?: any;
-}
-⋮----
-/** Auto-generated */
-⋮----
-inTime: number; //Gateway in time(ms)
-outTime: number; //Gateway out time(ms)
-⋮----
-export interface WsAPIWsKeyTopicMap {
-  [WS_KEY_MAP.wsApiSpotV1]: WsAPIOperation;
-  [WS_KEY_MAP.wsApiFuturesV1]: WsAPIOperation;
-}
-⋮----
-export type WSAPICancelOrderRequest = { symbol: string } & (
-  | { orderId: string }
-  | { clientOid: string }
-);
-⋮----
-export interface WSAPIOrderResponse {
-  orderId: string;
-  clientOid: string;
-}
-⋮----
-export interface WsAPITopicRequestParamMap {
-  [key: string]: unknown;
-
-  subscribe: never;
-  unsubscribe: never;
-  login: never;
-  access: never;
-  request: never;
-
-  ping: void;
-
-  'spot.order': SubmitHFOrderRequest;
-  'margin.order': SubmitHFMarginOrderRequest;
-  'futures.order': Order;
-  'spot.cancel': WSAPICancelOrderRequest;
-  'margin.cancel': WSAPICancelOrderRequest;
-  'futures.cancel': { orderId: string } | { clientOid: string; symbol: string };
-  'futures.multi_cancel': BatchCancelOrdersRequest;
-  'futures.multi_order': Order[];
-  'spot.sync_order': SubmitHFOrderRequest;
-  'spot.modify': ModifyHFOrderRequest;
-  'spot.sync_cancel': WSAPICancelOrderRequest;
-}
-⋮----
-export interface WsAPITopicResponseMap {
-  [key: string]: unknown;
-
-  subscribe: never;
-  unsubscribe: never;
-  login: never;
-  access: never;
-  request: never;
-
-  ping: unknown;
-
-  'spot.order': WSAPIResponse<WSAPIOrderResponse>;
-  'margin.order': WSAPIResponse<MarginSubmitOrderV3Response>;
-  'futures.order': WSAPIResponse<WSAPIOrderResponse>;
-  'spot.cancel': WSAPIResponse<WSAPIOrderResponse>;
-  'margin.cancel': WSAPIResponse<WSAPIOrderResponse>;
-  'futures.cancel': WSAPIResponse<
-    { cancelledOrderIds: string[] } | { clientOid: string }
-  >;
-  'futures.multi_cancel': WSAPIResponse<BatchCancelOrderResult[]>;
-  'futures.multi_order': WSAPIResponse<SubmitMultipleOrdersFuturesResponse[]>;
-  'spot.sync_order': WSAPIResponse<SubmitHFOrderSyncResponse>;
-  'spot.modify': WSAPIResponse<{
-    newOrderId: string;
-    clientOid: string;
-  }>;
-  'spot.sync_cancel': WSAPIResponse<SyncCancelHFOrderResponse>;
-}
-⋮----
-export interface WSAPIAuthenticationRequestFromServer {
-  timestamp: number;
-  sessionId: string;
-}
-⋮----
-export interface WSAPIAuthenticationConfirmedFromServer {
-  pingInterval: number;
-  sessionId: string;
-  pingTimeout: number;
-  data: 'welcome';
-}
-
-================
-File: README.md
-================
-# Node.js & JavaScript SDK for KuCoin REST APIs, Websockets & WebSocket API
-
-[![Build & Test](https://github.com/tiagosiebler/kucoin-api/actions/workflows/e2etest.yml/badge.svg?branch=master)](https://github.com/tiagosiebler/kucoin-api/actions/workflows/e2etest.yml)
-[![npm version](https://img.shields.io/npm/v/kucoin-api)][1]
-[![npm size](https://img.shields.io/bundlephobia/min/kucoin-api/latest)][1]
-[![npm downloads](https://img.shields.io/npm/dt/kucoin-api)][1]
-[![last commit](https://img.shields.io/github/last-commit/tiagosiebler/kucoin-api)][1]
-[![Telegram](https://img.shields.io/badge/chat-on%20telegram-blue.svg)](https://t.me/nodetraders)
-
-<p align="center">
-  <a href="https://www.npmjs.com/package/kucoin-api">
-    <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://github.com/tiagosiebler/kucoin-api/blob/master/docs/images/logoDarkMode2.svg?raw=true#gh-dark-mode-only">
-      <img alt="SDK Logo" src="https://github.com/tiagosiebler/kucoin-api/blob/master/docs/images/logoBrightMode2.svg?raw=true#gh-light-mode-only">
-    </picture>
-  </a>
-</p>
-
-[1]: https://www.npmjs.com/package/kucoin-api
-
-Updated & performant JavaScript & Node.js SDK for the KuCoin REST APIs and WebSockets:
-
-- Professional, robust & performant KuCoin SDK with extensive production use in live trading environments.
-- Complete integration with all KuCoin REST APIs and WebSockets.
-  - Dedicated REST clients for Spot, Futures, and Broker operations
-  - Unified WebSocket client for all markets
-  - Dedicated WebSocket API client, to trade on the WebSocket API without the complexity of WebSockets.
-- Complete TypeScript support (with type declarations for most API requests & responses).
-  - Strongly typed requests and responses.
-  - Automated end-to-end tests ensuring reliability.
-- Actively maintained with a modern, promise-driven interface.
-- Robust WebSocket integration with configurable connection heartbeats & automatic reconnect then resubscribe workflows.
-  - Event driven messaging.
-  - Smart WebSocket persistence with automatic reconnection handling.
-  - Emit `reconnected` event when dropped connection is restored.
-  - Support for both public and private WebSocket streams.
-- Supports WebSocket API on all available product groups, including Spot & Futures:
-  - Use the WebsocketClient's event-driven `sendWSAPIRequest()` method, or;
-  - Use the WebsocketAPIClient for a REST-like experience. Use the WebSocket API like a REST API! See [examples/WebSockets/WS-API/ws-api-client.ts](./examples/WebSockets/WS-API/ws-api-client.ts) for a demonstration.
-- Browser-friendly HMAC signature mechanism.
-- Automatically supports both ESM and CJS projects.
-- Heavy automated end-to-end testing with real API calls.
-- Proxy support via axios integration.
-- Active community support & collaboration in telegram: [Node.js Algo Traders](https://t.me/nodetraders).
-
-## Table of Contents
-
-- [Installation](#installation)
-- [Examples](#examples)
-- [Issues & Discussion](#issues--discussion)
-- [Related Projects](#related-projects)
-- [Documentation](#documentation)
-- [Structure](#structure)
-- [Usage](#usage)
-  - [REST API Clients](#rest-api)
-    - [Spot & Margin Trading](#spot--margin-trading)
-    - [Futures Trading](#futures-trading)
-    - [Broker Operations](#broker-operations)
-    - [Unified API](#unified-api)
-  - [WebSockets](#websockets)
-    - [WebSocket Consumers](#websocket-consumers)
-      - [Public WebSocket Streams](#public-websocket-streams)
-      - [Private WebSocket Streams](#private-websocket-streams)
-    - [WebSocket API](#websocket-api)
-      - [Event Driven API](#event-driven-api)
-      - [Promise Driven API](#async-await-api)
-- [Customise Logging](#customise-logging)
-- [Browser/Frontend Usage](#browserfrontend-usage)
-  - [Webpack](#webpack)
-- [LLMs & AI](#use-with-llms--ai)
-- [Used By](#used-by)
-- [Contributions & Thanks](#contributions--thanks)
-
-## Installation
-
-`npm install --save kucoin-api`
-
-## Examples
-
-Refer to the [examples](./examples) folder for implementation demos.
-
-## Issues & Discussion
-
-- Issues? Check the [issues tab](https://github.com/tiagosiebler/kucoin-api/issues).
-- Discuss & collaborate with other node devs? Join our [Node.js Algo Traders](https://t.me/nodetraders) engineering community on telegram.
-- Follow our announcement channel for real-time updates on [X/Twitter](https://x.com/sieblyio)
-
-<!-- template_related_projects -->
-
-## Related Projects
-
-Check out our JavaScript/TypeScript/Node.js SDKs & Projects:
-
-- Visit our website: [https://Siebly.io](https://siebly.io/?ref=gh)
-- Try our REST API & WebSocket SDKs published on npmjs:
-  - [Bybit Node.js SDK: bybit-api](https://www.npmjs.com/package/bybit-api)
-  - [Kraken Node.js SDK: @siebly/kraken-api](https://www.npmjs.com/package/@siebly/kraken-api)
-  - [OKX Node.js SDK: okx-api](https://www.npmjs.com/package/okx-api)
-  - [Binance Node.js SDK: binance](https://www.npmjs.com/package/binance)
-  - [Gate (gate.com) Node.js SDK: gateio-api](https://www.npmjs.com/package/gateio-api)
-  - [Bitget Node.js SDK: bitget-api](https://www.npmjs.com/package/bitget-api)
-  - [KuCoin Node.js SDK: kucoin-api](https://www.npmjs.com/package/kucoin-api)
-  - [Coinbase Node.js SDK: coinbase-api](https://www.npmjs.com/package/coinbase-api)
-  - [Bitmart Node.js SDK: bitmart-api](https://www.npmjs.com/package/bitmart-api)
-- Try my misc utilities:
-  - [OrderBooks Node.js: orderbooks](https://www.npmjs.com/package/orderbooks)
-  - [Crypto Exchange Account State Cache: accountstate](https://www.npmjs.com/package/accountstate)
-- Check out my examples:
-  - [awesome-crypto-examples Node.js](https://github.com/tiagosiebler/awesome-crypto-examples)
-  <!-- template_related_projects_end -->
-
-## Documentation
-
-Most methods accept JS objects. These can be populated using parameters specified by KuCoin's API documentation, or check the type definition in each class within this repository.
-
-### API Documentation Links
-
-- [KuCoin API Documentation](https://www.kucoin.com/docs-new/introduction)
-
-### SDK Documentation & Guides
-
-- Node.js Quick Start Guides
-  - [Spot Node.js KuCoin Quick Start Guide](./examples/kucoin-SPOT-examples-nodejs.md)
-  - [Futures Node.js KuCoin Quick Start Guide](./examples/kucoin-FUTURES-examples-nodejs.md)
-- [Futures Node.js KuCoin Order Placement Guide](./examples/rest-futures-orders-guide.ts)
-- [REST Endpoint Function List](./docs/endpointFunctionList.md)
-
-## Structure
-
-This project uses typescript. Resources are stored in 2 key structures:
-
-- [src](./src) - the whole connector written in typescript
-- [examples](./examples) - some implementation examples & demonstrations. Contributions are welcome!
-
----
-
-# Usage
-
-Create API credentials on KuCoin's website:
-
-- [KuCoin API Key Management](https://www.kucoin.com/account/api)
-
-## REST API
-
-The SDK provides dedicated REST clients for different trading products:
-
-- **SpotClient** - for spot trading and margin operations
-- **FuturesClient** - for futures trading operations
-- **BrokerClient** - for broker and sub-account management
-- **UnifiedAPIClient** - for unified market data access across all trading products
-
-### Spot & Margin Trading
-
-To use KuCoin's Spot and Margin APIs, import (or require) the `SpotClient`:
-
-```javascript
-const { SpotClient, FuturesClient } = require('kucoin-api');
-
-const client = new SpotClient({
-  apiKey: 'apiKeyHere',
-  apiSecret: 'apiSecretHere',
-  apiPassphrase: 'apiPassPhraseHere',
-});
-
-try {
-  const spotBuyResult = await client.submitHFOrder({
-    clientOid: client.generateNewOrderID(),
-    side: 'buy',
-    type: 'market',
-    symbol: 'BTC-USDT',
-    size: '0.00001',
-  });
-  console.log('spotBuy ', JSON.stringify(spotBuyResult, null, 2));
-
-  const spotSellResult = await client.submitHFOrder({
-    clientOid: client.generateNewOrderID(),
-    side: 'sell',
-    type: 'market',
-    symbol: 'BTC-USDT',
-    size: '0.00001',
-  });
-  console.log('spotSellResult ', JSON.stringify(spotSellResult, null, 2));
-} catch (e) {
-  console.error(`Req error: `, e);
-}
-```
-
-See [SpotClient](./src/SpotClient.ts) for further information, or the [examples](./examples/) for lots of usage examples.
-
-### Futures Trading
-
-Use the `FuturesClient` for futures trading operations. See [FuturesClient](./src/FuturesClient.ts) for complete API coverage.
-
-### Broker Operations
-
-Use the `BrokerClient` for broker and sub-account management operations. See [BrokerClient](./src/BrokerClient.ts) for complete API coverage.
-
-### Unified API
-
-The `UnifiedAPIClient` provides access to KuCoin's Unified API endpoints, which offer streamlined market data access across Spot, Futures, and Margin trading products. It doesn't serve a purpose of a UTA account(Unified trading account) - but it is a new generation of API endpoints generalised for all trading products.
-
-## WebSockets
-
-All WebSocket functionality is supported via the unified `WebsocketClient`. This client handles both spot and futures WebSocket streams with automatic connection management and reconnection.
-
-Key WebSocket features:
-
-- Event driven messaging
-- Smart WebSocket persistence with automatic reconnection
-- Heartbeat mechanisms to detect disconnections
-- Automatic resubscription after reconnection
-- Support for both public and private WebSocket streams
-- Unified client for spot and futures markets
-
-### WebSocket Consumers
-
-All websockets are accessible via the shared `WebsocketClient`. As before, API credentials are optional unless the user data stream is required.
-
-#### Public WebSocket Streams
-
-For public market data, API credentials are not required:
-
-All available WebSockets can be used via a shared `WebsocketClient`. The WebSocket client will automatically open/track/manage connections as needed. Each unique connection (one per server URL) is tracked using a WsKey (each WsKey is a string - see [WS_KEY_MAP](src/lib/websocket/websocket-util.ts) for a list of supported values).
-
-Any subscribe/unsubscribe events will need to include a WsKey, so the WebSocket client understands which connection the event should be routed to. See examples below or in the [examples](./examples/) folder on GitHub.
-
-Data events are emitted from the WebsocketClient via the `update` event, see example below:
-
-```javascript
-const { WebsocketClient } = require('kucoin-api');
-
-const client = new WebsocketClient();
-
-client.on('open', (data) => {
-  console.log('open: ', data?.wsKey);
-});
-
-// Data received
-client.on('update', (data) => {
-  console.info('data received: ', JSON.stringify(data));
-});
-
-// Something happened, attempting to reconenct
-client.on('reconnect', (data) => {
-  console.log('reconnect: ', data);
-});
-
-// Reconnect successful
-client.on('reconnected', (data) => {
-  console.log('reconnected: ', data);
-});
-
-// Connection closed. If unexpected, expect reconnect -> reconnected.
-client.on('close', (data) => {
-  console.error('close: ', data);
-});
-
-// Reply to a request, e.g. "subscribe"/"unsubscribe"/"authenticate"
-client.on('response', (data) => {
-  console.info('response: ', data);
-  // throw new Error('res?');
-});
-
-client.on('exception', (data) => {
-  console.error('exception: ', {
-    msg: data.msg,
-    errno: data.errno,
-    code: data.code,
-    syscall: data.syscall,
-    hostname: data.hostname,
-  });
-});
-
-try {
-  // Optional: await a connection to be ready before subscribing (this is not necessary)
-  // await client.connect('futuresPublicV1');
-
-  /**
-   * Examples for public futures websocket topics (that don't require authentication).
-   *
-   * These should all subscribe via the "futuresPublicV1" wsKey. For detailed usage, refer to the ws-private-spot-v1.ts & ws-public-futures-v1.ts examples.
-   */
-  client.subscribe(
-    [
-      '/contractMarket/tickerV2:XBTUSDM',
-      '/contractMarket/ticker:XBTUSDM',
-      '/contractMarket/level2:XBTUSDM',
-      '/contractMarket/execution:XBTUSDM',
-      '/contractMarket/level2Depth5:XBTUSDM',
-      '/contractMarket/level2Depth50:XBTUSDM',
-      '/contractMarket/limitCandle:XBTUSDTM_1hour',
-      '/contract/instrument:XBTUSDM',
-      '/contract/announcement',
-      '/contractMarket/snapshot:XBTUSDM',
-    ],
-    'futuresPublicV1',
-  );
-
-  /**
-   * The V2 (Pro) WebSockets are also supported, accessible via the corresponding V2 WsKeys. Below is a demonstration for the V2 public futures topics with the WsKey "futuresPublicProV2":
-   */
-
-  client.subscribe(
-    [
-      // BTCUSDT tickers for FUTURES market
-      // https://www.kucoin.com/docs-new/3470222w0
-      {
-        topic: 'ticker',
-        payload: {
-          tradeType: 'FUTURES',
-          symbol: 'XBTUSDTM',
-        },
-      },
-      // BTCUSDT orderbook updates for FUTURES market
-      // https://www.kucoin.com/docs-new/3470221w0
-      {
-        topic: 'obu',
-        payload: {
-          tradeType: 'FUTURES',
-          symbol: 'XBTUSDTM',
-          depth: '5', // 1 / 5 / 50 / increment
-          rpiFilter: 0, // 0：Only NoneRPI orders [Default]  1(Only Support Futures)：NoneRPI+ RPI Orders. When rpiFilter=1, "depth" only supports 5/50.
-        },
-      },
-      // BTCUSDT trades for spot market
-      // https://www.kucoin.com/docs-new/3470224w0
-      {
-        topic: 'trade',
-        payload: {
-          tradeType: 'FUTURES',
-          symbol: 'XBTUSDTM',
-        },
-      },
-    ],
-    'futuresPublicProV2',
-  );
-} catch (e) {
-  console.error(`Subscribe exception: `, e);
-}
-```
-
-#### Private WebSocket Streams
-
-For private account data streams, API credentials are required. The WebsocketClient will automatically handle authentication when you provide API credentials.
-
-See [WebsocketClient](./src/WebsocketClient.ts) for further information and make sure to check the [examples/WebSockets/](./examples/WebSockets/) folder for much more detail, especially [ws-private-spot-v1.ts](./examples/WebSockets/ws-private-spot-v1.ts) and [ws-private-pro-v2.ts](./examples/WebSockets/ws-private-pro-v2.ts), which explain in a lot of detail.
-
-### WebSocket API
-
-KuCoin also support sending requests (commands) over an active WebSocket connection. This is called the WebSocket API. There are two key ways of interacting with the WebSocket API. The existing WebsocketClient allows raw event routing via the awaitable sendWSAPIRequest() method, or for a much simpler & convenient interface, use the promise-driven API. The surface feels like a REST API, but routing is automatically routed via a dedicated WebSocket connection.
-
-#### Event Driven API
-
-The WebSocket API is available in the [WebsocketClient](./src/websocket-client.ts) via the `sendWSAPIRequest(wsKey, command, commandParameters)` method.
-
-Each call to this method is wrapped in a promise, which you can async await for a response, or handle it in a raw event-driven design.
-
-#### Promise Driven API
-
-The WebSocket API is also available in a promise-wrapped REST-like format. Either, as above, await any calls to `sendWSAPIRequest(...)`, or directly use the convenient WebsocketAPIClient. This class is very similar to existing REST API classes (such as the MainClient or USDMClient).
-
-It provides one function per endpoint, feels like a REST API and will automatically route your request via an automatically persisted, authenticated and health-checked WebSocket API connection.
-
-Below is an example showing how easy it is to use the WebSocket API without any concern for the complexity of managing WebSockets. For more detailed demonstration, take a look at the [examples/WebSockets/WS-API/ws-api-client.ts](./examples/WebSockets/WS-API/ws-api-client.ts) example:
-
-```typescript
-import { DefaultLogger, WebsocketAPIClient } from 'kucoin-api';
-
-// or, if you prefer `require()`:
-// const { DefaultLogger, WebsocketAPIClient } = require('kucoin-api');
-
-const customLogger = {
-  ...DefaultLogger,
-  // For a more detailed view of the WebsocketClient, enable the `trace` level by uncommenting the below line:
-  // trace: (...params) => console.log(new Date(), 'trace', ...params),
-};
-
-const account = {
-  key: process.env.API_KEY || 'keyHere',
-  secret: process.env.API_SECRET || 'secretHere',
-  passphrase: process.env.API_PASSPHRASE || 'apiPassPhraseHere', // This is NOT your account password
-};
-
-const wsClient = new WebsocketAPIClient(
-  {
-    apiKey: account.key,
-    apiSecret: account.secret,
-    apiPassphrase: account.passphrase,
-
-    // If you want your own event handlers instead of the default ones with logs, disable this setting and see the `attachEventHandlers` example below:
-    // attachEventListeners: false
-  },
-  // customLogger, // optional: uncomment this to inject a custom logger
-);
-
-// Make WebSocket API calls, very similar to a REST API:
-
-wsClient
-  .submitNewSpotOrder({
-    side: 'buy',
-    symbol: 'BTC-USDT',
-    type: 'limit',
-    price: '150000',
-    size: '0.0001',
-  })
-  .then((syncSpotOrderResponse) => {
-    console.log('Sync spot order response:', syncSpotOrderResponse);
-  })
-  .catch((e) => {
-    console.log('Sync spot order error:', e);
-  });
-
-wsClient
-  .submitFuturesOrder({
-    clientOid: 'futures-test-' + Date.now(),
-    side: 'buy',
-    symbol: 'XBTUSDTM',
-    marginMode: 'CROSS',
-    type: 'limit',
-    price: '1000',
-    qty: '0.01',
-    leverage: 10,
-    positionSide: 'LONG', // needed if trading two-way (hedge) position mode
-  })
-  .then((futuresOrderResponse) => {
-    console.log('Futures order response:', futuresOrderResponse);
-  })
-  .catch((e) => {
-    console.log('Futures order error:', e);
-  });
-```
-
----
-
-## Customise Logging
-
-Pass a custom logger which supports the log methods `trace`, `info` and `error`, or override methods from the default logger as desired.
-
-```javascript
-const { WebsocketClient, DefaultLogger } = require('kucoin-api');
-
-// E.g. customise logging for only the trace level:
-const logger = {
-  // Inherit existing logger methods, using an object spread
-  ...DefaultLogger,
-  // Define a custom trace function to override only that function
-  trace: (...params) => {
-    if (
-      [
-        // Selectively prevent some traces from logging
-        'Sending ping',
-        'Received pong',
-      ].includes(params[0])
-    ) {
-      return;
-    }
-    console.log('trace', JSON.stringify(params, null, 2));
-  },
-};
-
-const ws = new WebsocketClient(
-  {
-    apiKey: 'apiKeyHere',
-    apiSecret: 'apiSecretHere',
-    apiPassphrase: 'apiPassPhraseHere',
-  },
-  logger,
-);
-```
-
-## Browser/Frontend Usage
-
-### Webpack
-
-Build a bundle using webpack:
-
-- `npm install`
-- `npm run build`
-- `npm run pack`
-
-The bundle can be found in `dist/`. Altough usage should be largely consistent, smaller differences will exist. Documentation is still TODO.
-
-## Use with LLMs & AI
-
-This SDK includes a bundled `llms.txt` file in the root of the repository. If you're developing with LLMs, use the included `llms.txt` with your LLM - it will significantly improve the LLMs understanding of how to correctly use this SDK.
-
-This file contains AI optimised structure of all the functions in this package, and their parameters for easier use with any learning models or artificial intelligence.
-
----
-
-## Used By
-
-[![Repository Users Preview Image](https://dependents.info/tiagosiebler/kucoin-api/image)](https://github.com/tiagosiebler/kucoin-api/network/dependents)
-
----
-
-<!-- template_contributions -->
-
-### Contributions & Thanks
-
-Have my projects helped you? Share the love, there are many ways you can show your thanks:
-
-- Star & share my projects.
-- Are my projects useful? Sponsor me on Github and support my effort to maintain & improve them: https://github.com/sponsors/tiagosiebler
-- Have an interesting project? Get in touch & invite me to it.
-- Or buy me all the coffee:
-  - ETH(ERC20): `0xA3Bda8BecaB4DCdA539Dc16F9C54a592553Be06C` <!-- metamask -->
-- Sign up with my referral links:
-  - OKX (receive a 20% fee discount!): https://www.okx.com/join/42013004
-  - Binance (receive a 20% fee discount!): https://accounts.binance.com/register?ref=OKFFGIJJ
-  - HyperLiquid (receive a 4% fee discount!): https://app.hyperliquid.xyz/join/SDK
-  - Gate: https://www.gate.io/signup/NODESDKS?ref_type=103
-
-<!---
-old ones:
-  - BTC: `1C6GWZL1XW3jrjpPTS863XtZiXL1aTK7Jk`
-  - BTC(SegWit): `bc1ql64wr9z3khp2gy7dqlmqw7cp6h0lcusz0zjtls`
-  - ETH(ERC20): `0xe0bbbc805e0e83341fadc210d6202f4022e50992`
-  - USDT(TRC20): `TA18VUywcNEM9ahh3TTWF3sFpt9rkLnnQa
-  - gate: https://www.gate.io/signup/AVNNU1WK?ref_type=103
-
--->
-<!-- template_contributions_end -->
-
-### Contributions & Pull Requests
-
-Contributions are encouraged, I will review any incoming pull requests. See the issues tab for todo items.
-
-<!-- template_star_history -->
-
-## Star History
-
-[![Star History Chart](https://api.star-history.com/svg?repos=tiagosiebler/bybit-api,tiagosiebler/okx-api,tiagosiebler/binance,tiagosiebler/bitget-api,tiagosiebler/bitmart-api,tiagosiebler/gateio-api,tiagosiebler/kucoin-api,tiagosiebler/coinbase-api,tiagosiebler/orderbooks,tiagosiebler/accountstate,tiagosiebler/awesome-crypto-examples&type=Date)](https://star-history.com/#tiagosiebler/bybit-api&tiagosiebler/okx-api&tiagosiebler/binance&tiagosiebler/bitget-api&tiagosiebler/bitmart-api&tiagosiebler/gateio-api&tiagosiebler/kucoin-api&tiagosiebler/coinbase-api&tiagosiebler/orderbooks&tiagosiebler/accountstate&tiagosiebler/awesome-crypto-examples&Date)
-
-<!-- template_star_history_end -->
 
 ================
 File: src/lib/BaseWSClient.ts
@@ -15109,6 +15016,766 @@ public async assertIsAuthenticated(wsKey: TWSKey): Promise<unknown>
 // this.logger.trace('assertIsAuthenticated(): newly authenticated!');
 
 ================
+File: src/types/websockets/ws-api.ts
+================
+import { WS_KEY_MAP, WsKey } from '../../lib/websocket/websocket-util.js';
+import { BatchCancelOrdersRequest, Order } from '../request/futures.types.js';
+import { SubmitHFMarginOrderRequest } from '../request/spot-margin-trading.js';
+import {
+  ModifyHFOrderRequest,
+  SubmitHFOrderRequest,
+} from '../request/spot-trading.js';
+import {
+  BatchCancelOrderResult,
+  SubmitMultipleOrdersFuturesResponse,
+} from '../response/futures.types.js';
+import { MarginSubmitOrderV3Response } from '../response/spot-margin-trading.js';
+import {
+  SubmitHFOrderSyncResponse,
+  SyncCancelHFOrderResponse,
+} from '../response/spot-trading.js';
+⋮----
+export type WsOperation =
+  | 'subscribe'
+  | 'unsubscribe'
+  | 'login'
+  | 'access'
+  | 'request'
+  | 'ping';
+⋮----
+/**
+ * Kucoin's format for WS request operations with the V1 WebSockets
+ */
+export interface WsRequestOperationV1<TWSTopic extends string> {
+  id: number;
+  type: WsOperation;
+  topic: TWSTopic;
+  privateChannel: boolean;
+  response: boolean;
+}
+/**
+ * Kucoin's format for WS request operations with the V2 (Pro) WebSockets
+ */
+export interface WsRequestOperationV2<TWSTopic extends string> {
+  id: string;
+  action: WsOperation;
+  channel: TWSTopic;
+}
+⋮----
+export type Exact<T> = {
+  // This part says: if there's any key that's not in T, it's an error
+  // This conflicts sometimes for some reason...
+  // [K: string]: never;
+} & {
+  [K in keyof T]: T[K];
+};
+⋮----
+// This part says: if there's any key that's not in T, it's an error
+// This conflicts sometimes for some reason...
+// [K: string]: never;
+⋮----
+/**
+ * WS API commands (for sending requests via WS)
+ */
+⋮----
+export type WsAPIOperation = (typeof WS_API_Operations)[number];
+⋮----
+export interface WsRequestOperationKucoin<
+  TWSTopic extends string,
+  TWSParams extends object = any,
+> {
+  id: string;
+  op: WsOperation | WsAPIOperation;
+  args?: (TWSTopic | string | number)[] | TWSParams; // Business parameters, same as RestAPI
+}
+⋮----
+args?: (TWSTopic | string | number)[] | TWSParams; // Business parameters, same as RestAPI
+⋮----
+export interface WSAPIResponse<
+  TResponseData extends object = object,
+  TWSAPIOperation = WsAPIOperation,
+> {
+  /** Auto-generated */
+  id: string;
+
+  op: TWSAPIOperation;
+
+  msg?: string;
+  code: '200000' | string;
+
+  data: TResponseData;
+  inTime: number; //Gateway in time(ms)
+  outTime: number; //Gateway out time(ms)
+  rateLimit?: { limit: number; reset: number; remaining: number };
+
+  wsKey: WsKey;
+  isWSAPIResponse: boolean;
+
+  request?: any;
+}
+⋮----
+/** Auto-generated */
+⋮----
+inTime: number; //Gateway in time(ms)
+outTime: number; //Gateway out time(ms)
+⋮----
+export interface WsAPIWsKeyTopicMap {
+  [WS_KEY_MAP.wsApiSpotV1]: WsAPIOperation;
+  [WS_KEY_MAP.wsApiFuturesV1]: WsAPIOperation;
+}
+⋮----
+export type WSAPICancelOrderRequest = { symbol: string } & (
+  | { orderId: string }
+  | { clientOid: string }
+);
+⋮----
+export interface WSAPIOrderResponse {
+  orderId: string;
+  clientOid: string;
+}
+⋮----
+export interface WsAPITopicRequestParamMap {
+  [key: string]: unknown;
+
+  subscribe: never;
+  unsubscribe: never;
+  login: never;
+  access: never;
+  request: never;
+
+  ping: void;
+
+  'spot.order': SubmitHFOrderRequest;
+  'margin.order': SubmitHFMarginOrderRequest;
+  'futures.order': Order;
+  'spot.cancel': WSAPICancelOrderRequest;
+  'margin.cancel': WSAPICancelOrderRequest;
+  'futures.cancel': { orderId: string } | { clientOid: string; symbol: string };
+  'futures.multi_cancel': BatchCancelOrdersRequest;
+  'futures.multi_order': Order[];
+  'spot.sync_order': SubmitHFOrderRequest;
+  'spot.modify': ModifyHFOrderRequest;
+  'spot.sync_cancel': WSAPICancelOrderRequest;
+}
+⋮----
+export interface WsAPITopicResponseMap {
+  [key: string]: unknown;
+
+  subscribe: never;
+  unsubscribe: never;
+  login: never;
+  access: never;
+  request: never;
+
+  ping: unknown;
+
+  'spot.order': WSAPIResponse<WSAPIOrderResponse>;
+  'margin.order': WSAPIResponse<MarginSubmitOrderV3Response>;
+  'futures.order': WSAPIResponse<WSAPIOrderResponse>;
+  'spot.cancel': WSAPIResponse<WSAPIOrderResponse>;
+  'margin.cancel': WSAPIResponse<WSAPIOrderResponse>;
+  'futures.cancel': WSAPIResponse<
+    { cancelledOrderIds: string[] } | { clientOid: string }
+  >;
+  'futures.multi_cancel': WSAPIResponse<BatchCancelOrderResult[]>;
+  'futures.multi_order': WSAPIResponse<SubmitMultipleOrdersFuturesResponse[]>;
+  'spot.sync_order': WSAPIResponse<SubmitHFOrderSyncResponse>;
+  'spot.modify': WSAPIResponse<{
+    newOrderId: string;
+    clientOid: string;
+  }>;
+  'spot.sync_cancel': WSAPIResponse<SyncCancelHFOrderResponse>;
+}
+⋮----
+export interface WSAPIAuthenticationRequestFromServer {
+  timestamp: number;
+  sessionId: string;
+}
+⋮----
+export interface WSAPIAuthenticationConfirmedFromServer {
+  pingInterval: number;
+  sessionId: string;
+  pingTimeout: number;
+  data: 'welcome';
+}
+
+================
+File: README.md
+================
+# Node.js & JavaScript SDK for KuCoin REST APIs, Websockets & WebSocket API
+
+[![Build & Test](https://github.com/tiagosiebler/kucoin-api/actions/workflows/e2etest.yml/badge.svg?branch=master)](https://github.com/tiagosiebler/kucoin-api/actions/workflows/e2etest.yml)
+[![npm version](https://img.shields.io/npm/v/kucoin-api)][1]
+[![npm size](https://img.shields.io/bundlephobia/min/kucoin-api/latest)][1]
+[![npm downloads](https://img.shields.io/npm/dt/kucoin-api)][1]
+[![last commit](https://img.shields.io/github/last-commit/tiagosiebler/kucoin-api)][1]
+[![Telegram](https://img.shields.io/badge/chat-on%20telegram-blue.svg)](https://t.me/nodetraders)
+
+<p align="center">
+  <a href="https://www.npmjs.com/package/kucoin-api">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://github.com/tiagosiebler/kucoin-api/blob/master/docs/images/logoDarkMode2.svg?raw=true#gh-dark-mode-only">
+      <img alt="SDK Logo" src="https://github.com/tiagosiebler/kucoin-api/blob/master/docs/images/logoBrightMode2.svg?raw=true#gh-light-mode-only">
+    </picture>
+  </a>
+</p>
+
+[1]: https://www.npmjs.com/package/kucoin-api
+
+> [!TIP]
+> Upcoming change: As part of the Siebly.io brand, this SDK will soon be hosted under the [Siebly.io GitHub organisation](https://github.com/sieblyio). The migration is seamless and requires no user changes.
+
+Updated & performant JavaScript & Node.js SDK for the KuCoin REST APIs and WebSockets:
+
+- Professional, robust & performant KuCoin SDK with extensive production use in live trading environments.
+- Complete integration with all KuCoin REST APIs and WebSockets.
+  - Dedicated REST clients for Spot, Futures, and Broker operations
+  - Unified WebSocket client for all markets
+  - Dedicated WebSocket API client, to trade on the WebSocket API without the complexity of WebSockets.
+- Complete TypeScript support (with type declarations for most API requests & responses).
+  - Strongly typed requests and responses.
+  - Automated end-to-end tests ensuring reliability.
+- Actively maintained with a modern, promise-driven interface.
+- Robust WebSocket integration with configurable connection heartbeats & automatic reconnect then resubscribe workflows.
+  - Event driven messaging.
+  - Smart WebSocket persistence with automatic reconnection handling.
+  - Emit `reconnected` event when dropped connection is restored.
+  - Support for both public and private WebSocket streams.
+- Supports WebSocket API on all available product groups, including Spot & Futures:
+  - Use the WebsocketClient's event-driven `sendWSAPIRequest()` method, or;
+  - Use the WebsocketAPIClient for a REST-like experience. Use the WebSocket API like a REST API! See [examples/WebSockets/WS-API/ws-api-client.ts](./examples/WebSockets/WS-API/ws-api-client.ts) for a demonstration.
+- Browser-friendly HMAC signature mechanism.
+- Automatically supports both ESM and CJS projects.
+- Heavy automated end-to-end testing with real API calls.
+- Proxy support via axios integration.
+- Active community support & collaboration in telegram: [Node.js Algo Traders](https://t.me/nodetraders).
+
+## Table of Contents
+
+- [Installation](#installation)
+- [Examples](#examples)
+- [Issues & Discussion](#issues--discussion)
+- [Related Projects](#related-projects)
+- [Documentation](#documentation)
+- [Structure](#structure)
+- [Usage](#usage)
+  - [REST API Clients](#rest-api)
+    - [Spot & Margin Trading](#spot--margin-trading)
+    - [Futures Trading](#futures-trading)
+    - [Broker Operations](#broker-operations)
+    - [Unified API](#unified-api)
+  - [WebSockets](#websockets)
+    - [WebSocket Consumers](#websocket-consumers)
+      - [Public WebSocket Streams](#public-websocket-streams)
+      - [Private WebSocket Streams](#private-websocket-streams)
+    - [WebSocket API](#websocket-api)
+      - [Event Driven API](#event-driven-api)
+      - [Promise Driven API](#async-await-api)
+    - [KuCoin EU & Other Regions](#kucoin-eu--other-regions)
+- [Customise Logging](#customise-logging)
+- [Browser/Frontend Usage](#browserfrontend-usage)
+  - [Webpack](#webpack)
+- [LLMs & AI](#use-with-llms--ai)
+- [Used By](#used-by)
+- [Contributions & Thanks](#contributions--thanks)
+
+## Installation
+
+`npm install --save kucoin-api`
+
+## Examples
+
+Refer to the [examples](./examples) folder for implementation demos.
+
+## Issues & Discussion
+
+- Issues? Check the [issues tab](https://github.com/tiagosiebler/kucoin-api/issues).
+- Discuss & collaborate with other node devs? Join our [Node.js Algo Traders](https://t.me/nodetraders) engineering community on telegram.
+- Follow our announcement channel for real-time updates on [X/Twitter](https://x.com/sieblyio)
+
+<!-- template_related_projects -->
+
+## Related Projects
+
+Check out our JavaScript/TypeScript/Node.js SDKs & Projects:
+
+- Visit our website: [https://Siebly.io](https://siebly.io/?ref=gh)
+- Try our REST API & WebSocket SDKs published on npmjs:
+  - [Bybit Node.js SDK: bybit-api](https://www.npmjs.com/package/bybit-api)
+  - [Kraken Node.js SDK: @siebly/kraken-api](https://www.npmjs.com/package/@siebly/kraken-api)
+  - [OKX Node.js SDK: okx-api](https://www.npmjs.com/package/okx-api)
+  - [Binance Node.js SDK: binance](https://www.npmjs.com/package/binance)
+  - [Gate (gate.com) Node.js SDK: gateio-api](https://www.npmjs.com/package/gateio-api)
+  - [Bitget Node.js SDK: bitget-api](https://www.npmjs.com/package/bitget-api)
+  - [KuCoin Node.js SDK: kucoin-api](https://www.npmjs.com/package/kucoin-api)
+  - [Coinbase Node.js SDK: coinbase-api](https://www.npmjs.com/package/coinbase-api)
+  - [Bitmart Node.js SDK: bitmart-api](https://www.npmjs.com/package/bitmart-api)
+- Try my misc utilities:
+  - [OrderBooks Node.js: orderbooks](https://www.npmjs.com/package/orderbooks)
+  - [Crypto Exchange Account State Cache: accountstate](https://www.npmjs.com/package/accountstate)
+- Check out my examples:
+  - [awesome-crypto-examples Node.js](https://github.com/tiagosiebler/awesome-crypto-examples)
+  <!-- template_related_projects_end -->
+
+## Documentation
+
+Most methods accept JS objects. These can be populated using parameters specified by KuCoin's API documentation, or check the type definition in each class within this repository.
+
+### API Documentation Links
+
+- [KuCoin API Documentation](https://www.kucoin.com/docs-new/introduction)
+
+### SDK Documentation & Guides
+
+- Node.js Quick Start Guides
+  - [Spot Node.js KuCoin Quick Start Guide](./examples/kucoin-SPOT-examples-nodejs.md)
+  - [Futures Node.js KuCoin Quick Start Guide](./examples/kucoin-FUTURES-examples-nodejs.md)
+- [Futures Node.js KuCoin Order Placement Guide](./examples/rest-futures-orders-guide.ts)
+- [REST Endpoint Function List](./docs/endpointFunctionList.md)
+
+## Structure
+
+This project uses typescript. Resources are stored in 2 key structures:
+
+- [src](./src) - the whole connector written in typescript
+- [examples](./examples) - some implementation examples & demonstrations. Contributions are welcome!
+
+---
+
+# Usage
+
+Create API credentials on KuCoin's website:
+
+- [KuCoin API Key Management](https://www.kucoin.com/account/api)
+
+## REST API
+
+The SDK provides dedicated REST clients for different trading products:
+
+- **SpotClient** - for spot trading and margin operations
+- **FuturesClient** - for futures trading operations
+- **BrokerClient** - for broker and sub-account management
+- **UnifiedAPIClient** - for unified market data access across all trading products
+
+### Spot & Margin Trading
+
+To use KuCoin's Spot and Margin APIs, import (or require) the `SpotClient`:
+
+```javascript
+const { SpotClient, FuturesClient } = require('kucoin-api');
+
+const client = new SpotClient({
+  apiKey: 'apiKeyHere',
+  apiSecret: 'apiSecretHere',
+  apiPassphrase: 'apiPassPhraseHere',
+});
+
+try {
+  const spotBuyResult = await client.submitHFOrder({
+    clientOid: client.generateNewOrderID(),
+    side: 'buy',
+    type: 'market',
+    symbol: 'BTC-USDT',
+    size: '0.00001',
+  });
+  console.log('spotBuy ', JSON.stringify(spotBuyResult, null, 2));
+
+  const spotSellResult = await client.submitHFOrder({
+    clientOid: client.generateNewOrderID(),
+    side: 'sell',
+    type: 'market',
+    symbol: 'BTC-USDT',
+    size: '0.00001',
+  });
+  console.log('spotSellResult ', JSON.stringify(spotSellResult, null, 2));
+} catch (e) {
+  console.error(`Req error: `, e);
+}
+```
+
+See [SpotClient](./src/SpotClient.ts) for further information, or the [examples](./examples/) for lots of usage examples.
+
+### Futures Trading
+
+Use the `FuturesClient` for futures trading operations. See [FuturesClient](./src/FuturesClient.ts) for complete API coverage.
+
+### Broker Operations
+
+Use the `BrokerClient` for broker and sub-account management operations. See [BrokerClient](./src/BrokerClient.ts) for complete API coverage.
+
+### Unified API
+
+The `UnifiedAPIClient` provides access to KuCoin's Unified API endpoints, which offer streamlined market data access across Spot, Futures, and Margin trading products. It doesn't serve a purpose of a UTA account(Unified trading account) - but it is a new generation of API endpoints generalised for all trading products.
+
+## WebSockets
+
+All WebSocket functionality is supported via the unified `WebsocketClient`. This client handles both spot and futures WebSocket streams with automatic connection management and reconnection.
+
+Key WebSocket features:
+
+- Event driven messaging
+- Smart WebSocket persistence with automatic reconnection
+- Heartbeat mechanisms to detect disconnections
+- Automatic resubscription after reconnection
+- Support for both public and private WebSocket streams
+- Unified client for spot and futures markets
+
+### WebSocket Consumers
+
+All websockets are accessible via the shared `WebsocketClient`. As before, API credentials are optional unless the user data stream is required.
+
+#### Public WebSocket Streams
+
+For public market data, API credentials are not required:
+
+All available WebSockets can be used via a shared `WebsocketClient`. The WebSocket client will automatically open/track/manage connections as needed. Each unique connection (one per server URL) is tracked using a WsKey (each WsKey is a string - see [WS_KEY_MAP](src/lib/websocket/websocket-util.ts) for a list of supported values).
+
+Any subscribe/unsubscribe events will need to include a WsKey, so the WebSocket client understands which connection the event should be routed to. See examples below or in the [examples](./examples/) folder on GitHub.
+
+Data events are emitted from the WebsocketClient via the `update` event, see example below:
+
+```javascript
+const { WebsocketClient } = require('kucoin-api');
+
+const client = new WebsocketClient();
+
+client.on('open', (data) => {
+  console.log('open: ', data?.wsKey);
+});
+
+// Data received
+client.on('update', (data) => {
+  console.info('data received: ', JSON.stringify(data));
+});
+
+// Something happened, attempting to reconenct
+client.on('reconnect', (data) => {
+  console.log('reconnect: ', data);
+});
+
+// Reconnect successful
+client.on('reconnected', (data) => {
+  console.log('reconnected: ', data);
+});
+
+// Connection closed. If unexpected, expect reconnect -> reconnected.
+client.on('close', (data) => {
+  console.error('close: ', data);
+});
+
+// Reply to a request, e.g. "subscribe"/"unsubscribe"/"authenticate"
+client.on('response', (data) => {
+  console.info('response: ', data);
+  // throw new Error('res?');
+});
+
+client.on('exception', (data) => {
+  console.error('exception: ', {
+    msg: data.msg,
+    errno: data.errno,
+    code: data.code,
+    syscall: data.syscall,
+    hostname: data.hostname,
+  });
+});
+
+try {
+  // Optional: await a connection to be ready before subscribing (this is not necessary)
+  // await client.connect('futuresPublicV1');
+
+  /**
+   * Examples for public futures websocket topics (that don't require authentication).
+   *
+   * These should all subscribe via the "futuresPublicV1" wsKey. For detailed usage, refer to the ws-private-spot-v1.ts & ws-public-futures-v1.ts examples.
+   */
+  client.subscribe(
+    [
+      '/contractMarket/tickerV2:XBTUSDM',
+      '/contractMarket/ticker:XBTUSDM',
+      '/contractMarket/level2:XBTUSDM',
+      '/contractMarket/execution:XBTUSDM',
+      '/contractMarket/level2Depth5:XBTUSDM',
+      '/contractMarket/level2Depth50:XBTUSDM',
+      '/contractMarket/limitCandle:XBTUSDTM_1hour',
+      '/contract/instrument:XBTUSDM',
+      '/contract/announcement',
+      '/contractMarket/snapshot:XBTUSDM',
+    ],
+    'futuresPublicV1',
+  );
+
+  /**
+   * The V2 (Pro) WebSockets are also supported, accessible via the corresponding V2 WsKeys. Below is a demonstration for the V2 public futures topics with the WsKey "futuresPublicProV2":
+   */
+
+  client.subscribe(
+    [
+      // BTCUSDT tickers for FUTURES market
+      // https://www.kucoin.com/docs-new/3470222w0
+      {
+        topic: 'ticker',
+        payload: {
+          tradeType: 'FUTURES',
+          symbol: 'XBTUSDTM',
+        },
+      },
+      // BTCUSDT orderbook updates for FUTURES market
+      // https://www.kucoin.com/docs-new/3470221w0
+      {
+        topic: 'obu',
+        payload: {
+          tradeType: 'FUTURES',
+          symbol: 'XBTUSDTM',
+          depth: '5', // 1 / 5 / 50 / increment
+          rpiFilter: 0, // 0：Only NoneRPI orders [Default]  1(Only Support Futures)：NoneRPI+ RPI Orders. When rpiFilter=1, "depth" only supports 5/50.
+        },
+      },
+      // BTCUSDT trades for spot market
+      // https://www.kucoin.com/docs-new/3470224w0
+      {
+        topic: 'trade',
+        payload: {
+          tradeType: 'FUTURES',
+          symbol: 'XBTUSDTM',
+        },
+      },
+    ],
+    'futuresPublicProV2',
+  );
+} catch (e) {
+  console.error(`Subscribe exception: `, e);
+}
+```
+
+#### Private WebSocket Streams
+
+For private account data streams, API credentials are required. The WebsocketClient will automatically handle authentication when you provide API credentials.
+
+See [WebsocketClient](./src/WebsocketClient.ts) for further information and make sure to check the [examples/WebSockets/](./examples/WebSockets/) folder for much more detail, especially [ws-private-spot-v1.ts](./examples/WebSockets/ws-private-spot-v1.ts) and [ws-private-pro-v2.ts](./examples/WebSockets/ws-private-pro-v2.ts), which explain in a lot of detail.
+
+### WebSocket API
+
+KuCoin also support sending requests (commands) over an active WebSocket connection. This is called the WebSocket API. There are two key ways of interacting with the WebSocket API. The existing WebsocketClient allows raw event routing via the awaitable sendWSAPIRequest() method, or for a much simpler & convenient interface, use the promise-driven API. The surface feels like a REST API, but routing is automatically routed via a dedicated WebSocket connection.
+
+#### Event Driven API
+
+The WebSocket API is available in the [WebsocketClient](./src/websocket-client.ts) via the `sendWSAPIRequest(wsKey, command, commandParameters)` method.
+
+Each call to this method is wrapped in a promise, which you can async await for a response, or handle it in a raw event-driven design.
+
+#### Promise Driven API
+
+The WebSocket API is also available in a promise-wrapped REST-like format. Either, as above, await any calls to `sendWSAPIRequest(...)`, or directly use the convenient WebsocketAPIClient. This class is very similar to existing REST API classes (such as the MainClient or USDMClient).
+
+It provides one function per endpoint, feels like a REST API and will automatically route your request via an automatically persisted, authenticated and health-checked WebSocket API connection.
+
+Below is an example showing how easy it is to use the WebSocket API without any concern for the complexity of managing WebSockets. For more detailed demonstration, take a look at the [examples/WebSockets/WS-API/ws-api-client.ts](./examples/WebSockets/WS-API/ws-api-client.ts) example:
+
+```typescript
+import { DefaultLogger, WebsocketAPIClient } from 'kucoin-api';
+
+// or, if you prefer `require()`:
+// const { DefaultLogger, WebsocketAPIClient } = require('kucoin-api');
+
+const customLogger = {
+  ...DefaultLogger,
+  // For a more detailed view of the WebsocketClient, enable the `trace` level by uncommenting the below line:
+  // trace: (...params) => console.log(new Date(), 'trace', ...params),
+};
+
+const account = {
+  key: process.env.API_KEY || 'keyHere',
+  secret: process.env.API_SECRET || 'secretHere',
+  passphrase: process.env.API_PASSPHRASE || 'apiPassPhraseHere', // This is NOT your account password
+};
+
+const wsClient = new WebsocketAPIClient(
+  {
+    apiKey: account.key,
+    apiSecret: account.secret,
+    apiPassphrase: account.passphrase,
+
+    // If you want your own event handlers instead of the default ones with logs, disable this setting and see the `attachEventHandlers` example below:
+    // attachEventListeners: false
+  },
+  // customLogger, // optional: uncomment this to inject a custom logger
+);
+
+// Make WebSocket API calls, very similar to a REST API:
+
+wsClient
+  .submitNewSpotOrder({
+    side: 'buy',
+    symbol: 'BTC-USDT',
+    type: 'limit',
+    price: '150000',
+    size: '0.0001',
+  })
+  .then((syncSpotOrderResponse) => {
+    console.log('Sync spot order response:', syncSpotOrderResponse);
+  })
+  .catch((e) => {
+    console.log('Sync spot order error:', e);
+  });
+
+wsClient
+  .submitFuturesOrder({
+    clientOid: 'futures-test-' + Date.now(),
+    side: 'buy',
+    symbol: 'XBTUSDTM',
+    marginMode: 'CROSS',
+    type: 'limit',
+    price: '1000',
+    qty: '0.01',
+    leverage: 10,
+    positionSide: 'LONG', // needed if trading two-way (hedge) position mode
+  })
+  .then((futuresOrderResponse) => {
+    console.log('Futures order response:', futuresOrderResponse);
+  })
+  .catch((e) => {
+    console.log('Futures order error:', e);
+  });
+```
+
+---
+
+## KuCoin EU & Other Regions
+
+Below is an example for using this Node.js, TypeScript & JavaScript SDK for KuCoin's APIs, using an account registered on the KuCoin EU domain:
+
+```typescript
+const client = new SpotClient({
+  apiKey: API_KEY,
+  apiSecret: API_SECRET,
+  apiPassphrase: API_PASSPHRASE,
+  // apiRegion: 'global', // KuCoin.com, the default behaviour. Or 'EU' or 'AU':
+  apiRegion: 'EU', // KuCoin EU,
+  // apiRegion: 'AU', // KuCoin AU
+});
+
+try {
+  const accountSummary = await client.getAccountSummary();
+  console.log('accountSummary ', JSON.stringify(accountSummary, null, 2));
+} catch (e) {
+  console.error('Req error: ', e);
+}
+
+const wsClient = new WebsocketClient({
+  apiKey: account.key,
+  apiSecret: account.secret,
+  apiPassphrase: account.passphrase,
+  apiRegion: 'EU', // for KuCoin EU, or 'global' for KuCoin.com (default) or 'AU' for Australia
+});
+
+// ...
+```
+
+---
+
+## Customise Logging
+
+Pass a custom logger which supports the log methods `trace`, `info` and `error`, or override methods from the default logger as desired.
+
+```javascript
+const { WebsocketClient, DefaultLogger } = require('kucoin-api');
+
+// E.g. customise logging for only the trace level:
+const logger = {
+  // Inherit existing logger methods, using an object spread
+  ...DefaultLogger,
+  // Define a custom trace function to override only that function
+  trace: (...params) => {
+    if (
+      [
+        // Selectively prevent some traces from logging
+        'Sending ping',
+        'Received pong',
+      ].includes(params[0])
+    ) {
+      return;
+    }
+    console.log('trace', JSON.stringify(params, null, 2));
+  },
+};
+
+const ws = new WebsocketClient(
+  {
+    apiKey: 'apiKeyHere',
+    apiSecret: 'apiSecretHere',
+    apiPassphrase: 'apiPassPhraseHere',
+  },
+  logger,
+);
+```
+
+## Browser/Frontend Usage
+
+### Webpack
+
+Build a bundle using webpack:
+
+- `npm install`
+- `npm run build`
+- `npm run pack`
+
+The bundle can be found in `dist/`. Altough usage should be largely consistent, smaller differences will exist. Documentation is still TODO.
+
+## Use with LLMs & AI
+
+This SDK includes a bundled `llms.txt` file in the root of the repository. If you're developing with LLMs, use the included `llms.txt` with your LLM - it will significantly improve the LLMs understanding of how to correctly use this SDK.
+
+This file contains AI optimised structure of all the functions in this package, and their parameters for easier use with any learning models or artificial intelligence.
+
+---
+
+## Used By
+
+[![Repository Users Preview Image](https://dependents.info/tiagosiebler/kucoin-api/image)](https://github.com/tiagosiebler/kucoin-api/network/dependents)
+
+---
+
+<!-- template_contributions -->
+
+### Contributions & Thanks
+
+Have my projects helped you? Share the love, there are many ways you can show your thanks:
+
+- Star & share my projects.
+- Are my projects useful? Sponsor me on Github and support my effort to maintain & improve them: https://github.com/sponsors/tiagosiebler
+- Have an interesting project? Get in touch & invite me to it.
+- Or buy me all the coffee:
+  - ETH(ERC20): `0xA3Bda8BecaB4DCdA539Dc16F9C54a592553Be06C` <!-- metamask -->
+- Sign up with my referral links:
+  - OKX (receive a 20% fee discount!): https://www.okx.com/join/42013004
+  - Binance (receive a 20% fee discount!): https://accounts.binance.com/register?ref=OKFFGIJJ
+  - HyperLiquid (receive a 4% fee discount!): https://app.hyperliquid.xyz/join/SDK
+  - Gate: https://www.gate.io/signup/NODESDKS?ref_type=103
+
+<!---
+old ones:
+  - BTC: `1C6GWZL1XW3jrjpPTS863XtZiXL1aTK7Jk`
+  - BTC(SegWit): `bc1ql64wr9z3khp2gy7dqlmqw7cp6h0lcusz0zjtls`
+  - ETH(ERC20): `0xe0bbbc805e0e83341fadc210d6202f4022e50992`
+  - USDT(TRC20): `TA18VUywcNEM9ahh3TTWF3sFpt9rkLnnQa
+  - gate: https://www.gate.io/signup/AVNNU1WK?ref_type=103
+
+-->
+<!-- template_contributions_end -->
+
+### Contributions & Pull Requests
+
+Contributions are encouraged, I will review any incoming pull requests. See the issues tab for todo items.
+
+<!-- template_star_history -->
+
+## Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=tiagosiebler/bybit-api,tiagosiebler/okx-api,tiagosiebler/binance,tiagosiebler/bitget-api,tiagosiebler/bitmart-api,tiagosiebler/gateio-api,tiagosiebler/kucoin-api,tiagosiebler/coinbase-api,tiagosiebler/orderbooks,tiagosiebler/accountstate,tiagosiebler/awesome-crypto-examples&type=Date)](https://star-history.com/#tiagosiebler/bybit-api&tiagosiebler/okx-api&tiagosiebler/binance&tiagosiebler/bitget-api&tiagosiebler/bitmart-api&tiagosiebler/gateio-api&tiagosiebler/kucoin-api&tiagosiebler/coinbase-api&tiagosiebler/orderbooks&tiagosiebler/accountstate&tiagosiebler/awesome-crypto-examples&Date)
+
+<!-- template_star_history_end -->
+
+================
 File: src/WebsocketClient.ts
 ================
 import { FuturesClient } from './FuturesClient.js';
@@ -15409,7 +16076,7 @@ File: package.json
 ================
 {
   "name": "kucoin-api",
-  "version": "2.4.0",
+  "version": "2.5.1",
   "description": "Complete & robust Node.js SDK for Kucoin's REST APIs and WebSockets, with TypeScript & strong end to end tests.",
   "scripts": {
     "clean": "rm -rf dist",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kucoin-api",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kucoin-api",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kucoin-api",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Complete & robust Node.js SDK for Kucoin's REST APIs and WebSockets, with TypeScript & strong end to end tests.",
   "scripts": {
     "clean": "rm -rf dist",

--- a/src/BrokerClient.ts
+++ b/src/BrokerClient.ts
@@ -71,7 +71,7 @@ export class BrokerClient extends BaseRestClient {
    *
    * This interface supports the creation of Broker sub-account APIKEY.
    * Supports up to 20 IPs in the whitelist.
-   * Only General, Spot, and Futures permissions can be set.
+   * Permissions: General, Spot, Margin, Futures, InnerTransfer, Transfer, Earn.
    * Label must be between 4 and 32 characters.
    */
   createSubAccountApi(
@@ -97,7 +97,7 @@ export class BrokerClient extends BaseRestClient {
    *
    * This interface supports modifying the Broker's sub-account APIKEY.
    * Supports up to 20 IPs in the whitelist.
-   * Only General, Spot, and Futures permissions can be set.
+   * Permissions: General, Spot, Margin, Futures, InnerTransfer, Transfer, Earn.
    * Label must be between 4 and 32 characters.
    */
   updateSubAccountApi(

--- a/src/SpotClient.ts
+++ b/src/SpotClient.ts
@@ -398,7 +398,7 @@ export class SpotClient extends BaseRestClient {
   /**
    * Get Account - Cross Margin
    *
-   * Request via this endpoint to get the info of the cross margin account.
+   * Request cross margin account info. Preferred queryType: MARGIN. MARGIN_V2 phased out gradually.
    */
   getMarginBalance(
     params?: GetMarginBalanceRequest,
@@ -409,7 +409,7 @@ export class SpotClient extends BaseRestClient {
   /**
    * Get Account - Isolated Margin
    *
-   * Request via this endpoint to get the info of the isolated margin account.
+   * Request isolated margin account info. Preferred queryType: ISOLATED. ISOLATED_V2 phased out gradually.
    */
   getIsolatedMarginBalance(
     params?: GetIsolatedMarginBalanceRequest,
@@ -700,6 +700,7 @@ export class SpotClient extends BaseRestClient {
    * Get Transfer Quotas
    *
    * This endpoint returns the transferable balance of a specified account.
+   * Preferred type: MARGIN, ISOLATED. V2 (MARGIN_V2, ISOLATED_V2) phased out gradually.
    */
   getTransferable(
     params: GetTransferableRequest,
@@ -710,7 +711,8 @@ export class SpotClient extends BaseRestClient {
   /**
    * Flex Transfer
    *
-   * This endpoint can be used for transfers between master and sub accounts and inner transfers
+   * Transfers between master/sub accounts and inner transfers.
+   * Preferred account types: MARGIN, ISOLATED. For non-INTERNAL type, use MARGIN/ISOLATED (not MARGIN_V2/ISOLATED_V2).
    */
   submitFlexTransfer(params: FlexTransferRequest): Promise<
     APISuccessResponse<{
@@ -2546,8 +2548,9 @@ export class SpotClient extends BaseRestClient {
    */
 
   /**
-   * @deprecated This method is deprecated.
-   * It is recommended to use the getMarginBalance() endpoint instead of this endpoint
+   * @deprecated SPOT Margin LF endpoint no longer available (2026.03.04).
+   * Use getMarginBalance() instead.
+   * @see https://www.kucoin.com/announcement/kucoin-margin-notice-250702
    */
   getMarginBalances(): Promise<
     APISuccessResponse<{
@@ -2804,8 +2807,9 @@ export class SpotClient extends BaseRestClient {
    */
 
   /**
-   * @deprecated This method is deprecated.
-   * It is recommended to use the submitHFMarginOrder() endpoint instead of this endpoint
+   * @deprecated SPOT Margin LF endpoint no longer available (2026.03.04).
+   * Use submitHFMarginOrder() instead.
+   * @see https://www.kucoin.com/announcement/kucoin-margin-notice-250702
    */
   submitMarginOrder(
     params: SubmitMarginOrderRequest,
@@ -2814,8 +2818,9 @@ export class SpotClient extends BaseRestClient {
   }
 
   /**
-   * @deprecated This method is deprecated.
-   * It is recommended to use the submitHFMarginOrderTest() endpoint instead of this endpoint
+   * @deprecated SPOT Margin LF endpoint no longer available (2026.03.04).
+   * Use submitHFMarginOrderTest() instead.
+   * @see https://www.kucoin.com/announcement/kucoin-margin-notice-250702
    */
   submitMarginOrderTest(): Promise<any> {
     return this.postPrivate('api/v1/margin/order/test');
@@ -2828,8 +2833,9 @@ export class SpotClient extends BaseRestClient {
    */
 
   /**
-   * @deprecated This method is deprecated.
-   * It is recommended to use the getMarginBalance() endpoint instead of this endpoint
+   * @deprecated SPOT Margin LF endpoint no longer available (2026.03.04).
+   * Use getIsolatedMarginBalance() instead.
+   * @see https://www.kucoin.com/announcement/kucoin-margin-notice-250702
    */
   getIsolatedMarginAccounts(params?: {
     balanceCurrency?: 'USDT' | 'KCS' | 'BTC';
@@ -2838,8 +2844,9 @@ export class SpotClient extends BaseRestClient {
   }
 
   /**
-   * @deprecated This method is deprecated.
-   * It is recommended to use the getIsolatedMarginBalance() endpoint instead of this endpoint
+   * @deprecated SPOT Margin LF endpoint no longer available (2026.03.04).
+   * Use getIsolatedMarginBalance() instead.
+   * @see https://www.kucoin.com/announcement/kucoin-margin-notice-250702
    */
   getIsolatedMarginAccount(params: {
     symbol: string;

--- a/src/UnifiedAPIClient.ts
+++ b/src/UnifiedAPIClient.ts
@@ -1,6 +1,7 @@
 import { BaseRestClient } from './lib/BaseRestClient.js';
 import { REST_CLIENT_TYPE_ENUM, RestClientType } from './lib/requestUtils.js';
 import {
+  BatchCancelOrdersBySymbolRequestUTA,
   BatchCancelOrdersRequestUTA,
   BatchPlaceOrderRequestUTA,
   CancelOrderRequestUTA,
@@ -38,6 +39,7 @@ import {
 } from './types/request/uta-types.js';
 import { APISuccessResponse } from './types/response/shared.types.js';
 import {
+  BatchCancelOrdersBySymbolResponseUTA,
   BatchCancelOrdersResponseUTA,
   BatchPlaceOrderResponseUTA,
   CancelOrderResponseUTA,
@@ -493,6 +495,16 @@ export class UnifiedAPIClient extends BaseRestClient {
         ? `api/ua/v1/${accountMode}/order/cancel-batch?tradeType=${params.tradeType}`
         : `api/ua/v1/${accountMode}/order/cancel-batch`;
     return this.postPrivate(url, params);
+  }
+
+  /**
+   * Batch Cancel Orders By Symbol
+   * Cancels orders in batch by symbol. UTA only. Supports SPOT (non-margin) and Futures Cross Margin.
+   */
+  batchCancelOrdersBySymbol(
+    params: BatchCancelOrdersBySymbolRequestUTA,
+  ): Promise<APISuccessResponse<BatchCancelOrdersBySymbolResponseUTA>> {
+    return this.postPrivate('api/ua/v1/unified/order/cancel-all', params);
   }
 
   /**

--- a/src/types/request/broker.types.ts
+++ b/src/types/request/broker.types.ts
@@ -10,7 +10,14 @@ export interface GetBrokerSubAccountsRequest {
   pageSize?: number;
 }
 
-export type BrokerSubAccountPermission = 'general' | 'spot' | 'futures';
+export type BrokerSubAccountPermission =
+  | 'General'
+  | 'Spot'
+  | 'Margin'
+  | 'Futures'
+  | 'InnerTransfer'
+  | 'Transfer'
+  | 'Earn';
 
 export interface CreateBrokerSubAccountApiRequest {
   uid: string;

--- a/src/types/request/spot-funding.ts
+++ b/src/types/request/spot-funding.ts
@@ -111,6 +111,7 @@ export interface FlexTransferRequest {
     | 'TRADE_HF'
     | 'MARGIN_V2'
     | 'ISOLATED_V2'
+    | 'UNIFIED'
     | 'OPTION';
   fromAccountTag?: string;
   type: 'INTERNAL' | 'PARENT_TO_SUB' | 'SUB_TO_PARENT';
@@ -124,6 +125,7 @@ export interface FlexTransferRequest {
     | 'TRADE_HF'
     | 'MARGIN_V2'
     | 'ISOLATED_V2'
+    | 'UNIFIED'
     | 'OPTION';
   toAccountTag?: string;
 }

--- a/src/types/request/uta-types.ts
+++ b/src/types/request/uta-types.ts
@@ -335,6 +335,14 @@ export interface BatchCancelOrdersRequestUTA {
   cancelOrderList: CancelOrderItemRequestUTA[]; // Maximum 20 orders
 }
 
+/** Batch cancel orders by symbol (POST /order/cancel-all) */
+export interface BatchCancelOrdersBySymbolRequestUTA {
+  tradeType: 'SPOT' | 'FUTURES' | 'MARGIN';
+  symbol: string;
+  marginMode?: 'CROSS' | 'ISOLATED';
+  orderFilter?: 'NORMAL' | 'ADVANCED';
+}
+
 export interface SetDCPRequestUTA {
   tradeType: 'SPOT' | 'FUTURES' | 'MARGIN';
   timeout: number; // Range: timeout=-1 (unset) or 5 <= timeout <= 86400 seconds

--- a/src/types/response/broker.types.ts
+++ b/src/types/response/broker.types.ts
@@ -42,7 +42,15 @@ export interface BrokerSubAccountApi {
   label: string;
   apiKey: string;
   apiVersion: number;
-  permissions: ('General' | 'Spot' | 'Futures')[];
+  permissions: (
+    | 'General'
+    | 'Spot'
+    | 'Margin'
+    | 'Futures'
+    | 'InnerTransfer'
+    | 'Transfer'
+    | 'Earn'
+  )[];
   ipWhitelist: string[];
   createdAt: number;
 }

--- a/src/types/response/spot-account.ts
+++ b/src/types/response/spot-account.ts
@@ -57,7 +57,8 @@ export interface AccountHFMarginTransactions {
   amount: string;
   fee: string;
   balance: string;
-  accountType: 'MARGIN_V2' | 'ISOLATED_V2';
+  /** Migrating from MARGIN_V2/ISOLATED_V2 to MARGIN/ISOLATED per SPOT Margin HF migration */
+  accountType: 'MARGIN' | 'ISOLATED' | 'MARGIN_V2' | 'ISOLATED_V2';
   bizType:
     | 'TRANSFER'
     | 'MARGIN_EXCHANGE'
@@ -238,4 +239,5 @@ export interface ApiKeyInfo {
   createdAt: number; // API key creation timestamp (Unix milliseconds)
   expiredAt?: number | null; // API key expiration timestamp (Unix milliseconds). Returns null if no expiration is set
   thirdPartyApp?: string; // Third-party application name. Returns empty string if not associated with any third-party app
+  siteType?: 'global' | 'turkey' | 'australia' | 'europe' | 'thailand'; // Site Type
 }

--- a/src/types/response/uta-types.ts
+++ b/src/types/response/uta-types.ts
@@ -519,6 +519,28 @@ export interface BatchCancelOrdersResponseUTA {
   items: BatchCancelOrderItemResponseUTA[];
 }
 
+/** Batch cancel by symbol - Classic response (orderId list) */
+export interface BatchCancelOrdersBySymbolItemClassicUTA {
+  orderId: string;
+}
+
+/** Batch cancel by symbol - UTA response (full result per order) */
+export interface BatchCancelOrdersBySymbolItemUTA {
+  code?: string;
+  msg?: string;
+  orderId?: string;
+  ts?: number;
+  clientOid?: string | null;
+}
+
+export interface BatchCancelOrdersBySymbolResponseUTA {
+  tradeType: 'SPOT' | 'FUTURES' | 'MARGIN';
+  ts?: number;
+  items:
+    | BatchCancelOrdersBySymbolItemClassicUTA[]
+    | BatchCancelOrdersBySymbolItemUTA[];
+}
+
 export interface DCPResponseUTA {
   tradeType: 'SPOT' | 'FUTURES' | 'MARGIN';
   symbol: string[]; // Empty means effective for all symbols


### PR DESCRIPTION
feat: update API documentation and examples for Unified Trading Account

- Added new example for batch canceling orders by symbol in the Unified API client.
- Updated existing examples to reflect changes in endpoint paths and permissions.
- Enhanced type definitions for broker sub-account permissions and unified transfer requests.
- Incremented package version to 2.5.1 to reflect recent changes.