### PR TITLE
feat(v2.5.2): enhance Unified Trading Account API with new endpoints …

### DIFF
--- a/docs/endpointFunctionList.md
+++ b/docs/endpointFunctionList.md
@@ -365,42 +365,49 @@ This table includes all endpoints from the official Exchange API docs and corres
 
 | Function | AUTH | HTTP Method | Endpoint |
 | -------- | :------: | :------: | -------- |
-| [getAnnouncements()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L102) |  | GET | `api/ua/v1/market/announcement` |
-| [getCurrency()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L112) |  | GET | `api/ua/v1/market/currency` |
-| [getSymbols()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L122) |  | GET | `api/ua/v1/market/instrument` |
-| [getTickers()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L132) |  | GET | `api/ua/v1/market/ticker` |
-| [getTrades()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L142) |  | GET | `api/ua/v1/market/trade` |
-| [getOrderBook()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L152) |  | GET | `api/ua/v1/market/orderbook` |
-| [getKlines()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L162) |  | GET | `api/ua/v1/market/kline` |
-| [getCurrentFundingRate()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L172) |  | GET | `api/ua/v1/market/funding-rate` |
-| [getHistoryFundingRate()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L182) |  | GET | `api/ua/v1/market/funding-rate-history` |
-| [getCrossMarginConfig()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L192) |  | GET | `api/ua/v1/market/cross-config` |
-| [getServiceStatus()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L202) |  | GET | `api/ua/v1/server/status` |
-| [getClassicAccount()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L219) | :closed_lock_with_key:  | GET | `api/ua/v1/account/balance` |
-| [getAccount()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L229) | :closed_lock_with_key:  | GET | `api/ua/v1/unified/account/balance` |
-| [getAccountOverview()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L237) | :closed_lock_with_key:  | GET | `api/ua/v1/unified/account/overview` |
-| [getSubAccount()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L247) | :closed_lock_with_key:  | GET | `api/ua/v1/sub-account/balance` |
-| [getTransferQuotas()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L258) | :closed_lock_with_key:  | GET | `api/ua/v1/account/transfer-quota` |
-| [flexTransfer()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L269) | :closed_lock_with_key:  | POST | `api/ua/v1/account/transfer` |
-| [setSubAccountTransferPermission()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L279) | :closed_lock_with_key:  | POST | `api/ua/v1/sub-account/canTransferOut` |
-| [getAccountMode()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L289) | :closed_lock_with_key:  | GET | `api/ua/v1/account/mode` |
-| [setAccountMode()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L297) | :closed_lock_with_key:  | POST | `api/ua/v1/account/mode` |
-| [getFeeRate()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L309) | :closed_lock_with_key:  | GET | `api/ua/v1/user/fee-rate` |
-| [getAccountLedger()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L324) | :closed_lock_with_key:  | GET | `api/ua/v1/account/ledger` |
-| [getInterestHistory()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L338) | :closed_lock_with_key:  | GET | `api/ua/v1/account/interest-history` |
-| [modifyLeverage()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L348) | :closed_lock_with_key:  | POST | `api/ua/v1/unified/account/modify-leverage` |
-| [getDepositAddress()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L363) | :closed_lock_with_key:  | GET | `api/ua/v1/asset/deposit/address` |
-| [placeOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L383) | :closed_lock_with_key:  | GET | `api/ua/v1/{accountMode}/order/detail` |
-| [batchPlaceOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L401) | :closed_lock_with_key:  | GET | `api/ua/v1/{accountMode}/order/detail` |
-| [getOrderDetails()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L419) | :closed_lock_with_key:  | GET | `api/ua/v1/{accountMode}/order/detail` |
-| [getOpenOrderList()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L433) | :closed_lock_with_key:  | GET | `api/ua/v1/{accountMode}/order/open-list` |
-| [getOrderHistory()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L447) | :closed_lock_with_key:  | GET | `api/ua/v1/{accountMode}/order/history` |
-| [getTradeHistory()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L460) | :closed_lock_with_key:  | GET | `api/ua/v1/{accountMode}/order/execution` |
-| [cancelOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L472) | :closed_lock_with_key:  | POST | `api/ua/v1/unified/order/cancel-all` |
-| [batchCancelOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L489) | :closed_lock_with_key:  | POST | `api/ua/v1/unified/order/cancel-all` |
-| [batchCancelOrdersBySymbol()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L504) | :closed_lock_with_key:  | POST | `api/ua/v1/unified/order/cancel-all` |
-| [setDCP()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L517) | :closed_lock_with_key:  | POST | `api/ua/v1/dcp/set` |
-| [getDCP()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L528) | :closed_lock_with_key:  | GET | `api/ua/v1/dcp/query` |
-| [getPositionList()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L545) | :closed_lock_with_key:  | GET | `api/ua/v1/unified/position/open-list` |
-| [getPositionsHistory()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L558) | :closed_lock_with_key:  | GET | `api/ua/v1/position/history` |
-| [getAccountPositionTiers()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L569) | :closed_lock_with_key:  | GET | `api/ua/v1/{accountMode}/position/tiers` |
+| [getAnnouncements()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L115) |  | GET | `api/ua/v1/market/announcement` |
+| [getCurrency()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L125) |  | GET | `api/ua/v1/market/currency` |
+| [getThirdPartyCustodyCurrencies()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L135) |  | GET | `api/ua/v1/oes/currency` |
+| [getSymbols()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L145) |  | GET | `api/ua/v1/market/instrument` |
+| [getTickers()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L155) |  | GET | `api/ua/v1/market/ticker` |
+| [getTrades()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L165) |  | GET | `api/ua/v1/market/trade` |
+| [getOrderBook()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L175) |  | GET | `api/ua/v1/market/orderbook` |
+| [getKlines()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L185) |  | GET | `api/ua/v1/market/kline` |
+| [getCurrentFundingRate()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L195) |  | GET | `api/ua/v1/market/funding-rate` |
+| [getHistoryFundingRate()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L205) |  | GET | `api/ua/v1/market/funding-rate-history` |
+| [getCrossMarginConfig()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L215) |  | GET | `api/ua/v1/market/cross-config` |
+| [getBorrowableCurrencies()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L225) |  | GET | `api/ua/v1/market/borrowable-currency` |
+| [getServiceStatus()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L235) |  | GET | `api/ua/v1/server/status` |
+| [getClassicAccount()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L252) | :closed_lock_with_key:  | GET | `api/ua/v1/account/balance` |
+| [getAccount()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L262) | :closed_lock_with_key:  | GET | `api/ua/v1/unified/account/balance` |
+| [getAccountOverview()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L270) | :closed_lock_with_key:  | GET | `api/ua/v1/unified/account/overview` |
+| [getSubAccount()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L280) | :closed_lock_with_key:  | GET | `api/ua/v1/sub-account/balance` |
+| [getTransferQuotas()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L291) | :closed_lock_with_key:  | GET | `api/ua/v1/account/transfer-quota` |
+| [flexTransfer()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L302) | :closed_lock_with_key:  | POST | `api/ua/v1/account/transfer` |
+| [setSubAccountTransferPermission()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L312) | :closed_lock_with_key:  | POST | `api/ua/v1/sub-account/canTransferOut` |
+| [getAccountMode()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L322) | :closed_lock_with_key:  | GET | `api/ua/v1/account/mode` |
+| [setAccountMode()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L330) | :closed_lock_with_key:  | POST | `api/ua/v1/account/mode` |
+| [getFeeRate()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L342) | :closed_lock_with_key:  | GET | `api/ua/v1/user/fee-rate` |
+| [getAccountLedger()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L357) | :closed_lock_with_key:  | GET | `api/ua/v1/account/ledger` |
+| [getInterestHistory()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L371) | :closed_lock_with_key:  | GET | `api/ua/v1/account/interest-history` |
+| [getBorrowingRatesAndLimits()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L381) | :closed_lock_with_key:  | GET | `api/ua/v1/account/interest-limits` |
+| [modifyLeverage()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L391) | :closed_lock_with_key:  | POST | `api/ua/v1/unified/account/modify-leverage` |
+| [modifyMarginCrossLeverage()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L404) | :closed_lock_with_key:  | POST | `api/ua/v1/{accountMode}/account/modify-leverage-margin-cross` |
+| [getLeverage()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L418) | :closed_lock_with_key:  | GET | `api/ua/v1/unified/account/leverage` |
+| [getDepositAddress()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L430) | :closed_lock_with_key:  | GET | `api/ua/v1/asset/deposit/address` |
+| [getThirdPartyCustodyQuota()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L440) | :closed_lock_with_key:  | GET | `api/ua/v1/oes/custody-quota` |
+| [placeOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L460) | :closed_lock_with_key:  | GET | `api/ua/v1/{accountMode}/order/detail` |
+| [batchPlaceOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L481) | :closed_lock_with_key:  | GET | `api/ua/v1/{accountMode}/order/detail` |
+| [getOrderDetails()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L499) | :closed_lock_with_key:  | GET | `api/ua/v1/{accountMode}/order/detail` |
+| [getOpenOrderList()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L513) | :closed_lock_with_key:  | GET | `api/ua/v1/{accountMode}/order/open-list` |
+| [getOrderHistory()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L527) | :closed_lock_with_key:  | GET | `api/ua/v1/{accountMode}/order/history` |
+| [getTradeHistory()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L540) | :closed_lock_with_key:  | GET | `api/ua/v1/{accountMode}/order/execution` |
+| [cancelOrder()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L552) | :closed_lock_with_key:  | POST | `api/ua/v1/unified/order/cancel-all` |
+| [batchCancelOrders()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L569) | :closed_lock_with_key:  | POST | `api/ua/v1/unified/order/cancel-all` |
+| [batchCancelOrdersBySymbol()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L584) | :closed_lock_with_key:  | POST | `api/ua/v1/unified/order/cancel-all` |
+| [setDCP()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L597) | :closed_lock_with_key:  | POST | `api/ua/v1/dcp/set` |
+| [getDCP()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L608) | :closed_lock_with_key:  | GET | `api/ua/v1/dcp/query` |
+| [getPositionList()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L626) | :closed_lock_with_key:  | GET | `api/ua/v1/unified/position/open-list` |
+| [getPositionsHistory()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L639) | :closed_lock_with_key:  | GET | `api/ua/v1/position/history` |
+| [getPrivateFundingFeeHistory()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L649) | :closed_lock_with_key:  | GET | `api/ua/v1/position/funding-history` |
+| [getAccountPositionTiers()](https://github.com/tiagosiebler/kucoin-api/blob/master/src/UnifiedAPIClient.ts#L660) | :closed_lock_with_key:  | GET | `api/ua/v1/{accountMode}/position/tiers` |

--- a/examples/WebSockets/ws-private-pro-v2.ts
+++ b/examples/WebSockets/ws-private-pro-v2.ts
@@ -122,7 +122,7 @@ async function start() {
         {
           topic: 'orderAll',
           payload: {
-            tradeType: 'FUTURES', // SPOT / FUTURES / ISOLATED / CROSS / UNIFIED
+            tradeType: 'UNIFIED', // SPOT / FUTURES / ISOLATED / CROSS / UNIFIED
           },
         },
         // Specific order updates for a given symbol:
@@ -154,7 +154,7 @@ async function start() {
         {
           topic: 'balance',
           payload: {
-            accountType: 'TRADING', // TRADING / ISOLATED / CROSS / FUTURES / UNIFIED
+            accountType: 'SPOT', // SPOT / ISOLATED / CROSS / FUTURES / UNIFIED
           },
         },
         // Execution/trade updates:

--- a/examples/WebSockets/ws-public-futures-pro-v2.ts
+++ b/examples/WebSockets/ws-public-futures-pro-v2.ts
@@ -121,6 +121,13 @@ async function start() {
             symbol: 'XBTUSDTM',
           },
         },
+        {
+          topic: 'ticker',
+          payload: {
+            tradeType: 'FUTURES',
+            symbols: ['ETHUSDTM', 'XRPUSDTM'],
+          },
+        },
         // BTCUSDT orderbook updates for FUTURES market
         // https://www.kucoin.com/docs-new/3470221w0
         {

--- a/examples/WebSockets/ws-public-spot-pro-v2.ts
+++ b/examples/WebSockets/ws-public-spot-pro-v2.ts
@@ -120,6 +120,14 @@ async function start() {
             symbol: 'BTC-USDT',
           },
         },
+        // Multi-symbol ticker: use `symbols` instead of `symbol`
+        {
+          topic: 'ticker',
+          payload: {
+            tradeType: 'SPOT',
+            symbols: ['ETH-USDT', 'XRP-USDT'],
+          },
+        },
         // BTCUSDT orderbook updates for spot market
         // https://www.kucoin.com/docs-new/3470221w0
         {

--- a/examples/apidoc/UnifiedAPIClient/getBorrowableCurrencies.js
+++ b/examples/apidoc/UnifiedAPIClient/getBorrowableCurrencies.js
@@ -1,0 +1,21 @@
+const { UnifiedAPIClient } = require('kucoin-api');
+
+  // This example shows how to call this kucoin API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "kucoin-api" for kucoin exchange
+  // This kucoin API SDK is available on npm via "npm install kucoin-api"
+  // ENDPOINT: api/ua/v1/market/borrowable-currency
+  // METHOD: GET
+  // PUBLIC: YES
+
+const client = new UnifiedAPIClient({
+  apiKey: 'apiKeyHere',
+  apiSecret: 'apiSecretHere',
+  apiPassphrase: 'apiPassPhraseHere',
+});
+
+client.getBorrowableCurrencies(params)
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/UnifiedAPIClient/getBorrowingRatesAndLimits.js
+++ b/examples/apidoc/UnifiedAPIClient/getBorrowingRatesAndLimits.js
@@ -1,0 +1,21 @@
+const { UnifiedAPIClient } = require('kucoin-api');
+
+  // This example shows how to call this kucoin API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "kucoin-api" for kucoin exchange
+  // This kucoin API SDK is available on npm via "npm install kucoin-api"
+  // ENDPOINT: api/ua/v1/account/interest-limits
+  // METHOD: GET
+  // PUBLIC: NO
+
+const client = new UnifiedAPIClient({
+  apiKey: 'apiKeyHere',
+  apiSecret: 'apiSecretHere',
+  apiPassphrase: 'apiPassPhraseHere',
+});
+
+client.getBorrowingRatesAndLimits(params)
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/UnifiedAPIClient/getLeverage.js
+++ b/examples/apidoc/UnifiedAPIClient/getLeverage.js
@@ -1,0 +1,21 @@
+const { UnifiedAPIClient } = require('kucoin-api');
+
+  // This example shows how to call this kucoin API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "kucoin-api" for kucoin exchange
+  // This kucoin API SDK is available on npm via "npm install kucoin-api"
+  // ENDPOINT: api/ua/v1/unified/account/leverage
+  // METHOD: GET
+  // PUBLIC: NO
+
+const client = new UnifiedAPIClient({
+  apiKey: 'apiKeyHere',
+  apiSecret: 'apiSecretHere',
+  apiPassphrase: 'apiPassPhraseHere',
+});
+
+client.getLeverage(params)
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/UnifiedAPIClient/getPrivateFundingFeeHistory.js
+++ b/examples/apidoc/UnifiedAPIClient/getPrivateFundingFeeHistory.js
@@ -1,0 +1,21 @@
+const { UnifiedAPIClient } = require('kucoin-api');
+
+  // This example shows how to call this kucoin API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "kucoin-api" for kucoin exchange
+  // This kucoin API SDK is available on npm via "npm install kucoin-api"
+  // ENDPOINT: api/ua/v1/position/funding-history
+  // METHOD: GET
+  // PUBLIC: NO
+
+const client = new UnifiedAPIClient({
+  apiKey: 'apiKeyHere',
+  apiSecret: 'apiSecretHere',
+  apiPassphrase: 'apiPassPhraseHere',
+});
+
+client.getPrivateFundingFeeHistory(params)
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/UnifiedAPIClient/getThirdPartyCustodyCurrencies.js
+++ b/examples/apidoc/UnifiedAPIClient/getThirdPartyCustodyCurrencies.js
@@ -1,0 +1,21 @@
+const { UnifiedAPIClient } = require('kucoin-api');
+
+  // This example shows how to call this kucoin API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "kucoin-api" for kucoin exchange
+  // This kucoin API SDK is available on npm via "npm install kucoin-api"
+  // ENDPOINT: api/ua/v1/oes/currency
+  // METHOD: GET
+  // PUBLIC: YES
+
+const client = new UnifiedAPIClient({
+  apiKey: 'apiKeyHere',
+  apiSecret: 'apiSecretHere',
+  apiPassphrase: 'apiPassPhraseHere',
+});
+
+client.getThirdPartyCustodyCurrencies(params)
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/UnifiedAPIClient/getThirdPartyCustodyQuota.js
+++ b/examples/apidoc/UnifiedAPIClient/getThirdPartyCustodyQuota.js
@@ -1,0 +1,21 @@
+const { UnifiedAPIClient } = require('kucoin-api');
+
+  // This example shows how to call this kucoin API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "kucoin-api" for kucoin exchange
+  // This kucoin API SDK is available on npm via "npm install kucoin-api"
+  // ENDPOINT: api/ua/v1/oes/custody-quota
+  // METHOD: GET
+  // PUBLIC: NO
+
+const client = new UnifiedAPIClient({
+  apiKey: 'apiKeyHere',
+  apiSecret: 'apiSecretHere',
+  apiPassphrase: 'apiPassPhraseHere',
+});
+
+client.getThirdPartyCustodyQuota(params)
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/UnifiedAPIClient/modifyMarginCrossLeverage.js
+++ b/examples/apidoc/UnifiedAPIClient/modifyMarginCrossLeverage.js
@@ -1,0 +1,21 @@
+const { UnifiedAPIClient } = require('kucoin-api');
+
+  // This example shows how to call this kucoin API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "kucoin-api" for kucoin exchange
+  // This kucoin API SDK is available on npm via "npm install kucoin-api"
+  // ENDPOINT: api/ua/v1/{accountMode}/account/modify-leverage-margin-cross
+  // METHOD: POST
+  // PUBLIC: NO
+
+const client = new UnifiedAPIClient({
+  apiKey: 'apiKeyHere',
+  apiSecret: 'apiSecretHere',
+  apiPassphrase: 'apiPassPhraseHere',
+});
+
+client.modifyMarginCrossLeverage(params)
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/kucoin-UNIFIED-examples-nodejs.md
+++ b/examples/kucoin-UNIFIED-examples-nodejs.md
@@ -173,6 +173,10 @@ unifiedClient.getHistoryFundingRate({
 
 // Get Cross Margin Config (Spot cross margin)
 unifiedClient.getCrossMarginConfig();
+
+// Borrowable currencies + borrowing rates/limits (UTA)
+unifiedClient.getBorrowableCurrencies();
+unifiedClient.getBorrowingRatesAndLimits({ currency: 'USDT' });
 ```
 
 ### Account
@@ -180,7 +184,7 @@ unifiedClient.getCrossMarginConfig();
 #### Unified and Classic account balance
 
 ```js
-// Get Unified Account (UTA) balance
+// Get Unified Account (UTA) balance — currency rows may include potentialBorrow (2026.04.19)
 unifiedClient.getAccount();
 
 // Get Unified Account overview
@@ -188,7 +192,10 @@ unifiedClient.getAccountOverview();
 
 // Get Classic Account balance (FUNDING, SPOT, FUTURES, CROSS, ISOLATED)
 unifiedClient.getClassicAccount({ accountType: 'SPOT' });
-unifiedClient.getClassicAccount({ accountType: 'FUTURES', currency: 'USDT,XBT' });
+unifiedClient.getClassicAccount({
+  accountType: 'FUTURES',
+  currency: 'USDT,XBT',
+});
 unifiedClient.getClassicAccount({
   accountType: 'ISOLATED',
   accountSubtype: 'BTC-USDT',
@@ -277,6 +284,22 @@ unifiedClient.getInterestHistory({
 // Modify Leverage (Unified Futures)
 unifiedClient.modifyLeverage({ symbol: 'XBTUSDTM', leverage: '5' });
 
+// Cross margin leverage + query leverage (2026.04.19)
+unifiedClient.modifyMarginCrossLeverage(
+  { currency: 'BTC', leverage: '5' },
+  'unified',
+);
+unifiedClient.getLeverage({
+  tradeType: 'FUTURES',
+  marginMode: 'CROSS',
+  symbol: 'XBTUSDTM',
+});
+unifiedClient.getLeverage({
+  tradeType: 'MARGIN',
+  marginMode: 'CROSS',
+  currency: 'BTC',
+});
+
 // Get Deposit Address
 unifiedClient.getDepositAddress({ currency: 'BTC' });
 unifiedClient.getDepositAddress({ currency: 'BTC', chain: 'BTC' });
@@ -286,12 +309,12 @@ unifiedClient.getDepositAddress({ currency: 'BTC', chain: 'BTC' });
 
 #### Place order (Unified vs Classic)
 
-Unified mode: use `accountMode: 'unified'` (default). For unified, `tradeType` is not sent in the request (the client omits it).  
-Classic mode: use `accountMode: 'classic'` and pass `tradeType` in the request (Spot/Futures/Isolated/Cross).
+Unified mode: use `accountMode: 'unified'` (default). For unified, `tradeType` is sent in the JSON body 
+Classic mode: use `accountMode: 'classic'` and pass `tradeType` as a query parameter (Spot/Futures/Isolated/Cross/Margin per API).
 
 ```js
 // Unified mode - Spot limit order (default accountMode is 'unified')
-// tradeType can be omitted in request for unified; if provided it is not sent
+// tradeType is included in the body for unified (e.g. SPOT, MARGIN, FUTURES)
 unifiedClient.placeOrder(
   {
     tradeType: 'SPOT',
@@ -492,6 +515,8 @@ Unified position endpoints apply to the Unified account (Futures positions).
 // Get Position List (all open positions or filter by symbol)
 unifiedClient.getPositionList();
 unifiedClient.getPositionList({ symbol: 'XBTUSDTM' });
+// pageNumber, pageSize and liquidationPrice per row (as of 2026.04.09)
+unifiedClient.getPositionList({ pageNumber: 1, pageSize: 50 });
 
 // Get Positions History (up to 3 months, max 7 days per query)
 unifiedClient.getPositionsHistory({
@@ -501,11 +526,25 @@ unifiedClient.getPositionsHistory({
   pageSize: 50,
 });
 
+// Private funding fee history (2026.04.19)
+unifiedClient.getPrivateFundingFeeHistory({ symbol: 'XBTUSDTM' });
+
 // Get Account Position Tiers (risk limit) - Classic Futures isolated
 unifiedClient.getAccountPositionTiers(
   { symbol: 'XBTUSDTM', tradeType: 'FUTURES', marginMode: 'ISOLATED' },
   'classic',
 );
+```
+
+```js
+// Third-party custody (OES): currencies (public) and account custody limits (private)
+unifiedClient.getThirdPartyCustodyCurrencies();
+unifiedClient.getThirdPartyCustodyCurrencies({
+  custodian: 'BITGO_SG',
+  currency: 'BTC',
+});
+unifiedClient.getThirdPartyCustodyQuota();
+unifiedClient.getThirdPartyCustodyQuota({ custodian: 'CEFFU' });
 ```
 
 ## Websocket
@@ -514,7 +553,7 @@ For WebSocket examples that work with the unified (PRO) API, please refer to:
 
 - [Spot Public Websocket](https://github.com/tiagosiebler/kucoin-api/blob/master/examples/WebSockets/ws-public-spot-pro-v2.ts) (PRO v2)
 - [Futures Public Websocket](https://github.com/tiagosiebler/kucoin-api/blob/master/examples/WebSockets/ws-public-futures-pro-v2.ts) (PRO v2)
-- [Private WebSocket (PRO v2)](https://github.com/tiagosiebler/kucoin-api/blob/master/examples/WebSockets/ws-private-pro-v2.ts)
+- [Private WebSocket (PRO v2)](https://github.com/tiagosiebler/kucoin-api/blob/master/examples/WebSockets/ws-private-pro-v2.ts) — includes `execution.lite`, `accountType: "SPOT"` for spot balance, and comments for Pro API changes (e.g. 2026.03.30: `eT` `match`, BBO/trade high-speed channels on public Pro).
 
 ## Community group
 

--- a/llms.txt
+++ b/llms.txt
@@ -136,6 +136,7 @@ LICENSE.md
 package.json
 postBuild.sh
 README.md
+RELEASE_NOTES.md
 tsconfig.cjs.json
 tsconfig.esm.json
 tsconfig.json
@@ -312,78 +313,6 @@ export async function signMessage(
 ): Promise<string>
 ⋮----
 export function checkWebCryptoAPISupported()
-
-================
-File: src/types/request/broker.types.ts
-================
-export interface GetBrokerInfoRequest {
-  begin: string;
-  end: string;
-  tradeType: '1' | '2';
-}
-⋮----
-export interface GetBrokerSubAccountsRequest {
-  uid: string;
-  currentPage?: number;
-  pageSize?: number;
-}
-⋮----
-export type BrokerSubAccountPermission =
-  | 'General'
-  | 'Spot'
-  | 'Margin'
-  | 'Futures'
-  | 'InnerTransfer'
-  | 'Transfer'
-  | 'Earn';
-⋮----
-export interface CreateBrokerSubAccountApiRequest {
-  uid: string;
-  passphrase: string;
-  ipWhitelist: string[];
-  permissions: BrokerSubAccountPermission[];
-  label: string;
-}
-⋮----
-export interface GetBrokerSubAccountApisRequest {
-  uid: string;
-  apiKey?: string;
-}
-⋮----
-export interface UpdateBrokerSubAccountApiRequest {
-  uid: string;
-  apiKey: string;
-  ipWhitelist: string[];
-  permissions: BrokerSubAccountPermission[];
-  label: string;
-}
-⋮----
-export interface DeleteBrokerSubAccountApiRequest {
-  uid: string;
-  apiKey: string;
-}
-⋮----
-export type BrokerTransferDirection = 'OUT' | 'IN';
-export type BrokerAccountType = 'MAIN' | 'TRADE';
-⋮----
-export interface BrokerTransferRequest {
-  currency: string;
-  amount: string;
-  clientOid: string;
-  direction: BrokerTransferDirection;
-  accountType: BrokerAccountType;
-  specialUid: string;
-  specialAccountType: BrokerAccountType;
-}
-⋮----
-export interface GetBrokerDepositListRequest {
-  currency?: string;
-  status?: 'PROCESSING' | 'SUCCESS' | 'FAILURE';
-  hash?: string;
-  startTimestamp?: number;
-  endTimestamp?: number;
-  limit?: number;
-}
 
 ================
 File: src/types/request/spot-account.ts
@@ -658,191 +587,6 @@ orderId?: string; // optional - Order Id
 investCurrency?: string; // optional - Investment Currency
 currentPage?: number; // optional - Current Page, default: 1
 pageSize?: number; // optional - Page Size >= 10, <= 500, default: 15
-
-================
-File: src/types/request/spot-funding.ts
-================
-/**
- *
- ***********
- * Funding
- ***********
- *
- */
-⋮----
-export interface CreateDepositAddressV3Request {
-  currency: string;
-  chain?: string;
-  to?: 'main' | 'trade';
-  amount?: string;
-}
-⋮----
-export interface GetMarginBalanceRequest {
-  quoteCurrency?: string;
-  queryType?: 'MARGIN' | 'MARGIN_V2' | 'ALL';
-}
-⋮----
-export interface GetIsolatedMarginBalanceRequest {
-  symbol?: string;
-  quoteCurrency?: string;
-  queryType?: 'ISOLATED' | 'ISOLATED_V2' | 'ALL';
-}
-⋮----
-/**
- *
- * Deposit
- *
- */
-⋮----
-export interface GetDepositsRequest {
-  currency?: string;
-  startAt?: number;
-  endAt?: number;
-  status?: 'PROCESSING' | 'SUCCESS' | 'FAILURE';
-  currentPage?: number;
-  pageSize?: number;
-}
-⋮----
-/**
- *
- * Withdrawals
- *
- */
-⋮----
-export interface GetWithdrawalsRequest {
-  currency?: string;
-  status?: 'PROCESSING' | 'WALLET_PROCESSING' | 'SUCCESS' | 'FAILURE';
-  startAt?: number;
-  endAt?: number;
-  currentPage?: number;
-  pageSize?: number;
-}
-⋮----
-export interface ApplyWithdrawRequest {
-  currency: string;
-  address: string;
-  amount: number;
-  memo?: string;
-  isInner?: boolean;
-  remark?: string;
-  chain?: string;
-  feeDeductType?: 'INTERNAL' | 'EXTERNAL';
-}
-⋮----
-export interface SubmitWithdrawV3Request {
-  currency: string;
-  toAddress: string;
-  amount: number;
-  memo?: string;
-  isInner?: boolean;
-  remark?: string;
-  chain?: string;
-  feeDeductType?: 'INTERNAL' | 'EXTERNAL';
-  withdrawType: 'ADDRESS' | 'UID' | 'MAIL' | 'PHONE';
-}
-⋮----
-/**
- *
- * Transfer
- *
- */
-⋮----
-export interface GetTransferableRequest {
-  currency: string;
-  type:
-    | 'MAIN'
-    | 'TRADE'
-    | 'TRADE_HF'
-    | 'MARGIN'
-    | 'ISOLATED'
-    | 'OPTION'
-    | 'MARGIN_V2'
-    | 'ISOLATED_V2';
-  tag?: string;
-}
-⋮----
-export interface FlexTransferRequest {
-  clientOid: string;
-  currency?: string;
-  amount: string;
-  fromUserId?: string;
-  fromAccountType:
-    | 'MAIN'
-    | 'TRADE'
-    | 'CONTRACT'
-    | 'MARGIN'
-    | 'ISOLATED'
-    | 'TRADE_HF'
-    | 'MARGIN_V2'
-    | 'ISOLATED_V2'
-    | 'UNIFIED'
-    | 'OPTION';
-  fromAccountTag?: string;
-  type: 'INTERNAL' | 'PARENT_TO_SUB' | 'SUB_TO_PARENT';
-  toUserId?: string;
-  toAccountType:
-    | 'MAIN'
-    | 'TRADE'
-    | 'CONTRACT'
-    | 'MARGIN'
-    | 'ISOLATED'
-    | 'TRADE_HF'
-    | 'MARGIN_V2'
-    | 'ISOLATED_V2'
-    | 'UNIFIED'
-    | 'OPTION';
-  toAccountTag?: string;
-}
-⋮----
-export interface submitTransferMasterSubRequest {
-  clientOid: string;
-  currency: string;
-  amount: string;
-  direction: 'OUT' | 'IN';
-  accountType?:
-    | 'MAIN'
-    | 'TRADE'
-    | 'TRADE_HF'
-    | 'MARGIN'
-    | 'CONTRACT'
-    | 'OPTION';
-  subAccountType?:
-    | 'MAIN'
-    | 'TRADE'
-    | 'TRADE_HF'
-    | 'MARGIN'
-    | 'CONTRACT'
-    | 'OPTION';
-  subUserId: string;
-}
-⋮----
-export interface InnerTransferRequest {
-  clientOid: string;
-  currency: string;
-  from:
-    | 'main'
-    | 'trade'
-    | 'trade_hf'
-    | 'margin'
-    | 'isolated'
-    | 'margin_v2'
-    | 'isolated_v2'
-    | 'contract'
-    | 'option';
-  to:
-    | 'main'
-    | 'trade'
-    | 'trade_hf'
-    | 'margin'
-    | 'isolated'
-    | 'margin_v2'
-    | 'isolated_v2'
-    | 'contract'
-    | 'option';
-  amount: string;
-  fromTag?: string;
-  toTag?: string;
-}
 
 ================
 File: src/types/request/spot-misc.ts
@@ -1145,130 +889,6 @@ export interface GetOCOOrdersRequest {
   startAt?: number;
   endAt?: number;
   orderIds?: string;
-}
-
-================
-File: src/types/response/broker.types.ts
-================
-export interface BrokerInfo {
-  accountSize: number;
-  maxAccountSize: number | null;
-  level: number;
-}
-⋮----
-export interface CreateBrokerSubAccountResponse {
-  accountName: string;
-  uid: string;
-  createdAt: number;
-  level: number;
-}
-⋮----
-export interface BrokerSubAccount {
-  accountName: string;
-  uid: string;
-  createdAt: number;
-  level: number;
-}
-⋮----
-export interface GetBrokerSubAccountsResponse {
-  currentPage: number;
-  pageSize: number;
-  totalNum: number;
-  totalPage: number;
-  items: BrokerSubAccount[];
-}
-⋮----
-export interface CreateBrokerSubAccountApiResponse {
-  uid: string;
-  label: string;
-  apiKey: string;
-  secretKey: string;
-  apiVersion: number;
-  permissions: string[];
-  ipWhitelist: string[];
-  createdAt: number;
-}
-⋮----
-export interface BrokerSubAccountApi {
-  uid: string;
-  label: string;
-  apiKey: string;
-  apiVersion: number;
-  permissions: (
-    | 'General'
-    | 'Spot'
-    | 'Margin'
-    | 'Futures'
-    | 'InnerTransfer'
-    | 'Transfer'
-    | 'Earn'
-  )[];
-  ipWhitelist: string[];
-  createdAt: number;
-}
-⋮----
-export type BrokerTransferAccountType =
-  | 'MAIN'
-  | 'TRADE'
-  | 'CONTRACT'
-  | 'MARGIN'
-  | 'ISOLATED';
-export type BrokerTransferStatus = 'PROCESSING' | 'SUCCESS' | 'FAILURE';
-⋮----
-export interface BrokerTransferHistory {
-  orderId: string;
-  currency: string;
-  amount: string;
-  fromUid: number;
-  fromAccountType: BrokerTransferAccountType;
-  fromAccountTag: string;
-  toUid: number;
-  toAccountType: BrokerTransferAccountType;
-  toAccountTag: string;
-  status: BrokerTransferStatus;
-  reason: string | null;
-  createdAt: number;
-}
-⋮----
-export interface BrokerDepositRecord {
-  uid: number;
-  hash: string;
-  address: string;
-  memo: string;
-  amount: string;
-  fee: string;
-  currency: string;
-  isInner: boolean;
-  walletTxId: string;
-  status: BrokerTransferStatus;
-  remark: string;
-  chain: string;
-  createdAt: number;
-  updatedAt: number;
-}
-⋮----
-export type BrokerWithdrawalStatus =
-  | 'PROCESSING'
-  | 'WALLET_PROCESSING'
-  | 'REVIEW'
-  | 'SUCCESS'
-  | 'FAILURE';
-⋮----
-export interface BrokerWithdrawalRecord {
-  id: string;
-  chain: string;
-  walletTxId: string;
-  uid: number;
-  amount: string;
-  memo: string;
-  fee: string;
-  address: string;
-  remark: string;
-  isInner: boolean;
-  currency: string;
-  status: BrokerWithdrawalStatus;
-  createdAt: number;
-  updatedAt: number;
 }
 
 ================
@@ -2505,224 +2125,6 @@ export interface OtcLoanAccount {
 }
 
 ================
-File: src/BrokerClient.ts
-================
-import { BaseRestClient } from './lib/BaseRestClient.js';
-import { REST_CLIENT_TYPE_ENUM, RestClientType } from './lib/requestUtils.js';
-import {
-  BrokerTransferRequest,
-  CreateBrokerSubAccountApiRequest,
-  DeleteBrokerSubAccountApiRequest,
-  GetBrokerDepositListRequest,
-  GetBrokerInfoRequest,
-  GetBrokerSubAccountApisRequest,
-  GetBrokerSubAccountsRequest,
-  UpdateBrokerSubAccountApiRequest,
-} from './types/request/broker.types.js';
-import {
-  BrokerDepositRecord,
-  BrokerInfo,
-  BrokerSubAccountApi,
-  BrokerTransferHistory,
-  BrokerWithdrawalRecord,
-  CreateBrokerSubAccountApiResponse,
-  CreateBrokerSubAccountResponse,
-  GetBrokerSubAccountsResponse,
-} from './types/response/broker.types.js';
-import { APISuccessResponse } from './types/response/shared.types.js';
-⋮----
-/**
- *
- */
-export class BrokerClient extends BaseRestClient
-⋮----
-getClientType(): RestClientType
-⋮----
-/**
-   * Get Broker Info
-   *
-   * This endpoint supports querying the basic information of the current Broker
-   */
-getBrokerInfo(
-    params: GetBrokerInfoRequest,
-): Promise<APISuccessResponse<BrokerInfo>>
-⋮----
-/**
-   * Add SubAccount
-   *
-   * This endpoint supports Broker users to create sub-accounts.
-   * Note that the account name is unique across the exchange.
-   * It is recommended to add a special identifier to prevent name duplication.
-   */
-createSubAccount(params: {
-    accountName: string;
-}): Promise<APISuccessResponse<CreateBrokerSubAccountResponse>>
-⋮----
-/**
-   * Get SubAccount
-   *
-   * This interface supports querying sub-accounts created by Broker.
-   * Returns paginated results with default page size of 20 (max 100).
-   */
-getSubAccounts(
-    params: GetBrokerSubAccountsRequest,
-): Promise<APISuccessResponse<GetBrokerSubAccountsResponse>>
-⋮----
-/**
-   * Add SubAccount API
-   *
-   * This interface supports the creation of Broker sub-account APIKEY.
-   * Supports up to 20 IPs in the whitelist.
-   * Permissions: General, Spot, Margin, Futures, InnerTransfer, Transfer, Earn.
-   * Label must be between 4 and 32 characters.
-   */
-createSubAccountApi(
-    params: CreateBrokerSubAccountApiRequest,
-): Promise<APISuccessResponse<CreateBrokerSubAccountApiResponse>>
-⋮----
-/**
-   * Get SubAccount API
-   *
-   * This interface supports querying the Broker's sub-account APIKEYs.
-   * Can optionally filter by specific apiKey.
-   */
-getSubAccountApis(
-    params: GetBrokerSubAccountApisRequest,
-): Promise<APISuccessResponse<BrokerSubAccountApi[]>>
-⋮----
-/**
-   * Modify SubAccount API
-   *
-   * This interface supports modifying the Broker's sub-account APIKEY.
-   * Supports up to 20 IPs in the whitelist.
-   * Permissions: General, Spot, Margin, Futures, InnerTransfer, Transfer, Earn.
-   * Label must be between 4 and 32 characters.
-   */
-updateSubAccountApi(
-    params: UpdateBrokerSubAccountApiRequest,
-): Promise<APISuccessResponse<BrokerSubAccountApi>>
-⋮----
-/**
-   * Delete SubAccount API
-   *
-   * This interface supports deleting Broker's sub-account APIKEY.
-   */
-deleteSubAccountApi(
-    params: DeleteBrokerSubAccountApiRequest,
-): Promise<APISuccessResponse<boolean>>
-⋮----
-/**
-   * Transfer
-   *
-   * This endpoint supports fund transfer between Broker account and Broker sub-accounts.
-   * Please be aware that withdrawal from sub-account is not directly supported.
-   * Broker has to transfer funds from broker sub-account to broker account to initiate the withdrawals.
-   *
-   * Direction:
-   * - OUT: Broker account is transferred to Broker sub-account
-   * - IN: Broker sub-account is transferred to Broker account
-   *
-   * Account Types:
-   * - MAIN: Funding account
-   * - TRADE: Spot trading account
-   */
-submitTransfer(params: BrokerTransferRequest): Promise<
-    APISuccessResponse<{
-      orderId: string;
-    }>
-  > {
-    return this.postPrivate('api/v1/broker/nd/transfer', params);
-⋮----
-/**
-   * Get Transfer History
-   *
-   * This endpoint supports querying transfer records of the broker itself and its created sub-accounts.
-   *
-   * Account Types:
-   * - MAIN: Funding account
-   * - TRADE: Spot trading account
-   * - CONTRACT: Contract account
-   * - MARGIN: Margin account
-   * - ISOLATED: Isolated margin account
-   *
-   * Status:
-   * - PROCESSING: Processing
-   * - SUCCESS: Successful
-   * - FAILURE: Failed
-   */
-getTransferHistory(params: {
-    orderId: string;
-}): Promise<APISuccessResponse<BrokerTransferHistory>>
-⋮----
-/**
-   * Get Deposit List
-   *
-   * This endpoint can obtain the deposit records of each sub-account under the ND Broker.
-   * Default limit is 1000 records (max 1000).
-   * Results are sorted in descending order by default.
-   *
-   * Status:
-   * - PROCESSING: Processing
-   * - SUCCESS: Successful
-   * - FAILURE: Failed
-   */
-getDeposits(
-    params?: GetBrokerDepositListRequest,
-): Promise<APISuccessResponse<BrokerDepositRecord[]>>
-⋮----
-/**
-   * Get Deposit Detail
-   *
-   * This endpoint supports querying the deposit record of sub-accounts created by a Broker
-   * (excluding main account of nd broker).
-   *
-   * Status:
-   * - PROCESSING: Processing
-   * - SUCCESS: Successful
-   * - FAILURE: Failed
-   */
-getDeposit(params: {
-    currency: string;
-    hash: string;
-}): Promise<APISuccessResponse<BrokerDepositRecord>>
-⋮----
-/**
-   * Get Withdrawal Detail
-   *
-   * This endpoint supports querying the withdrawal records of sub-accounts created by a Broker
-   * (excluding main account of nd broker).
-   *
-   * Status:
-   * - PROCESSING: Processing
-   * - WALLET_PROCESSING: Wallet Processing
-   * - REVIEW: Under Review
-   * - SUCCESS: Successful
-   * - FAILURE: Failed
-   */
-getWithdrawal(params: {
-    withdrawalId: string;
-}): Promise<APISuccessResponse<BrokerWithdrawalRecord>>
-⋮----
-/**
-   * Get Broker Rebate
-   *
-   * This interface supports downloading Broker rebate orders.
-   * Returns a URL to download a CSV file containing the rebate data.
-   * The URL is valid for 1 day.
-   * Maximum interval between begin and end dates is 6 months.
-   */
-getBrokerRebate(params: {
-    begin: string;
-    end: string;
-    tradeType: '1' | '2';
-  }): Promise<
-    APISuccessResponse<{
-      url: string;
-    }>
-  > {
-    return this.getPrivate('api/v1/broker/nd/rebase/download', params);
-
-================
 File: .nvmrc
 ================
 v22.18.0
@@ -2946,6 +2348,74 @@ cat >dist/mjs/package.json <<!EOF
 
 find src -name '*.d.ts' -exec cp {} dist/mjs \;
 find src -name '*.d.ts' -exec cp {} dist/cjs \;
+
+================
+File: RELEASE_NOTES.md
+================
+# Release notes (PR summary)
+
+SDK updates aligned with KuCoin Pro / UTA API and WebSocket documentation. **Regenerate** `docs/endpointFunctionList.md` and `examples/apidoc/` if your workflow auto-generates them from `UnifiedAPIClient`.
+
+---
+
+## WebSocket examples & docs (2026.03.30)
+
+- **`examples/WebSockets/ws-private-pro-v2.ts`**
+  - Documented **Order** channel: `eT` may include `match`; notes on `O` (Risk Engine vs Match Engine for UTA Spot).
+  - **Balance** subscription: prefer `accountType: 'SPOT'` (replaces documented `TRADING`; still accepted upstream).
+  - Added **`execution.lite`** subscription (lighter payload; no `f` / `fC`).
+- **`examples/WebSockets/ws-public-spot-pro-v2.ts`** & **`ws-public-futures-pro-v2.ts`**
+  - Comments: **BBO (`obu`)** and **`trade`** use high-speed push path (lower latency).
+  - Futures **trade** comment fixed (FUTURES vs spot wording).
+- **`examples/WebSockets/README.md`**: short summary of Pro private/public changes.
+- **`examples/kucoin-UNIFIED-examples-nodejs.md`**: private Pro v2 bullet updated (incl. execution.lite, balance, 2026.03.30 notes).
+
+---
+
+## REST: positions, OES custody, endpoint list (2026.04.09)
+
+- **Types & client**
+  - `GetPositionListRequestUTA`: **`pageNumber`**, **`pageSize`**.
+  - `PositionUTA`: **`liquidationPrice`**.
+  - `getThirdPartyCustodyCurrencies` → `GET /api/ua/v1/oes/currency` (public).
+  - `getThirdPartyCustodyQuota` → `GET /api/ua/v1/oes/custody-quota` (private).
+  - New types: `ThirdPartyCustodyCustodianUTA`, `GetThirdPartyCustody*RequestUTA`, `ThirdPartyCustodyCurrencyUTA`, `ThirdPartyCustodyQuotaUTA`.
+- **`docs/endpointFunctionList.md`**: was updated in that PR pass to include new methods and line refs (re-run your generator if you use one).
+
+---
+
+## REST: UTA & market expansion (2026.04.19)
+
+- **`tradeType`**: **`MARGIN`** added everywhere it applies for UTA order flows  
+  (place, batch place, get order details / open / history / trade history, cancel, batch cancel) — request + response `tradeType` unions and `OrderDetailsUTA` list wrappers.
+- **`placeOrder` (`unified`)**: sends **`tradeType` in the JSON body** (required for MARGIN and explicit product; classic unchanged — query `tradeType` only).
+- **New `UnifiedAPIClient` methods**
+  - `getBorrowableCurrencies` — `GET /api/ua/v1/market/borrowable-currency` (public).
+  - `getBorrowingRatesAndLimits` — `GET /api/ua/v1/account/interest-limits`.
+  - `modifyMarginCrossLeverage` — `POST /api/ua/v1/{accountMode}/account/modify-leverage-margin-cross`.
+  - `getLeverage` — `GET /api/ua/v1/unified/account/leverage`.
+  - `getPrivateFundingFeeHistory` — `GET /api/ua/v1/position/funding-history`.
+- **Response / account**
+  - `GetCurrentFundingRateResponseUTA`: **`currentGranularity`**, **`newGranularity`**, **`newGranularityStartTime`**.
+  - `AccountCurrencyUTA`: optional **`potentialBorrow`** (UTA balance).
+- **WebSocket examples (2026.04.19)**
+  - Private: `order` / `orderAll` **`tradeType: UNIFIED`** note; `leverage` note (`c`, `tT`, `mM`); balance example `SPOT`.
+  - Public: **ticker** multi-symbol via **`symbols`** (spot + futures examples).
+- **`examples/WebSockets/README.md`** & **`kucoin-UNIFIED-examples-nodejs.md`**: new endpoints, funding-rate fields, account `potentialBorrow`, unified place-order body behavior, margin/funding examples.
+
+---
+
+## Files touched (high level)
+
+| Area          | Paths                                                                                                                                  |
+| ------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| Types         | `src/types/request/uta-types.ts`, `src/types/response/uta-types.ts`                                                                    |
+| Client        | `src/UnifiedAPIClient.ts`                                                                                                              |
+| WS examples   | `examples/WebSockets/ws-private-pro-v2.ts`, `ws-public-spot-pro-v2.ts`, `ws-public-futures-pro-v2.ts`, `examples/WebSockets/README.md` |
+| Unified guide | `examples/kucoin-UNIFIED-examples-nodejs.md`                                                                                           |
+| Optional      | `docs/endpointFunctionList.md` (if updated in your branch)                                                                             |
+
+No intentional changes to `package.json` version in this note (bump as you release).
 
 ================
 File: tsconfig.cjs.json
@@ -3668,6 +3138,10 @@ unifiedClient.getHistoryFundingRate({
 
 // Get Cross Margin Config (Spot cross margin)
 unifiedClient.getCrossMarginConfig();
+
+// Borrowable currencies + borrowing rates/limits (UTA)
+unifiedClient.getBorrowableCurrencies();
+unifiedClient.getBorrowingRatesAndLimits({ currency: 'USDT' });
 ```
 
 ### Account
@@ -3675,7 +3149,7 @@ unifiedClient.getCrossMarginConfig();
 #### Unified and Classic account balance
 
 ```js
-// Get Unified Account (UTA) balance
+// Get Unified Account (UTA) balance — currency rows may include potentialBorrow (2026.04.19)
 unifiedClient.getAccount();
 
 // Get Unified Account overview
@@ -3683,7 +3157,10 @@ unifiedClient.getAccountOverview();
 
 // Get Classic Account balance (FUNDING, SPOT, FUTURES, CROSS, ISOLATED)
 unifiedClient.getClassicAccount({ accountType: 'SPOT' });
-unifiedClient.getClassicAccount({ accountType: 'FUTURES', currency: 'USDT,XBT' });
+unifiedClient.getClassicAccount({
+  accountType: 'FUTURES',
+  currency: 'USDT,XBT',
+});
 unifiedClient.getClassicAccount({
   accountType: 'ISOLATED',
   accountSubtype: 'BTC-USDT',
@@ -3772,6 +3249,22 @@ unifiedClient.getInterestHistory({
 // Modify Leverage (Unified Futures)
 unifiedClient.modifyLeverage({ symbol: 'XBTUSDTM', leverage: '5' });
 
+// Cross margin leverage + query leverage (2026.04.19)
+unifiedClient.modifyMarginCrossLeverage(
+  { currency: 'BTC', leverage: '5' },
+  'unified',
+);
+unifiedClient.getLeverage({
+  tradeType: 'FUTURES',
+  marginMode: 'CROSS',
+  symbol: 'XBTUSDTM',
+});
+unifiedClient.getLeverage({
+  tradeType: 'MARGIN',
+  marginMode: 'CROSS',
+  currency: 'BTC',
+});
+
 // Get Deposit Address
 unifiedClient.getDepositAddress({ currency: 'BTC' });
 unifiedClient.getDepositAddress({ currency: 'BTC', chain: 'BTC' });
@@ -3781,12 +3274,12 @@ unifiedClient.getDepositAddress({ currency: 'BTC', chain: 'BTC' });
 
 #### Place order (Unified vs Classic)
 
-Unified mode: use `accountMode: 'unified'` (default). For unified, `tradeType` is not sent in the request (the client omits it).  
-Classic mode: use `accountMode: 'classic'` and pass `tradeType` in the request (Spot/Futures/Isolated/Cross).
+Unified mode: use `accountMode: 'unified'` (default). For unified, `tradeType` is sent in the JSON body 
+Classic mode: use `accountMode: 'classic'` and pass `tradeType` as a query parameter (Spot/Futures/Isolated/Cross/Margin per API).
 
 ```js
 // Unified mode - Spot limit order (default accountMode is 'unified')
-// tradeType can be omitted in request for unified; if provided it is not sent
+// tradeType is included in the body for unified (e.g. SPOT, MARGIN, FUTURES)
 unifiedClient.placeOrder(
   {
     tradeType: 'SPOT',
@@ -3987,6 +3480,8 @@ Unified position endpoints apply to the Unified account (Futures positions).
 // Get Position List (all open positions or filter by symbol)
 unifiedClient.getPositionList();
 unifiedClient.getPositionList({ symbol: 'XBTUSDTM' });
+// pageNumber, pageSize and liquidationPrice per row (as of 2026.04.09)
+unifiedClient.getPositionList({ pageNumber: 1, pageSize: 50 });
 
 // Get Positions History (up to 3 months, max 7 days per query)
 unifiedClient.getPositionsHistory({
@@ -3996,11 +3491,25 @@ unifiedClient.getPositionsHistory({
   pageSize: 50,
 });
 
+// Private funding fee history (2026.04.19)
+unifiedClient.getPrivateFundingFeeHistory({ symbol: 'XBTUSDTM' });
+
 // Get Account Position Tiers (risk limit) - Classic Futures isolated
 unifiedClient.getAccountPositionTiers(
   { symbol: 'XBTUSDTM', tradeType: 'FUTURES', marginMode: 'ISOLATED' },
   'classic',
 );
+```
+
+```js
+// Third-party custody (OES): currencies (public) and account custody limits (private)
+unifiedClient.getThirdPartyCustodyCurrencies();
+unifiedClient.getThirdPartyCustodyCurrencies({
+  custodian: 'BITGO_SG',
+  currency: 'BTC',
+});
+unifiedClient.getThirdPartyCustodyQuota();
+unifiedClient.getThirdPartyCustodyQuota({ custodian: 'CEFFU' });
 ```
 
 ## Websocket
@@ -4009,7 +3518,7 @@ For WebSocket examples that work with the unified (PRO) API, please refer to:
 
 - [Spot Public Websocket](https://github.com/tiagosiebler/kucoin-api/blob/master/examples/WebSockets/ws-public-spot-pro-v2.ts) (PRO v2)
 - [Futures Public Websocket](https://github.com/tiagosiebler/kucoin-api/blob/master/examples/WebSockets/ws-public-futures-pro-v2.ts) (PRO v2)
-- [Private WebSocket (PRO v2)](https://github.com/tiagosiebler/kucoin-api/blob/master/examples/WebSockets/ws-private-pro-v2.ts)
+- [Private WebSocket (PRO v2)](https://github.com/tiagosiebler/kucoin-api/blob/master/examples/WebSockets/ws-private-pro-v2.ts) — includes `execution.lite`, `accountType: "SPOT"` for spot balance, and comments for Pro API changes (e.g. 2026.03.30: `eT` `match`, BBO/trade high-speed channels on public Pro).
 
 ## Community group
 
@@ -4024,6 +3533,78 @@ export type LogParams = null | any;
 // console.log(_params);
 ⋮----
 export type DefaultLogger = typeof DefaultLogger;
+
+================
+File: src/types/request/broker.types.ts
+================
+export interface GetBrokerInfoRequest {
+  begin: string;
+  end: string;
+  tradeType: '1' | '2';
+}
+⋮----
+export interface GetBrokerSubAccountsRequest {
+  uid: string;
+  currentPage?: number;
+  pageSize?: number;
+}
+⋮----
+export type BrokerSubAccountPermission =
+  | 'General'
+  | 'Spot'
+  | 'Margin'
+  | 'Futures'
+  | 'InnerTransfer'
+  | 'Transfer'
+  | 'Earn';
+⋮----
+export interface CreateBrokerSubAccountApiRequest {
+  uid: string;
+  passphrase: string;
+  ipWhitelist: string[];
+  permissions: BrokerSubAccountPermission[];
+  label: string;
+}
+⋮----
+export interface GetBrokerSubAccountApisRequest {
+  uid: string;
+  apiKey?: string;
+}
+⋮----
+export interface UpdateBrokerSubAccountApiRequest {
+  uid: string;
+  apiKey: string;
+  ipWhitelist: string[];
+  permissions: BrokerSubAccountPermission[];
+  label: string;
+}
+⋮----
+export interface DeleteBrokerSubAccountApiRequest {
+  uid: string;
+  apiKey: string;
+}
+⋮----
+export type BrokerTransferDirection = 'OUT' | 'IN';
+export type BrokerAccountType = 'MAIN' | 'TRADE';
+⋮----
+export interface BrokerTransferRequest {
+  currency: string;
+  amount: string;
+  clientOid: string;
+  direction: BrokerTransferDirection;
+  accountType: BrokerAccountType;
+  specialUid: string;
+  specialAccountType: BrokerAccountType;
+}
+⋮----
+export interface GetBrokerDepositListRequest {
+  currency?: string;
+  status?: 'PROCESSING' | 'SUCCESS' | 'FAILURE';
+  hash?: string;
+  startTimestamp?: number;
+  endTimestamp?: number;
+  limit?: number;
+}
 
 ================
 File: src/types/request/spot-affiliate.ts
@@ -4111,6 +3692,191 @@ endAt?: number; // optional - End time
 lastId?: string; // optional - Last Id
 direction?: 'PRE' | 'NEXT'; // optional - Page direction
 pageSize?: number; // optional - Page size >= 1, <= 500, default: 10
+
+================
+File: src/types/request/spot-funding.ts
+================
+/**
+ *
+ ***********
+ * Funding
+ ***********
+ *
+ */
+⋮----
+export interface CreateDepositAddressV3Request {
+  currency: string;
+  chain?: string;
+  to?: 'main' | 'trade';
+  amount?: string;
+}
+⋮----
+export interface GetMarginBalanceRequest {
+  quoteCurrency?: string;
+  queryType?: 'MARGIN' | 'MARGIN_V2' | 'ALL';
+}
+⋮----
+export interface GetIsolatedMarginBalanceRequest {
+  symbol?: string;
+  quoteCurrency?: string;
+  queryType?: 'ISOLATED' | 'ISOLATED_V2' | 'ALL';
+}
+⋮----
+/**
+ *
+ * Deposit
+ *
+ */
+⋮----
+export interface GetDepositsRequest {
+  currency?: string;
+  startAt?: number;
+  endAt?: number;
+  status?: 'PROCESSING' | 'SUCCESS' | 'FAILURE';
+  currentPage?: number;
+  pageSize?: number;
+}
+⋮----
+/**
+ *
+ * Withdrawals
+ *
+ */
+⋮----
+export interface GetWithdrawalsRequest {
+  currency?: string;
+  status?: 'PROCESSING' | 'WALLET_PROCESSING' | 'SUCCESS' | 'FAILURE';
+  startAt?: number;
+  endAt?: number;
+  currentPage?: number;
+  pageSize?: number;
+}
+⋮----
+export interface ApplyWithdrawRequest {
+  currency: string;
+  address: string;
+  amount: number;
+  memo?: string;
+  isInner?: boolean;
+  remark?: string;
+  chain?: string;
+  feeDeductType?: 'INTERNAL' | 'EXTERNAL';
+}
+⋮----
+export interface SubmitWithdrawV3Request {
+  currency: string;
+  toAddress: string;
+  amount: number;
+  memo?: string;
+  isInner?: boolean;
+  remark?: string;
+  chain?: string;
+  feeDeductType?: 'INTERNAL' | 'EXTERNAL';
+  withdrawType: 'ADDRESS' | 'UID' | 'MAIL' | 'PHONE';
+}
+⋮----
+/**
+ *
+ * Transfer
+ *
+ */
+⋮----
+export interface GetTransferableRequest {
+  currency: string;
+  type:
+    | 'MAIN'
+    | 'TRADE'
+    | 'TRADE_HF'
+    | 'MARGIN'
+    | 'ISOLATED'
+    | 'OPTION'
+    | 'MARGIN_V2'
+    | 'ISOLATED_V2';
+  tag?: string;
+}
+⋮----
+export interface FlexTransferRequest {
+  clientOid: string;
+  currency?: string;
+  amount: string;
+  fromUserId?: string;
+  fromAccountType:
+    | 'MAIN'
+    | 'TRADE'
+    | 'CONTRACT'
+    | 'MARGIN'
+    | 'ISOLATED'
+    | 'TRADE_HF'
+    | 'MARGIN_V2'
+    | 'ISOLATED_V2'
+    | 'UNIFIED'
+    | 'OPTION';
+  fromAccountTag?: string;
+  type: 'INTERNAL' | 'PARENT_TO_SUB' | 'SUB_TO_PARENT';
+  toUserId?: string;
+  toAccountType:
+    | 'MAIN'
+    | 'TRADE'
+    | 'CONTRACT'
+    | 'MARGIN'
+    | 'ISOLATED'
+    | 'TRADE_HF'
+    | 'MARGIN_V2'
+    | 'ISOLATED_V2'
+    | 'UNIFIED'
+    | 'OPTION';
+  toAccountTag?: string;
+}
+⋮----
+export interface submitTransferMasterSubRequest {
+  clientOid: string;
+  currency: string;
+  amount: string;
+  direction: 'OUT' | 'IN';
+  accountType?:
+    | 'MAIN'
+    | 'TRADE'
+    | 'TRADE_HF'
+    | 'MARGIN'
+    | 'CONTRACT'
+    | 'OPTION';
+  subAccountType?:
+    | 'MAIN'
+    | 'TRADE'
+    | 'TRADE_HF'
+    | 'MARGIN'
+    | 'CONTRACT'
+    | 'OPTION';
+  subUserId: string;
+}
+⋮----
+export interface InnerTransferRequest {
+  clientOid: string;
+  currency: string;
+  from:
+    | 'main'
+    | 'trade'
+    | 'trade_hf'
+    | 'margin'
+    | 'isolated'
+    | 'margin_v2'
+    | 'isolated_v2'
+    | 'contract'
+    | 'option';
+  to:
+    | 'main'
+    | 'trade'
+    | 'trade_hf'
+    | 'margin'
+    | 'isolated'
+    | 'margin_v2'
+    | 'isolated_v2'
+    | 'contract'
+    | 'option';
+  amount: string;
+  fromTag?: string;
+  toTag?: string;
+}
 
 ================
 File: src/types/request/spot-margin-trading.ts
@@ -4484,279 +4250,128 @@ export interface GetMarginCollateralRatioRequest {
 currencyList?: string; // If not specified, all currencies will be returned. Supports multiple currencies, separated by commas.
 
 ================
-File: src/types/response/spot-account.ts
+File: src/types/response/broker.types.ts
 ================
-export interface SpotAccountSummary {
+export interface BrokerInfo {
+  accountSize: number;
+  maxAccountSize: number | null;
   level: number;
-  subQuantity: number;
-  spotSubQuantity: number;
-  marginSubQuantity: number;
-  futuresSubQuantity: number;
-  optionSubQuantity: number;
-  maxSubQuantity: number;
-  maxDefaultSubQuantity: number;
-  maxSpotSubQuantity: number;
-  maxMarginSubQuantity: number;
-  maxFuturesSubQuantity: number;
-  maxOptionSubQuantity: number;
 }
 ⋮----
-export interface Balances {
-  id: string;
-  currency: string;
-  type: 'main' | 'trade';
-  balance: string;
-  available: string;
-  holds: string;
-}
-⋮----
-export interface Account {
-  currency: string;
-  balance: string;
-  available: string;
-  holds: string;
-}
-⋮----
-export interface SpotAccountTransaction {
-  id: string;
-  currency: string;
-  amount: string;
-  fee: string;
-  tax: string;
-  balance: string;
-  accountType: string; // 'TRADE_HF'
-  bizType: string;
-  direction: 'out' | 'in';
-  createdAt: string;
-  context: string;
-}
-⋮----
-accountType: string; // 'TRADE_HF'
-⋮----
-export interface SpotAccountTransactions {
-  currentPage: number;
-  pageSize: number;
-  totalNum: number;
-  totalPage: number;
-  items: SpotAccountTransaction[];
-}
-⋮----
-export interface AccountHFMarginTransactions {
-  id: string;
-  currency: string;
-  amount: string;
-  fee: string;
-  balance: string;
-  /** Migrating from MARGIN_V2/ISOLATED_V2 to MARGIN/ISOLATED per SPOT Margin HF migration */
-  accountType: 'MARGIN' | 'ISOLATED' | 'MARGIN_V2' | 'ISOLATED_V2';
-  bizType:
-    | 'TRANSFER'
-    | 'MARGIN_EXCHANGE'
-    | 'ISOLATED_EXCHANGE'
-    | 'LIQUIDATION'
-    | 'ASSERT_RETURN';
-  direction: 'out' | 'in';
-  createdAt: string;
-  tax: string;
-  context: string;
-}
-⋮----
-/** Migrating from MARGIN_V2/ISOLATED_V2 to MARGIN/ISOLATED per SPOT Margin HF migration */
-⋮----
-/**
- *
- * Sub-Account
- *
- */
-⋮----
-export interface SubAccountInfo {
-  userId: string;
-  uid: number;
-  subName: string;
-  status: number;
-  type: number;
-  access: string;
+export interface CreateBrokerSubAccountResponse {
+  accountName: string;
+  uid: string;
   createdAt: number;
-  remarks: string;
-  tradeTypes: string[];
-  openedTradeTypes: string[];
-  hostedStatus: null | string;
+  level: number;
 }
 ⋮----
-export interface SubAccountsV2 {
-  currentPage: number;
-  pageSize: number;
-  totalNum: number;
-  totalPage: number;
-  items: SubAccountInfo[];
-}
-⋮----
-export interface SubAccountItem {
-  userId: string;
-  uid: number;
-  subName: string;
-  status: number;
-  type: number;
-  access: string;
+export interface BrokerSubAccount {
+  accountName: string;
+  uid: string;
   createdAt: number;
-  remarks: string;
-  tradeTypes: string[];
-  openedTradeTypes: string[];
-  hostedStatus: null | string;
+  level: number;
 }
 ⋮----
-export interface CreateSubAccount {
+export interface GetBrokerSubAccountsResponse {
   currentPage: number;
   pageSize: number;
   totalNum: number;
   totalPage: number;
-  items: SubAccountItem[];
+  items: BrokerSubAccount[];
 }
 ⋮----
-export interface SubAccountBalance {
-  currency: string;
-  balance: string;
-  available: string;
-  holds: string;
-  baseCurrency: string;
-  baseCurrencyPrice: string;
-  baseAmount: string;
+export interface CreateBrokerSubAccountApiResponse {
+  uid: string;
+  label: string;
+  apiKey: string;
+  secretKey: string;
+  apiVersion: number;
+  permissions: string[];
+  ipWhitelist: string[];
+  createdAt: number;
 }
 ⋮----
-// deprecated
-export interface SubAccountBalances {
-  subUserId: string;
-  subName: string;
-  mainAccounts: SubAccountBalance[];
-  tradeAccounts: SubAccountBalance[];
-  marginAccounts: SubAccountBalance[];
-}
-⋮----
-export interface SubAccountBalancesV2 {
-  currentPage: number;
-  pageSize: number;
-  totalNum: number;
-  totalPage: number;
-  items: {
-    subUserId: string;
-    subName: string;
-    mainAccounts: SubAccountBalance[];
-  }[];
-}
-export interface SubAccountV2Details {
-  currency?: string;
-  balance?: string;
-  available?: string;
-  holds?: string;
-  baseCurrency?: string;
-  baseCurrencyPrice?: string;
-  baseAmount?: string;
-  tag?: string;
-}
-⋮----
-export interface SubAccountBalanceItemV2 {
-  subUserId: string;
-  subName: string;
-  mainAccounts: SubAccountV2Details[]; // Funding Account
-  tradeAccounts: SubAccountV2Details[]; // Spot Account
-  marginAccounts: SubAccountV2Details[]; // Margin Account
-  tradeHFAccounts: string[]; // Deprecated, only for old users
-}
-⋮----
-mainAccounts: SubAccountV2Details[]; // Funding Account
-tradeAccounts: SubAccountV2Details[]; // Spot Account
-marginAccounts: SubAccountV2Details[]; // Margin Account
-tradeHFAccounts: string[]; // Deprecated, only for old users
-⋮----
-/**
- *
- * Sub-Account API
- *
- *
- */
-⋮----
-export interface SubAccountAPIInfo {
-  subName: string;
-  remark: string;
+export interface BrokerSubAccountApi {
+  uid: string;
+  label: string;
   apiKey: string;
   apiVersion: number;
-  permission: string;
-  ipWhitelist: string;
+  permissions: (
+    | 'General'
+    | 'Spot'
+    | 'Margin'
+    | 'Futures'
+    | 'InnerTransfer'
+    | 'Transfer'
+    | 'Earn'
+  )[];
+  ipWhitelist: string[];
   createdAt: number;
+}
+⋮----
+export type BrokerTransferAccountType =
+  | 'MAIN'
+  | 'TRADE'
+  | 'CONTRACT'
+  | 'MARGIN'
+  | 'ISOLATED';
+export type BrokerTransferStatus = 'PROCESSING' | 'SUCCESS' | 'FAILURE';
+⋮----
+export interface BrokerTransferHistory {
+  orderId: string;
+  currency: string;
+  amount: string;
+  fromUid: number;
+  fromAccountType: BrokerTransferAccountType;
+  fromAccountTag: string;
+  toUid: number;
+  toAccountType: BrokerTransferAccountType;
+  toAccountTag: string;
+  status: BrokerTransferStatus;
+  reason: string | null;
+  createdAt: number;
+}
+⋮----
+export interface BrokerDepositRecord {
   uid: number;
-  isMaster: boolean;
-}
-⋮----
-export interface CreateSubAPI {
-  subName: string;
+  hash: string;
+  address: string;
+  memo: string;
+  amount: string;
+  fee: string;
+  currency: string;
+  isInner: boolean;
+  walletTxId: string;
+  status: BrokerTransferStatus;
   remark: string;
-  apiKey: string;
-  apiSecret: string;
-  apiVersion: number;
-  passphrase: string;
-  permission: string;
+  chain: string;
   createdAt: number;
+  updatedAt: number;
 }
 ⋮----
-export interface UpdateSubAPI {
-  apiKey: string;
-  ipWhitelist: string;
-  permission: string;
-  subName: string;
+export type BrokerWithdrawalStatus =
+  | 'PROCESSING'
+  | 'WALLET_PROCESSING'
+  | 'REVIEW'
+  | 'SUCCESS'
+  | 'FAILURE';
+⋮----
+export interface BrokerWithdrawalRecord {
+  id: string;
+  chain: string;
+  walletTxId: string;
+  uid: number;
+  amount: string;
+  memo: string;
+  fee: string;
+  address: string;
+  remark: string;
+  isInner: boolean;
+  currency: string;
+  status: BrokerWithdrawalStatus;
+  createdAt: number;
+  updatedAt: number;
 }
-⋮----
-export interface DeleteSubAccountAPI {
-  subName: string;
-  apiKey: string;
-}
-⋮----
-/**
- * Get KYC Regions Response
- */
-export interface KYCRegion {
-  code: string; // Two-letter country code
-  enName: string; // English name of the region
-}
-⋮----
-code: string; // Two-letter country code
-enName: string; // English name of the region
-⋮----
-/**
- * Get API Key Info Response
- */
-export interface ApiKeyInfo {
-  uid: number; // Account UID
-  parentUid?: number; // Master account UID. Returns empty when called by the master account itself
-  region: string; // KYC region of the account, returns the two-letter country code
-  kycStatus: 0 | 1; // KYC status
-  subName?: string; // Sub-account name (not present for the master account)
-  remark: string; // Remarks
-  apiKey: string; // API key
-  apiVersion: number; // API version
-  permission: string; // Permissions
-  ipWhitelist?: string; // IP whitelist (comma-separated list of allowed IPs)
-  isMaster: boolean; // Indicates whether this is the master account
-  createdAt: number; // API key creation timestamp (Unix milliseconds)
-  expiredAt?: number | null; // API key expiration timestamp (Unix milliseconds). Returns null if no expiration is set
-  thirdPartyApp?: string; // Third-party application name. Returns empty string if not associated with any third-party app
-  siteType?: 'global' | 'turkey' | 'australia' | 'europe' | 'thailand'; // Site Type
-}
-⋮----
-uid: number; // Account UID
-parentUid?: number; // Master account UID. Returns empty when called by the master account itself
-region: string; // KYC region of the account, returns the two-letter country code
-kycStatus: 0 | 1; // KYC status
-subName?: string; // Sub-account name (not present for the master account)
-remark: string; // Remarks
-apiKey: string; // API key
-apiVersion: number; // API version
-permission: string; // Permissions
-ipWhitelist?: string; // IP whitelist (comma-separated list of allowed IPs)
-isMaster: boolean; // Indicates whether this is the master account
-createdAt: number; // API key creation timestamp (Unix milliseconds)
-expiredAt?: number | null; // API key expiration timestamp (Unix milliseconds). Returns null if no expiration is set
-thirdPartyApp?: string; // Third-party application name. Returns empty string if not associated with any third-party app
-siteType?: 'global' | 'turkey' | 'australia' | 'europe' | 'thailand'; // Site Type
 
 ================
 File: src/types/response/spot-affiliate.ts
@@ -4948,6 +4563,224 @@ export interface MessageEventLike<TDataType = string> {
 }
 ⋮----
 export function isMessageEvent(msg: unknown): msg is MessageEventLike
+
+================
+File: src/BrokerClient.ts
+================
+import { BaseRestClient } from './lib/BaseRestClient.js';
+import { REST_CLIENT_TYPE_ENUM, RestClientType } from './lib/requestUtils.js';
+import {
+  BrokerTransferRequest,
+  CreateBrokerSubAccountApiRequest,
+  DeleteBrokerSubAccountApiRequest,
+  GetBrokerDepositListRequest,
+  GetBrokerInfoRequest,
+  GetBrokerSubAccountApisRequest,
+  GetBrokerSubAccountsRequest,
+  UpdateBrokerSubAccountApiRequest,
+} from './types/request/broker.types.js';
+import {
+  BrokerDepositRecord,
+  BrokerInfo,
+  BrokerSubAccountApi,
+  BrokerTransferHistory,
+  BrokerWithdrawalRecord,
+  CreateBrokerSubAccountApiResponse,
+  CreateBrokerSubAccountResponse,
+  GetBrokerSubAccountsResponse,
+} from './types/response/broker.types.js';
+import { APISuccessResponse } from './types/response/shared.types.js';
+⋮----
+/**
+ *
+ */
+export class BrokerClient extends BaseRestClient
+⋮----
+getClientType(): RestClientType
+⋮----
+/**
+   * Get Broker Info
+   *
+   * This endpoint supports querying the basic information of the current Broker
+   */
+getBrokerInfo(
+    params: GetBrokerInfoRequest,
+): Promise<APISuccessResponse<BrokerInfo>>
+⋮----
+/**
+   * Add SubAccount
+   *
+   * This endpoint supports Broker users to create sub-accounts.
+   * Note that the account name is unique across the exchange.
+   * It is recommended to add a special identifier to prevent name duplication.
+   */
+createSubAccount(params: {
+    accountName: string;
+}): Promise<APISuccessResponse<CreateBrokerSubAccountResponse>>
+⋮----
+/**
+   * Get SubAccount
+   *
+   * This interface supports querying sub-accounts created by Broker.
+   * Returns paginated results with default page size of 20 (max 100).
+   */
+getSubAccounts(
+    params: GetBrokerSubAccountsRequest,
+): Promise<APISuccessResponse<GetBrokerSubAccountsResponse>>
+⋮----
+/**
+   * Add SubAccount API
+   *
+   * This interface supports the creation of Broker sub-account APIKEY.
+   * Supports up to 20 IPs in the whitelist.
+   * Permissions: General, Spot, Margin, Futures, InnerTransfer, Transfer, Earn.
+   * Label must be between 4 and 32 characters.
+   */
+createSubAccountApi(
+    params: CreateBrokerSubAccountApiRequest,
+): Promise<APISuccessResponse<CreateBrokerSubAccountApiResponse>>
+⋮----
+/**
+   * Get SubAccount API
+   *
+   * This interface supports querying the Broker's sub-account APIKEYs.
+   * Can optionally filter by specific apiKey.
+   */
+getSubAccountApis(
+    params: GetBrokerSubAccountApisRequest,
+): Promise<APISuccessResponse<BrokerSubAccountApi[]>>
+⋮----
+/**
+   * Modify SubAccount API
+   *
+   * This interface supports modifying the Broker's sub-account APIKEY.
+   * Supports up to 20 IPs in the whitelist.
+   * Permissions: General, Spot, Margin, Futures, InnerTransfer, Transfer, Earn.
+   * Label must be between 4 and 32 characters.
+   */
+updateSubAccountApi(
+    params: UpdateBrokerSubAccountApiRequest,
+): Promise<APISuccessResponse<BrokerSubAccountApi>>
+⋮----
+/**
+   * Delete SubAccount API
+   *
+   * This interface supports deleting Broker's sub-account APIKEY.
+   */
+deleteSubAccountApi(
+    params: DeleteBrokerSubAccountApiRequest,
+): Promise<APISuccessResponse<boolean>>
+⋮----
+/**
+   * Transfer
+   *
+   * This endpoint supports fund transfer between Broker account and Broker sub-accounts.
+   * Please be aware that withdrawal from sub-account is not directly supported.
+   * Broker has to transfer funds from broker sub-account to broker account to initiate the withdrawals.
+   *
+   * Direction:
+   * - OUT: Broker account is transferred to Broker sub-account
+   * - IN: Broker sub-account is transferred to Broker account
+   *
+   * Account Types:
+   * - MAIN: Funding account
+   * - TRADE: Spot trading account
+   */
+submitTransfer(params: BrokerTransferRequest): Promise<
+    APISuccessResponse<{
+      orderId: string;
+    }>
+  > {
+    return this.postPrivate('api/v1/broker/nd/transfer', params);
+⋮----
+/**
+   * Get Transfer History
+   *
+   * This endpoint supports querying transfer records of the broker itself and its created sub-accounts.
+   *
+   * Account Types:
+   * - MAIN: Funding account
+   * - TRADE: Spot trading account
+   * - CONTRACT: Contract account
+   * - MARGIN: Margin account
+   * - ISOLATED: Isolated margin account
+   *
+   * Status:
+   * - PROCESSING: Processing
+   * - SUCCESS: Successful
+   * - FAILURE: Failed
+   */
+getTransferHistory(params: {
+    orderId: string;
+}): Promise<APISuccessResponse<BrokerTransferHistory>>
+⋮----
+/**
+   * Get Deposit List
+   *
+   * This endpoint can obtain the deposit records of each sub-account under the ND Broker.
+   * Default limit is 1000 records (max 1000).
+   * Results are sorted in descending order by default.
+   *
+   * Status:
+   * - PROCESSING: Processing
+   * - SUCCESS: Successful
+   * - FAILURE: Failed
+   */
+getDeposits(
+    params?: GetBrokerDepositListRequest,
+): Promise<APISuccessResponse<BrokerDepositRecord[]>>
+⋮----
+/**
+   * Get Deposit Detail
+   *
+   * This endpoint supports querying the deposit record of sub-accounts created by a Broker
+   * (excluding main account of nd broker).
+   *
+   * Status:
+   * - PROCESSING: Processing
+   * - SUCCESS: Successful
+   * - FAILURE: Failed
+   */
+getDeposit(params: {
+    currency: string;
+    hash: string;
+}): Promise<APISuccessResponse<BrokerDepositRecord>>
+⋮----
+/**
+   * Get Withdrawal Detail
+   *
+   * This endpoint supports querying the withdrawal records of sub-accounts created by a Broker
+   * (excluding main account of nd broker).
+   *
+   * Status:
+   * - PROCESSING: Processing
+   * - WALLET_PROCESSING: Wallet Processing
+   * - REVIEW: Under Review
+   * - SUCCESS: Successful
+   * - FAILURE: Failed
+   */
+getWithdrawal(params: {
+    withdrawalId: string;
+}): Promise<APISuccessResponse<BrokerWithdrawalRecord>>
+⋮----
+/**
+   * Get Broker Rebate
+   *
+   * This interface supports downloading Broker rebate orders.
+   * Returns a URL to download a CSV file containing the rebate data.
+   * The URL is valid for 1 day.
+   * Maximum interval between begin and end dates is 6 months.
+   */
+getBrokerRebate(params: {
+    begin: string;
+    end: string;
+    tradeType: '1' | '2';
+  }): Promise<
+    APISuccessResponse<{
+      url: string;
+    }>
+  > {
+    return this.getPrivate('api/v1/broker/nd/rebase/download', params);
 
 ================
 File: webpack/webpack.config.cjs
@@ -6366,503 +6199,279 @@ deleteTopic(key: WsKey, topic: TWSTopicSubscribeEventArgs)
 // Check if we're subscribed to a topic like this
 
 ================
-File: src/types/request/uta-types.ts
+File: src/types/response/spot-account.ts
 ================
-/**
- * Unified Trading Account Request Types
- */
-⋮----
-export interface GetAnnouncementsRequestUTA {
-  language?:
-    | 'zh_HK'
-    | 'ja_JP'
-    | 'ko_KR'
-    | 'en_US'
-    | 'pl_PL'
-    | 'es_ES'
-    | 'fr_FR'
-    | 'ar_AE'
-    | 'it_IT'
-    | 'id_ID'
-    | 'nl_NL'
-    | 'pt_PT'
-    | 'vi_VN'
-    | 'de_DE'
-    | 'tr_TR'
-    | 'ms_MY'
-    | 'ru_RU'
-    | 'th_TH'
-    | 'hi_IN'
-    | 'bn_BD'
-    | 'fil_PH'
-    | 'ur_PK';
-  type?:
-    | 'latest-announcements'
-    | 'activities'
-    | 'product-updates'
-    | 'vip'
-    | 'maintenance-updates'
-    | 'delistings'
-    | 'others'
-    | 'api-campaigns'
-    | 'new-listings'
-    | 'futures-announcements';
-  pageNumber?: number;
-  pageSize?: number;
-  startTime?: number;
-  endTime?: number;
+export interface SpotAccountSummary {
+  level: number;
+  subQuantity: number;
+  spotSubQuantity: number;
+  marginSubQuantity: number;
+  futuresSubQuantity: number;
+  optionSubQuantity: number;
+  maxSubQuantity: number;
+  maxDefaultSubQuantity: number;
+  maxSpotSubQuantity: number;
+  maxMarginSubQuantity: number;
+  maxFuturesSubQuantity: number;
+  maxOptionSubQuantity: number;
 }
 ⋮----
-export interface GetCurrencyRequestUTA {
-  currency?: string;
-  chain?: string;
-}
-⋮----
-export interface GetSymbolRequestUTA {
-  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS';
-  symbol?: string;
-}
-⋮----
-export interface GetTickerRequestUTA {
-  tradeType: 'SPOT' | 'FUTURES';
-  symbol?: string;
-}
-⋮----
-export interface GetTradesRequestUTA {
-  tradeType: 'SPOT' | 'FUTURES';
-  symbol: string;
-}
-⋮----
-export interface GetOrderBookRequestUTA {
-  tradeType: 'SPOT' | 'FUTURES';
-  symbol: string;
-  limit: '20' | '50' | '100' | 'FULL';
-  /**
-   * Whether it is an RPI Order. Applicable to FUTURES only.
-   * 0: noneRPI Orders (default)
-   * 1: noneRPI + RPI Orders
-   */
-  rpiFilter?: 0 | 1;
-}
-⋮----
-/**
-   * Whether it is an RPI Order. Applicable to FUTURES only.
-   * 0: noneRPI Orders (default)
-   * 1: noneRPI + RPI Orders
-   */
-⋮----
-export interface GetKlinesRequestUTA {
-  tradeType: 'SPOT' | 'FUTURES';
-  symbol: string;
-  interval:
-    | '1min'
-    | '3min'
-    | '5min'
-    | '15min'
-    | '30min'
-    | '1hour'
-    | '2hour'
-    | '4hour'
-    | '6hour'
-    | '8hour'
-    | '12hour'
-    | '1day'
-    | '1week'
-    | '1month';
-  startAt?: number;
-  endAt?: number;
-}
-⋮----
-export interface GetCurrentFundingRateRequestUTA {
-  symbol: string;
-}
-⋮----
-export interface GetHistoryFundingRateRequestUTA {
-  symbol: string;
-  startAt: number;
-  endAt: number;
-}
-⋮----
-export interface GetServiceStatusRequestUTA {
-  tradeType: 'SPOT' | 'FUTURES';
-}
-⋮----
-/**
- * Account Endpoints
- */
-⋮----
-export interface GetClassicAccountRequestUTA {
-  accountType: 'FUNDING' | 'SPOT' | 'FUTURES' | 'CROSS' | 'ISOLATED';
-  accountSubtype?: string; // For ISOLATED (trading pair) or FUTURES (settlement currency)
-  currency?: string; // Up to 20 currencies, comma-separated
-}
-⋮----
-accountSubtype?: string; // For ISOLATED (trading pair) or FUTURES (settlement currency)
-currency?: string; // Up to 20 currencies, comma-separated
-⋮----
-export interface GetSubAccountRequestUTA {
-  UID?: string; // Up to 50 UIDs, comma-separated
-  pageSize?: number; // Default 10, max 50
-  lastId?: number;
-}
-⋮----
-UID?: string; // Up to 50 UIDs, comma-separated
-pageSize?: number; // Default 10, max 50
-⋮----
-export interface GetTransferQuotasRequestUTA {
+export interface Balances {
+  id: string;
   currency: string;
-  accountType:
-    | 'FUNDING'
-    | 'SPOT'
-    | 'FUTURES'
-    | 'CROSS'
-    | 'ISOLATED'
-    | 'UNIFIED';
-  symbol?: string; // Required when accountType is ISOLATED
+  type: 'main' | 'trade';
+  balance: string;
+  available: string;
+  holds: string;
 }
 ⋮----
-symbol?: string; // Required when accountType is ISOLATED
+export interface Account {
+  currency: string;
+  balance: string;
+  available: string;
+  holds: string;
+}
 ⋮----
-export interface FlexTransferRequestUTA {
-  clientOid: string;
+export interface SpotAccountTransaction {
+  id: string;
   currency: string;
   amount: string;
-  type: '0' | '1' | '2' | '3'; // 0=INTERNAL, 1=PARENT_TO_SUB, 2=SUB_TO_PARENT, 3=SUB_TO_SUB
-  fromAccountType:
-    | 'FUNDING'
-    | 'SPOT'
-    | 'FUTURES'
-    | 'CROSS'
-    | 'ISOLATED'
-    | 'UNIFIED';
-  toAccountType:
-    | 'FUNDING'
-    | 'SPOT'
-    | 'FUTURES'
-    | 'CROSS'
-    | 'ISOLATED'
-    | 'UNIFIED';
-  fromAccountSymbol?: string; // Required when fromAccountType is ISOLATED
-  toAccountSymbol?: string; // Required when toAccountType is ISOLATED
-  fromUid?: string; // Required for SUB transfers
-  toUid?: string; // Required for SUB transfers
+  fee: string;
+  tax: string;
+  balance: string;
+  accountType: string; // 'TRADE_HF'
+  bizType: string;
+  direction: 'out' | 'in';
+  createdAt: string;
+  context: string;
 }
 ⋮----
-type: '0' | '1' | '2' | '3'; // 0=INTERNAL, 1=PARENT_TO_SUB, 2=SUB_TO_PARENT, 3=SUB_TO_SUB
+accountType: string; // 'TRADE_HF'
 ⋮----
-fromAccountSymbol?: string; // Required when fromAccountType is ISOLATED
-toAccountSymbol?: string; // Required when toAccountType is ISOLATED
-fromUid?: string; // Required for SUB transfers
-toUid?: string; // Required for SUB transfers
-⋮----
-export interface SetSubAccountTransferPermissionRequestUTA {
-  subUids: string; // Comma-separated sub account UIDs
-  subToSub: boolean;
+export interface SpotAccountTransactions {
+  currentPage: number;
+  pageSize: number;
+  totalNum: number;
+  totalPage: number;
+  items: SpotAccountTransaction[];
 }
 ⋮----
-subUids: string; // Comma-separated sub account UIDs
-⋮----
-export interface SetAccountModeRequestUTA {
-  accountType: 'CLASSIC' | 'UNIFIED';
-}
-⋮----
-export interface GetFeeRateRequestUTA {
-  tradeType: 'SPOT' | 'FUTURES';
-  symbol: string; // Spot: up to 10 symbols comma-separated, Futures: 1 symbol only
-}
-⋮----
-symbol: string; // Spot: up to 10 symbols comma-separated, Futures: 1 symbol only
-⋮----
-export interface GetAccountLedgerRequestUTA {
-  accountType:
-    | 'FUNDING'
-    | 'SPOT'
-    | 'FUTURES'
-    | 'CROSS'
-    | 'ISOLATED'
-    | 'UNIFIED';
-  currency?: string; // Up to 10 currencies, comma-separated
-  direction?: 'IN' | 'OUT';
-  businessType?:
-    | 'TRADE_EXCHANGE'
-    | 'TRANSFER'
-    | 'SUB_TRANSFER'
-    | 'RETURNED_FEES'
-    | 'DEDUCTION_FEES'
-    | 'OTHER'
-    | 'SUB_TO_SUB_TRANSFER'
-    | 'SPOT_EXCHANGE'
-    | 'SPOT_EXCHANGE_REBATE'
-    | 'FUTURES_EXCHANGE_OPEN'
-    | 'FUTURES_EXCHANGE_CLOSE'
-    | 'FUTURES_EXCHANGE_REBATE'
-    | 'FUNDING_FEE'
-    | 'LIABILITY_INTEREST'
-    | 'KCS_DEDUCTION_FEES'
-    | 'KCS_RETURNED_FEES'
-    | 'AUTO_EXCHANGE_USER';
-  lastId?: number;
-  startAt?: number; // milliseconds
-  endAt?: number; // milliseconds
-  pageSize?: number; // Default 100, max 200
-}
-⋮----
-currency?: string; // Up to 10 currencies, comma-separated
-⋮----
-startAt?: number; // milliseconds
-endAt?: number; // milliseconds
-pageSize?: number; // Default 100, max 200
-⋮----
-export interface GetInterestHistoryRequestUTA {
-  accountType: 'UNIFIED';
-  currency?: string;
-  startTime?: number; // milliseconds
-  endTime?: number; // milliseconds
-  page?: number;
-  size?: number; // Default 50, max 1000
-}
-⋮----
-startTime?: number; // milliseconds
-endTime?: number; // milliseconds
-⋮----
-size?: number; // Default 50, max 1000
-⋮----
-export interface ModifyLeverageRequestUTA {
-  symbol: string;
-  leverage: string;
-}
-⋮----
-export interface GetDepositAddressRequestUTA {
+export interface AccountHFMarginTransactions {
+  id: string;
   currency: string;
-  chain?: string; // If both currency and chain provided, address will be created if not exists
+  amount: string;
+  fee: string;
+  balance: string;
+  /** Migrating from MARGIN_V2/ISOLATED_V2 to MARGIN/ISOLATED per SPOT Margin HF migration */
+  accountType: 'MARGIN' | 'ISOLATED' | 'MARGIN_V2' | 'ISOLATED_V2';
+  bizType:
+    | 'TRANSFER'
+    | 'MARGIN_EXCHANGE'
+    | 'ISOLATED_EXCHANGE'
+    | 'LIQUIDATION'
+    | 'ASSERT_RETURN';
+  direction: 'out' | 'in';
+  createdAt: string;
+  tax: string;
+  context: string;
 }
 ⋮----
-chain?: string; // If both currency and chain provided, address will be created if not exists
+/** Migrating from MARGIN_V2/ISOLATED_V2 to MARGIN/ISOLATED per SPOT Margin HF migration */
 ⋮----
 /**
- * Order Endpoints
+ *
+ * Sub-Account
+ *
  */
 ⋮----
-export interface PlaceOrderRequestUTA {
-  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS';
-  clientOid?: string; // Mandatory for futures and margin; optional otherwise. Max 40 chars
-  symbol: string;
-  side: 'BUY' | 'SELL';
-  positionSide?: 'BOTH' | 'LONG' | 'SHORT'; // For Classic Futures only
-  orderType: 'LIMIT' | 'MARKET';
-  size: string;
-  sizeUnit: 'BASECCY' | 'QUOTECCY' | 'UNIT'; // Required for UTA, UNIT for Futures
-  price?: string;
-  leverage?: number; // Only for Classic Mode isolated margin
-  reduceOnly?: boolean; // Only for Futures
-  marginMode?: 'ISOLATED' | 'CROSS'; // Only for Classic Futures
-  stp?: 'DC' | 'CO' | 'CN' | 'CB';
-  /**
-   * Time in Force. Added 'RPI' as of 2025.01.02
-   * - GTC: Good Till Cancel (default)
-   * - FOK: Fill Or Kill
-   * - IOC: Immediate Or Cancel
-   * - GTT: Good Till Time (not supported for Futures)
-   * - RPI: Retail Price Improvement Order (Phase 1: Futures only)
-   */
-  timeInForce?: 'GTC' | 'IOC' | 'GTT' | 'FOK' | 'RPI';
-  cancelAfter?: number; // Only effective when timeInForce is GTT
-  postOnly?: boolean;
-  autoBorrow?: boolean; // Only for Isolated/Cross Margin (Classic only)
-  autoRepay?: boolean; // Only for Isolated/Cross Margin (Classic only)
-  tags?: string; // Max length 20
-  triggerDirection?: 'DOWN' | 'UP'; // Required when triggerPrice is set
-  triggerPrice?: string;
-  triggerPriceType?: 'TP' | 'IP' | 'MP'; // Only for Futures
-  tpTriggerPrice?: string; // Only for Futures
-  tpTriggerPriceType?: 'TP' | 'IP' | 'MP';
-  slTriggerPrice?: string; // Only for Futures
-  slTriggerPriceType?: 'TP' | 'IP' | 'MP';
+export interface SubAccountInfo {
+  userId: string;
+  uid: number;
+  subName: string;
+  status: number;
+  type: number;
+  access: string;
+  createdAt: number;
+  remarks: string;
+  tradeTypes: string[];
+  openedTradeTypes: string[];
+  hostedStatus: null | string;
 }
 ⋮----
-clientOid?: string; // Mandatory for futures and margin; optional otherwise. Max 40 chars
+export interface SubAccountsV2 {
+  currentPage: number;
+  pageSize: number;
+  totalNum: number;
+  totalPage: number;
+  items: SubAccountInfo[];
+}
 ⋮----
-positionSide?: 'BOTH' | 'LONG' | 'SHORT'; // For Classic Futures only
+export interface SubAccountItem {
+  userId: string;
+  uid: number;
+  subName: string;
+  status: number;
+  type: number;
+  access: string;
+  createdAt: number;
+  remarks: string;
+  tradeTypes: string[];
+  openedTradeTypes: string[];
+  hostedStatus: null | string;
+}
 ⋮----
-sizeUnit: 'BASECCY' | 'QUOTECCY' | 'UNIT'; // Required for UTA, UNIT for Futures
+export interface CreateSubAccount {
+  currentPage: number;
+  pageSize: number;
+  totalNum: number;
+  totalPage: number;
+  items: SubAccountItem[];
+}
 ⋮----
-leverage?: number; // Only for Classic Mode isolated margin
-reduceOnly?: boolean; // Only for Futures
-marginMode?: 'ISOLATED' | 'CROSS'; // Only for Classic Futures
+export interface SubAccountBalance {
+  currency: string;
+  balance: string;
+  available: string;
+  holds: string;
+  baseCurrency: string;
+  baseCurrencyPrice: string;
+  baseAmount: string;
+}
+⋮----
+// deprecated
+export interface SubAccountBalances {
+  subUserId: string;
+  subName: string;
+  mainAccounts: SubAccountBalance[];
+  tradeAccounts: SubAccountBalance[];
+  marginAccounts: SubAccountBalance[];
+}
+⋮----
+export interface SubAccountBalancesV2 {
+  currentPage: number;
+  pageSize: number;
+  totalNum: number;
+  totalPage: number;
+  items: {
+    subUserId: string;
+    subName: string;
+    mainAccounts: SubAccountBalance[];
+  }[];
+}
+export interface SubAccountV2Details {
+  currency?: string;
+  balance?: string;
+  available?: string;
+  holds?: string;
+  baseCurrency?: string;
+  baseCurrencyPrice?: string;
+  baseAmount?: string;
+  tag?: string;
+}
+⋮----
+export interface SubAccountBalanceItemV2 {
+  subUserId: string;
+  subName: string;
+  mainAccounts: SubAccountV2Details[]; // Funding Account
+  tradeAccounts: SubAccountV2Details[]; // Spot Account
+  marginAccounts: SubAccountV2Details[]; // Margin Account
+  tradeHFAccounts: string[]; // Deprecated, only for old users
+}
+⋮----
+mainAccounts: SubAccountV2Details[]; // Funding Account
+tradeAccounts: SubAccountV2Details[]; // Spot Account
+marginAccounts: SubAccountV2Details[]; // Margin Account
+tradeHFAccounts: string[]; // Deprecated, only for old users
 ⋮----
 /**
-   * Time in Force. Added 'RPI' as of 2025.01.02
-   * - GTC: Good Till Cancel (default)
-   * - FOK: Fill Or Kill
-   * - IOC: Immediate Or Cancel
-   * - GTT: Good Till Time (not supported for Futures)
-   * - RPI: Retail Price Improvement Order (Phase 1: Futures only)
-   */
-⋮----
-cancelAfter?: number; // Only effective when timeInForce is GTT
-⋮----
-autoBorrow?: boolean; // Only for Isolated/Cross Margin (Classic only)
-autoRepay?: boolean; // Only for Isolated/Cross Margin (Classic only)
-tags?: string; // Max length 20
-triggerDirection?: 'DOWN' | 'UP'; // Required when triggerPrice is set
-⋮----
-triggerPriceType?: 'TP' | 'IP' | 'MP'; // Only for Futures
-tpTriggerPrice?: string; // Only for Futures
-⋮----
-slTriggerPrice?: string; // Only for Futures
-⋮----
-export interface BatchPlaceOrderRequestUTA {
-  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS';
-  orderList: Omit<PlaceOrderRequestUTA, 'tradeType'>[];
-}
-⋮----
-export interface GetOrderDetailsRequestUTA {
-  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS';
-  symbol: string;
-  orderId?: string; // At least one of orderId or clientOid required
-  clientOid?: string; // At least one of orderId or clientOid required
-}
-⋮----
-orderId?: string; // At least one of orderId or clientOid required
-clientOid?: string; // At least one of orderId or clientOid required
-⋮----
-export interface GetOpenOrderListRequestUTA {
-  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS';
-  symbol?: string; // Required for SPOT, ISOLATED, and CROSS
-  orderFilter?: 'NORMAL' | 'CONDITION'; // Defaults to NORMAL
-  startAt?: number; // milliseconds
-  endAt?: number; // milliseconds
-  pageNumber?: number;
-  pageSize?: number; // Default 50, max 200
-}
-⋮----
-symbol?: string; // Required for SPOT, ISOLATED, and CROSS
-orderFilter?: 'NORMAL' | 'CONDITION'; // Defaults to NORMAL
-startAt?: number; // milliseconds
-endAt?: number; // milliseconds
-⋮----
-pageSize?: number; // Default 50, max 200
-⋮----
-export interface GetOrderHistoryRequestUTA {
-  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS';
-  symbol?: string; // Required for SPOT, ISOLATED, and CROSS
-  side?: 'BUY' | 'SELL';
-  orderFilter?: 'NORMAL' | 'CONDITION'; // Defaults to NORMAL
-  startAt?: number; // milliseconds
-  endAt?: number; // milliseconds
-  lastId?: string;
-  pageSize?: number; // Default 50, max 200
-}
-⋮----
-symbol?: string; // Required for SPOT, ISOLATED, and CROSS
-⋮----
-orderFilter?: 'NORMAL' | 'CONDITION'; // Defaults to NORMAL
-startAt?: number; // milliseconds
-endAt?: number; // milliseconds
-⋮----
-pageSize?: number; // Default 50, max 200
-⋮----
-export interface GetTradeHistoryRequestUTA {
-  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS';
-  symbol?: string; // Required for SPOT, ISOLATED, and CROSS
-  orderId?: string;
-  side?: 'BUY' | 'SELL';
-  type?: 'LIMIT' | 'MARKET';
-  startAt?: number; // milliseconds
-  endAt?: number; // milliseconds
-  lastId?: string;
-  pageSize?: number; // Default 50, max 200
-}
-⋮----
-symbol?: string; // Required for SPOT, ISOLATED, and CROSS
-⋮----
-startAt?: number; // milliseconds
-endAt?: number; // milliseconds
-⋮----
-pageSize?: number; // Default 50, max 200
-⋮----
-export interface CancelOrderRequestUTA {
-  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS';
-  symbol: string; // For FUTURES optional for single order cancellation (ignored if orderId provided); For UTA FUTURES, required
-  orderId?: string; // At least one of orderId or clientOid required
-  clientOid?: string; // At least one of orderId or clientOid required
-}
-⋮----
-symbol: string; // For FUTURES optional for single order cancellation (ignored if orderId provided); For UTA FUTURES, required
-orderId?: string; // At least one of orderId or clientOid required
-clientOid?: string; // At least one of orderId or clientOid required
-⋮----
-export interface CancelOrderItemRequestUTA {
-  symbol: string;
-  orderId?: string; // At least one of orderId or clientOid required
-  clientOid?: string; // At least one of orderId or clientOid required
-}
-⋮----
-orderId?: string; // At least one of orderId or clientOid required
-clientOid?: string; // At least one of orderId or clientOid required
-⋮----
-export interface BatchCancelOrdersRequestUTA {
-  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS';
-  cancelOrderList: CancelOrderItemRequestUTA[]; // Maximum 20 orders
-}
-⋮----
-cancelOrderList: CancelOrderItemRequestUTA[]; // Maximum 20 orders
-⋮----
-/** Batch cancel orders by symbol (POST /order/cancel-all) */
-export interface BatchCancelOrdersBySymbolRequestUTA {
-  tradeType: 'SPOT' | 'FUTURES' | 'MARGIN';
-  symbol: string;
-  marginMode?: 'CROSS' | 'ISOLATED';
-  orderFilter?: 'NORMAL' | 'ADVANCED';
-}
-⋮----
-export interface SetDCPRequestUTA {
-  tradeType: 'SPOT' | 'FUTURES' | 'MARGIN';
-  timeout: number; // Range: timeout=-1 (unset) or 5 <= timeout <= 86400 seconds
-  symbols?: string[]; // Up to 50 trading pairs. Empty means all trading pairs
-}
-⋮----
-timeout: number; // Range: timeout=-1 (unset) or 5 <= timeout <= 86400 seconds
-symbols?: string[]; // Up to 50 trading pairs. Empty means all trading pairs
-⋮----
-export interface GetDCPRequestUTA {
-  tradeType: 'SPOT' | 'FUTURES' | 'MARGIN';
-}
-⋮----
-/**
- * Position Endpoints
+ *
+ * Sub-Account API
+ *
+ *
  */
 ⋮----
-export interface GetPositionListRequestUTA {
-  symbol?: string; // Optional, if not provided returns all open positions
+export interface SubAccountAPIInfo {
+  subName: string;
+  remark: string;
+  apiKey: string;
+  apiVersion: number;
+  permission: string;
+  ipWhitelist: string;
+  createdAt: number;
+  uid: number;
+  isMaster: boolean;
 }
 ⋮----
-symbol?: string; // Optional, if not provided returns all open positions
-⋮----
-export interface GetPositionsHistoryRequestUTA {
-  symbol?: string;
-  startAt?: number; // milliseconds
-  endAt?: number; // milliseconds
-  lastId?: number; // For cursor-based pagination
-  pageSize?: number; // Default 10, max 200
+export interface CreateSubAPI {
+  subName: string;
+  remark: string;
+  apiKey: string;
+  apiSecret: string;
+  apiVersion: number;
+  passphrase: string;
+  permission: string;
+  createdAt: number;
 }
 ⋮----
-startAt?: number; // milliseconds
-endAt?: number; // milliseconds
-lastId?: number; // For cursor-based pagination
-pageSize?: number; // Default 10, max 200
-⋮----
-export interface GetAccountPositionTiersRequestUTA {
-  symbol: string; // Supports up to 10 symbols, comma-separated
-  tradeType?: 'FUTURES' | 'MARGIN'; // Not support margin for the time being
-  marginMode?: 'ISOLATED' | 'CROSS'; // Not support cross for the time being
-  data?: 'RISK_LIMIT' | 'BORROW'; // Not support borrow for the time being
+export interface UpdateSubAPI {
+  apiKey: string;
+  ipWhitelist: string;
+  permission: string;
+  subName: string;
 }
 ⋮----
-symbol: string; // Supports up to 10 symbols, comma-separated
-tradeType?: 'FUTURES' | 'MARGIN'; // Not support margin for the time being
-marginMode?: 'ISOLATED' | 'CROSS'; // Not support cross for the time being
-data?: 'RISK_LIMIT' | 'BORROW'; // Not support borrow for the time being
+export interface DeleteSubAccountAPI {
+  subName: string;
+  apiKey: string;
+}
+⋮----
+/**
+ * Get KYC Regions Response
+ */
+export interface KYCRegion {
+  code: string; // Two-letter country code
+  enName: string; // English name of the region
+}
+⋮----
+code: string; // Two-letter country code
+enName: string; // English name of the region
+⋮----
+/**
+ * Get API Key Info Response
+ */
+export interface ApiKeyInfo {
+  uid: number; // Account UID
+  parentUid?: number; // Master account UID. Returns empty when called by the master account itself
+  region: string; // KYC region of the account, returns the two-letter country code
+  kycStatus: 0 | 1; // KYC status
+  subName?: string; // Sub-account name (not present for the master account)
+  remark: string; // Remarks
+  apiKey: string; // API key
+  apiVersion: number; // API version
+  permission: string; // Permissions
+  ipWhitelist?: string; // IP whitelist (comma-separated list of allowed IPs)
+  isMaster: boolean; // Indicates whether this is the master account
+  createdAt: number; // API key creation timestamp (Unix milliseconds)
+  expiredAt?: number | null; // API key expiration timestamp (Unix milliseconds). Returns null if no expiration is set
+  thirdPartyApp?: string; // Third-party application name. Returns empty string if not associated with any third-party app
+  siteType?: 'global' | 'turkey' | 'australia' | 'europe' | 'thailand'; // Site Type
+}
+⋮----
+uid: number; // Account UID
+parentUid?: number; // Master account UID. Returns empty when called by the master account itself
+region: string; // KYC region of the account, returns the two-letter country code
+kycStatus: 0 | 1; // KYC status
+subName?: string; // Sub-account name (not present for the master account)
+remark: string; // Remarks
+apiKey: string; // API key
+apiVersion: number; // API version
+permission: string; // Permissions
+ipWhitelist?: string; // IP whitelist (comma-separated list of allowed IPs)
+isMaster: boolean; // Indicates whether this is the master account
+createdAt: number; // API key creation timestamp (Unix milliseconds)
+expiredAt?: number | null; // API key expiration timestamp (Unix milliseconds). Returns null if no expiration is set
+thirdPartyApp?: string; // Third-party application name. Returns empty string if not associated with any third-party app
+siteType?: 'global' | 'turkey' | 'australia' | 'europe' | 'thailand'; // Site Type
 
 ================
 File: src/types/response/spot-margin-trading.ts
@@ -7499,708 +7108,6 @@ currency: string; // Currency
 borrowableAmount: string; // Borrowable Amount
 
 ================
-File: src/types/response/uta-types.ts
-================
-/**
- * Unified Trading Account Response Types
- */
-⋮----
-export interface AnnouncementItemUTA {
-  id: number;
-  title: string;
-  type: string[];
-  description: string;
-  releaseTime: number;
-  language: string;
-  url: string;
-}
-⋮----
-export interface GetAnnouncementsResponseUTA {
-  totalNumber: number;
-  totalPage: number;
-  pageNumber: number;
-  pageSize: number;
-  list: AnnouncementItemUTA[];
-}
-⋮----
-export interface CurrencyChainUTA {
-  chainName: string;
-  minWithdrawSize: string | null;
-  minDepositSize: string | null;
-  withdrawFeeRate: string;
-  minWithdrawFee: string;
-  isWithdrawEnabled: boolean;
-  isDepositEnabled: boolean;
-  confirms: number;
-  preConfirms: number;
-  contractAddress: string;
-  withdrawPrecision: number;
-  maxWithdrawSize: string | null;
-  maxDepositSize: string | null;
-  needTag: boolean;
-  chainId: string;
-}
-⋮----
-export interface GetCurrencyResponseUTA {
-  currency: string;
-  name: string;
-  fullName: string;
-  precision: number;
-  confirms: number | null;
-  contractAddress: string | null;
-  isMarginEnabled: boolean;
-  isDebitEnabled: boolean;
-  list: CurrencyChainUTA[];
-}
-⋮----
-export interface SymbolUTA {
-  symbol: string;
-  name?: string;
-  baseCurrency: string;
-  quoteCurrency: string;
-  market?: string;
-  minBaseOrderSize?: string;
-  minQuoteOrderSize?: string;
-  maxBaseOrderSize?: string | number;
-  maxQuoteOrderSize?: string;
-  baseOrderStep?: string;
-  quoteOrderStep?: string;
-  tickSize?: string | number;
-  feeCurrency?: string;
-  tradingStatus?: string;
-  marginMode?: string;
-  priceLimitRatio?: string;
-  feeCategory?: number;
-  makerFeeCoefficient?: string;
-  takerFeeCoefficient?: string;
-  st?: boolean;
-  settlementCurrency?: string;
-  contractType?: string;
-  isInverse?: boolean;
-  launchTime?: number;
-  expiryTime?: number | null;
-  settlementTime?: number | null;
-  maxPrice?: string | number;
-  lotSize?: string | number;
-  /**
-   * Unit size. As of 2026.01.12:
-   * - For inverse contracts: changed from -1 to 1 (1 contract = 1 USD)
-   * - For Futures: unitSize indicates contract size
-   */
-  unitSize?: string | number;
-  makerFeeRate?: string | number;
-  takerFeeRate?: string | number;
-  settlementFeeRate?: string | number | null;
-  maxLeverage?: number;
-  indexSourceExchanges?: string[];
-  k?: string | number;
-  m?: string | number;
-  f?: string | number;
-  mmrLimit?: string | number;
-  mmrLevConstant?: string | number;
-  alertRiskRatio?: string;
-  liquidationRiskRatio?: string;
-  baseBorrowEnable?: boolean | string;
-  quoteBorrowEnable?: boolean | string;
-  baseTransferInEnable?: boolean | string;
-  quoteTransferInEnable?: boolean | string;
-  /** Display symbol for Futures (added 2025.12.26 & 2026.01.12) */
-  displaySymbol?: string;
-  /** Display base currency for Futures (added 2025.12.26 & 2026.01.12) */
-  displayBaseCurrency?: string;
-}
-⋮----
-/**
-   * Unit size. As of 2026.01.12:
-   * - For inverse contracts: changed from -1 to 1 (1 contract = 1 USD)
-   * - For Futures: unitSize indicates contract size
-   */
-⋮----
-/** Display symbol for Futures (added 2025.12.26 & 2026.01.12) */
-⋮----
-/** Display base currency for Futures (added 2025.12.26 & 2026.01.12) */
-⋮----
-export interface GetSymbolResponseUTA {
-  tradeType: string;
-  list: SymbolUTA[];
-}
-⋮----
-export interface TickerUTA {
-  symbol: string;
-  name?: string;
-  bestBidPrice: string;
-  bestBidSize: string;
-  bestAskPrice: string;
-  bestAskSize: string;
-  high: string;
-  low: string;
-  baseVolume: string;
-  quoteVolume: string;
-  lastPrice: string;
-  open: string;
-  size: string;
-}
-⋮----
-export interface GetTickerResponseUTA {
-  tradeType: string;
-  /** Timestamp in nanoseconds (as of 2026.01.12) */
-  ts: number;
-  list: TickerUTA[];
-}
-⋮----
-/** Timestamp in nanoseconds (as of 2026.01.12) */
-⋮----
-export interface TradeUTA {
-  sequence: string | number;
-  tradeId: string;
-  price: string;
-  size: string;
-  side: 'buy' | 'sell';
-  /** Timestamp in nanoseconds */
-  ts: number;
-  /** Whether it is an RPI trade (Futures only) */
-  isRpiTrade?: boolean;
-}
-⋮----
-/** Timestamp in nanoseconds */
-⋮----
-/** Whether it is an RPI trade (Futures only) */
-⋮----
-export interface GetTradesResponseUTA {
-  tradeType: string;
-  list: TradeUTA[];
-}
-⋮----
-export interface GetOrderBookResponseUTA {
-  tradeType: string;
-  symbol: string;
-  /** Sequence number. Changed from string to number for Spot as of 2026.01.17 */
-  sequence: number;
-  /**
-   * Bids array, ordered from high to low.
-   * When rpiFilter=0 (or not set): each entry is [price, size]
-   * When rpiFilter=1: each entry is [price, noneRPISize, RPISize]
-   * As of 2026.01.17: All values are strings
-   */
-  bids: string[][];
-  /**
-   * Asks array, ordered from low to high.
-   * When rpiFilter=0 (or not set): each entry is [price, size]
-   * When rpiFilter=1: each entry is [price, noneRPISize, RPISize]
-   * As of 2026.01.17: All values are strings
-   */
-  asks: string[][];
-  /** Timestamp in nanoseconds (Futures only) */
-  ts?: number;
-}
-⋮----
-/** Sequence number. Changed from string to number for Spot as of 2026.01.17 */
-⋮----
-/**
-   * Bids array, ordered from high to low.
-   * When rpiFilter=0 (or not set): each entry is [price, size]
-   * When rpiFilter=1: each entry is [price, noneRPISize, RPISize]
-   * As of 2026.01.17: All values are strings
-   */
-⋮----
-/**
-   * Asks array, ordered from low to high.
-   * When rpiFilter=0 (or not set): each entry is [price, size]
-   * When rpiFilter=1: each entry is [price, noneRPISize, RPISize]
-   * As of 2026.01.17: All values are strings
-   */
-⋮----
-/** Timestamp in nanoseconds (Futures only) */
-⋮----
-export interface GetKlinesResponseUTA {
-  tradeType: string;
-  symbol: string;
-  list: string[][]; // [time, open, close, high, low, volume, turnover]
-}
-⋮----
-list: string[][]; // [time, open, close, high, low, volume, turnover]
-⋮----
-export interface GetCurrentFundingRateResponseUTA {
-  symbol: string;
-  nextFundingRate: number;
-  fundingTime: number;
-  fundingRateCap: number;
-  fundingRateFloor: number;
-}
-⋮----
-export interface FundingRateHistoryItemUTA {
-  fundingRate: number;
-  ts: number;
-}
-⋮----
-export interface GetHistoryFundingRateResponseUTA {
-  symbol: string;
-  list: FundingRateHistoryItemUTA[];
-}
-⋮----
-export interface GetCrossMarginConfigResponseUTA {
-  maxLeverage: number;
-  alertRiskRatio: string;
-  liquidationRiskRatio: string;
-  currencyList: string[];
-}
-⋮----
-export interface GetServiceStatusResponseUTA {
-  tradeType: string;
-  serverStatus: 'open' | 'close' | 'cancelonly';
-  msg: string;
-}
-⋮----
-/**
- * Account Response Types
- */
-⋮----
-export interface AccountCurrencyUTA {
-  currency: string;
-  hold: string;
-  available: string;
-  balance: string;
-  equity: string;
-  liability?: string;
-  totalCrossMargin?: string;
-  crossPosMargin?: string;
-  crossOrderMargin?: string;
-  crossUnPnl?: string;
-  isolatedPosMargin?: string;
-  isolatedOrderMargin?: string;
-  isolatedFundingFeeMargin?: string;
-  isolatedUnPnl?: string;
-  liabilityPrinciple?: string;
-  liabilityInterest?: string;
-  unrealisedPnl?: string;
-}
-⋮----
-export interface AccountDataUTA {
-  accountSubtype?: string; // For ISOLATED (trading pair) or FUTURES (settlement currency)
-  riskRatio?: string;
-  currencies: AccountCurrencyUTA[];
-}
-⋮----
-accountSubtype?: string; // For ISOLATED (trading pair) or FUTURES (settlement currency)
-⋮----
-export interface GetClassicAccountResponseUTA {
-  accountType: string;
-  ts: number;
-  accounts: AccountDataUTA[];
-}
-⋮----
-export interface GetAccountOverviewResponseUTA {
-  accountType: string;
-  riskRatio: string;
-  equity: string;
-  liability: string;
-  availableMargin: string;
-  adjustedEquity: string;
-  im: string;
-  mm: string;
-}
-⋮----
-export interface SubAccountUserUTA {
-  uid: number;
-  accountList: {
-    accountType:
-      | 'FUNDING'
-      | 'SPOT'
-      | 'FUTURES'
-      | 'CROSS'
-      | 'ISOLATED'
-      | 'OPTIONS'
-      | 'UNIFIED';
-    accountSubType: string | null;
-    currencyList: AccountCurrencyUTA[];
-  }[];
-}
-⋮----
-export interface GetSubAccountResponseUTA {
-  ts: number;
-  userList: SubAccountUserUTA[];
-}
-⋮----
-export interface GetTransferQuotasResponseUTA {
-  currency: string;
-  transferable: string;
-  accountType: string;
-}
-⋮----
-export interface FlexTransferResponseUTA {
-  orderId: string;
-  clientOid: string;
-}
-⋮----
-export interface SubAccountTransferPermissionUTA {
-  subUid: string;
-  subToSub: boolean;
-}
-⋮----
-export interface GetAccountModeResponseUTA {
-  selfAccountMode: 'CLASSIC' | 'UNIFIED';
-  unifiedSubAccount: number[];
-  classicSubAccount: number[];
-}
-⋮----
-export interface FeeRateItemUTA {
-  symbol: string;
-  takerFeeRate: string;
-  makerFeeRate: string;
-}
-⋮----
-export interface GetFeeRateResponseUTA {
-  tradeType: string;
-  list: FeeRateItemUTA[];
-}
-⋮----
-export interface AccountLedgerItemUTA {
-  accountType:
-    | 'FUNDING'
-    | 'SPOT'
-    | 'FUTURES'
-    | 'CROSS'
-    | 'ISOLATED'
-    | 'UNIFIED';
-  id: string;
-  currency: string;
-  direction: 'IN' | 'OUT';
-  businessType: string;
-  amount: string;
-  balance: string;
-  fee: string;
-  tax: string;
-  remark: string;
-  /** Timestamp in nanoseconds (standardized as of 2026.01.12) */
-  ts: number;
-}
-⋮----
-/** Timestamp in nanoseconds (standardized as of 2026.01.12) */
-⋮----
-export interface GetAccountLedgerResponseUTA {
-  lastId?: number;
-  items?: AccountLedgerItemUTA[];
-}
-⋮----
-export type GetAccountLedgerResponseClassicUTA = AccountLedgerItemUTA[];
-⋮----
-export interface InterestHistoryItemUTA {
-  liability: string;
-  interest: string;
-  hourlyInterestRate: string;
-  currency: string;
-  ts: number;
-  interestFreeLiability: string;
-}
-⋮----
-export interface GetInterestHistoryResponseUTA {
-  items: InterestHistoryItemUTA[];
-  lastId: number;
-}
-⋮----
-export interface DepositAddressUTA {
-  address: string;
-  memo: string;
-  chainId: string;
-  to: 'MAIN' | 'TRADE';
-  currency: string;
-  contractAddress: string;
-  chainName: string;
-  expirationDate: string;
-  remark: string;
-}
-⋮----
-/**
- * Order Response Types
- */
-⋮----
-export interface PlaceOrderResponseUTA {
-  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS';
-  orderId: string;
-  clientOid: string;
-  /** Timestamp when system completes order request in nanoseconds. Classic mode not supported */
-  ts?: number;
-  /** Borrow amount. Unified mode not supported */
-  borrowSize?: string;
-  /** Loan order ID. Unified mode not supported */
-  loanApplyId?: string;
-}
-⋮----
-/** Timestamp when system completes order request in nanoseconds. Classic mode not supported */
-⋮----
-/** Borrow amount. Unified mode not supported */
-⋮----
-/** Loan order ID. Unified mode not supported */
-⋮----
-export interface BatchPlaceOrderItemResponseUTA {
-  orderId?: string;
-  clientOid?: string;
-  symbol?: string;
-  code?: string;
-  msg?: string;
-}
-⋮----
-export interface BatchPlaceOrderResponseUTA {
-  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS';
-  items: BatchPlaceOrderItemResponseUTA[];
-}
-⋮----
-export interface OrderDetailsUTA {
-  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS';
-  orderId: string;
-  clientOid: string;
-  /**
-   * Order status:
-   * - 0: notTriggered (conditional order, not triggered)
-   * - 1: triggered (conditional order, triggered but not live)
-   * - 2: live (not filled)
-   * - 3: filled (fully filled)
-   * - 4: partial filled (partially filled, still active)
-   * - 5: canceled (no fills, fully canceled)
-   * - 6: partial canceled (partially filled, remainder canceled)
-   * Changed from String to Number for UTA as of 2026.01.17
-   */
-  status: number;
-  filledSize: string;
-  avgPrice: string;
-  fee: string;
-  feeCurrency: string;
-  tax: string;
-  tradeId: string;
-  symbol: string;
-  side: 'BUY' | 'SELL';
-  positionSide?: 'BOTH' | 'LONG' | 'SHORT';
-  orderType: 'LIMIT' | 'MARKET';
-  size: string;
-  sizeUnit: 'BASECCY' | 'QUOTECCY' | 'UNIT';
-  price: string;
-  leverage?: string;
-  reduceOnly?: boolean;
-  marginMode?: 'ISOLATED' | 'CROSS';
-  stp?: 'DC' | 'CO' | 'CN' | 'CB' | '';
-  /**
-   * Time in Force. Added 'RPI' as of 2025.01.02
-   */
-  timeInForce: 'GTC' | 'IOC' | 'GTT' | 'FOK' | 'RPI';
-  cancelReason?: number;
-  cancelSize: string;
-  cancelAfter?: number;
-  triggerDirection?: 'UP' | 'DOWN';
-  triggerPrice?: string;
-  triggerPriceType?: 'TP' | 'IP' | 'MP';
-  tpTriggerPrice?: string;
-  tpTriggerPriceType?: 'TP' | 'IP' | 'MP';
-  tpOrderPrice?: string;
-  slTriggerPrice?: string;
-  slTriggerPriceType?: 'TP' | 'IP' | 'MP';
-  slOrderPrice?: string;
-  postOnly?: boolean;
-  tags?: string;
-  triggerOrderId?: string;
-  /** Order creation time in nanoseconds (standardized as of 2026.01.12) */
-  orderTime: number;
-  /** Latest order update time in nanoseconds (standardized as of 2026.01.12) */
-  updatedTime: number;
-}
-⋮----
-/**
-   * Order status:
-   * - 0: notTriggered (conditional order, not triggered)
-   * - 1: triggered (conditional order, triggered but not live)
-   * - 2: live (not filled)
-   * - 3: filled (fully filled)
-   * - 4: partial filled (partially filled, still active)
-   * - 5: canceled (no fills, fully canceled)
-   * - 6: partial canceled (partially filled, remainder canceled)
-   * Changed from String to Number for UTA as of 2026.01.17
-   */
-⋮----
-/**
-   * Time in Force. Added 'RPI' as of 2025.01.02
-   */
-⋮----
-/** Order creation time in nanoseconds (standardized as of 2026.01.12) */
-⋮----
-/** Latest order update time in nanoseconds (standardized as of 2026.01.12) */
-⋮----
-export interface GetOpenOrderListResponseUTA {
-  pageNumber: number;
-  pageSize?: number;
-  totalNum?: number;
-  totalPage?: number;
-  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS';
-  items: OrderDetailsUTA[];
-}
-⋮----
-export interface GetOrderHistoryResponseUTA {
-  lastId: number;
-  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS';
-  items: OrderDetailsUTA[];
-}
-⋮----
-export interface TradeHistoryItemUTA {
-  tradeId: string;
-  orderId: string;
-  symbol: string;
-  side: 'BUY' | 'SELL';
-  positionSide?: 'BOTH' | 'LONG' | 'SHORT';
-  type: 'LIMIT' | 'MARKET';
-  price: string;
-  size: string;
-  sizeUnit: 'BASECCY' | 'QUOTECCY' | 'UNIT';
-  value: string;
-  feeRate: string;
-  fee: string;
-  feeCurrency: string;
-  tax: string;
-  liquidity: 'TAKER' | 'MAKER';
-  /** Execution time in nanoseconds (standardized as of 2026.01.12) */
-  executionTime: number;
-  /** Whether it is an RPI trade (added 2025.01.02, Futures only) */
-  isRpiTrade?: boolean;
-}
-⋮----
-/** Execution time in nanoseconds (standardized as of 2026.01.12) */
-⋮----
-/** Whether it is an RPI trade (added 2025.01.02, Futures only) */
-⋮----
-export interface GetTradeHistoryResponseUTA {
-  lastId: number;
-  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS';
-  items: TradeHistoryItemUTA[];
-}
-⋮----
-export interface CancelOrderResponseUTA {
-  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS';
-  orderId?: string;
-  clientOid?: string;
-  /** Timestamp when system completes order cancellation request (nanoseconds). Only for unified accounts */
-  ts?: number;
-}
-⋮----
-/** Timestamp when system completes order cancellation request (nanoseconds). Only for unified accounts */
-⋮----
-export interface BatchCancelOrderItemResponseUTA {
-  code?: string;
-  msg?: string;
-  orderId?: string;
-  clientOid?: string;
-  /** Timestamp when system completes order cancellation request (nanoseconds). Not supported for classic accounts */
-  ts?: number;
-}
-⋮----
-/** Timestamp when system completes order cancellation request (nanoseconds). Not supported for classic accounts */
-⋮----
-export interface BatchCancelOrdersResponseUTA {
-  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS';
-  items: BatchCancelOrderItemResponseUTA[];
-}
-⋮----
-/** Batch cancel by symbol - Classic response (orderId list) */
-export interface BatchCancelOrdersBySymbolItemClassicUTA {
-  orderId: string;
-}
-⋮----
-/** Batch cancel by symbol - UTA response (full result per order) */
-export interface BatchCancelOrdersBySymbolItemUTA {
-  code?: string;
-  msg?: string;
-  orderId?: string;
-  ts?: number;
-  clientOid?: string | null;
-}
-⋮----
-export interface BatchCancelOrdersBySymbolResponseUTA {
-  tradeType: 'SPOT' | 'FUTURES' | 'MARGIN';
-  ts?: number;
-  items:
-    | BatchCancelOrdersBySymbolItemClassicUTA[]
-    | BatchCancelOrdersBySymbolItemUTA[];
-}
-⋮----
-export interface DCPResponseUTA {
-  tradeType: 'SPOT' | 'FUTURES' | 'MARGIN';
-  symbol: string[]; // Empty means effective for all symbols
-  systemTime: number; // Time when system received request (in seconds)
-  triggerTime: number; // Trigger cancellation time (in seconds)
-}
-⋮----
-symbol: string[]; // Empty means effective for all symbols
-systemTime: number; // Time when system received request (in seconds)
-triggerTime: number; // Trigger cancellation time (in seconds)
-⋮----
-/**
- * Position Response Types
- */
-⋮----
-export interface PositionUTA {
-  id: string;
-  symbol: string;
-  marginMode: 'CROSS' | 'ISOLATED';
-  size: string; // Positive = long, negative = short
-  entryPrice: string;
-  positionValue: string;
-  markPrice: string;
-  leverage: string;
-  unrealizedPnL: string;
-  realizedPnL: string;
-  initialMargin: string;
-  mmr: string; // Maintenance Margin Rate
-  maintenanceMargin: string;
-  /** Timestamp when position was first opened (nanoseconds, standardized as of 2026.01.12) */
-  creationTime: number;
-}
-⋮----
-size: string; // Positive = long, negative = short
-⋮----
-mmr: string; // Maintenance Margin Rate
-⋮----
-/** Timestamp when position was first opened (nanoseconds, standardized as of 2026.01.12) */
-⋮----
-export interface PositionHistoryItemUTA {
-  closeId: string;
-  symbol: string;
-  marginMode: 'CROSS' | 'ISOLATED';
-  side: 'LONG' | 'SHORT';
-  entryPrice: string;
-  closePrice: string;
-  avgClosePrice: string;
-  maxSize: string;
-  leverage: string;
-  realizedPnL: string;
-  fee: string;
-  tax: string;
-  fundingFee: string;
-  /** Position opening timestamp (nanoseconds, standardized as of 2026.01.12) */
-  creationTime: number;
-  /** Position closing timestamp (nanoseconds, standardized as of 2026.01.12) */
-  closingTime: number;
-}
-⋮----
-/** Position opening timestamp (nanoseconds, standardized as of 2026.01.12) */
-⋮----
-/** Position closing timestamp (nanoseconds, standardized as of 2026.01.12) */
-⋮----
-export interface GetPositionsHistoryResponseUTA {
-  items: PositionHistoryItemUTA[];
-  lastId?: number;
-}
-⋮----
-export interface PositionTierUTA {
-  symbol: string;
-  tier: number; // Current tier of user
-  maxSize: string; // Upper limit (USDT) (included)
-  minSize: string; // Lower limit (USDT)
-  maxLeverage: string;
-  initialMarginRate: string;
-  maintainMarginRate: string;
-}
-⋮----
-tier: number; // Current tier of user
-maxSize: string; // Upper limit (USDT) (included)
-minSize: string; // Lower limit (USDT)
-
-================
 File: src/index.ts
 ================
 
@@ -8286,7 +7193,7 @@ tradeType: 'SPOT', // SPOT / FUTURES / ISOLATED / CROSS / UNIFIED
 // Other markets for orderAll topic:
 // https://www.kucoin.com/docs-new/3470228w0
 ⋮----
-tradeType: 'FUTURES', // SPOT / FUTURES / ISOLATED / CROSS / UNIFIED
+tradeType: 'UNIFIED', // SPOT / FUTURES / ISOLATED / CROSS / UNIFIED
 ⋮----
 // Specific order updates for a given symbol:
 // https://www.kucoin.com/docs-new/3470228w0
@@ -8303,7 +7210,7 @@ tradeType: 'FUTURES', //  FUTURES / UNIFIED
 // Account balance updates:
 // https://www.kucoin.com/docs-new/3470231w0
 ⋮----
-accountType: 'TRADING', // TRADING / ISOLATED / CROSS / FUTURES / UNIFIED
+accountType: 'SPOT', // SPOT / ISOLATED / CROSS / FUTURES / UNIFIED
 ⋮----
 // Execution/trade updates:
 // https://www.kucoin.com/docs-new/3470232w0
@@ -8491,6 +7398,8 @@ async function start()
 ⋮----
 // BTCUSDT tickers for spot market
 // https://www.kucoin.com/docs-new/3470222w0
+⋮----
+// Multi-symbol ticker: use `symbols` instead of `symbol`
 ⋮----
 // BTCUSDT orderbook updates for spot market
 // https://www.kucoin.com/docs-new/3470221w0
@@ -8871,6 +7780,1367 @@ export interface CopyTradeSwitchPositionModeRequest {
 }
 ⋮----
 positionMode: '0' | '1'; // 0 = one-way mode, 1 = hedge mode
+
+================
+File: src/types/request/uta-types.ts
+================
+/**
+ * Unified Trading Account Request Types
+ */
+⋮----
+export interface GetAnnouncementsRequestUTA {
+  language?:
+    | 'zh_HK'
+    | 'ja_JP'
+    | 'ko_KR'
+    | 'en_US'
+    | 'pl_PL'
+    | 'es_ES'
+    | 'fr_FR'
+    | 'ar_AE'
+    | 'it_IT'
+    | 'id_ID'
+    | 'nl_NL'
+    | 'pt_PT'
+    | 'vi_VN'
+    | 'de_DE'
+    | 'tr_TR'
+    | 'ms_MY'
+    | 'ru_RU'
+    | 'th_TH'
+    | 'hi_IN'
+    | 'bn_BD'
+    | 'fil_PH'
+    | 'ur_PK';
+  type?:
+    | 'latest-announcements'
+    | 'activities'
+    | 'product-updates'
+    | 'vip'
+    | 'maintenance-updates'
+    | 'delistings'
+    | 'others'
+    | 'api-campaigns'
+    | 'new-listings'
+    | 'futures-announcements';
+  pageNumber?: number;
+  pageSize?: number;
+  startTime?: number;
+  endTime?: number;
+}
+⋮----
+export interface GetCurrencyRequestUTA {
+  currency?: string;
+  chain?: string;
+}
+⋮----
+export interface GetSymbolRequestUTA {
+  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS';
+  symbol?: string;
+}
+⋮----
+export interface GetTickerRequestUTA {
+  tradeType: 'SPOT' | 'FUTURES';
+  symbol?: string;
+}
+⋮----
+export interface GetTradesRequestUTA {
+  tradeType: 'SPOT' | 'FUTURES';
+  symbol: string;
+}
+⋮----
+export interface GetOrderBookRequestUTA {
+  tradeType: 'SPOT' | 'FUTURES';
+  symbol: string;
+  limit: '20' | '50' | '100' | 'FULL';
+  /**
+   * Whether it is an RPI Order. Applicable to FUTURES only.
+   * 0: noneRPI Orders (default)
+   * 1: noneRPI + RPI Orders
+   */
+  rpiFilter?: 0 | 1;
+}
+⋮----
+/**
+   * Whether it is an RPI Order. Applicable to FUTURES only.
+   * 0: noneRPI Orders (default)
+   * 1: noneRPI + RPI Orders
+   */
+⋮----
+export interface GetKlinesRequestUTA {
+  tradeType: 'SPOT' | 'FUTURES';
+  symbol: string;
+  interval:
+    | '1min'
+    | '3min'
+    | '5min'
+    | '15min'
+    | '30min'
+    | '1hour'
+    | '2hour'
+    | '4hour'
+    | '6hour'
+    | '8hour'
+    | '12hour'
+    | '1day'
+    | '1week'
+    | '1month';
+  startAt?: number;
+  endAt?: number;
+}
+⋮----
+export interface GetCurrentFundingRateRequestUTA {
+  symbol: string;
+}
+⋮----
+export interface GetHistoryFundingRateRequestUTA {
+  symbol: string;
+  startAt: number;
+  endAt: number;
+}
+⋮----
+export interface GetServiceStatusRequestUTA {
+  tradeType: 'SPOT' | 'FUTURES';
+}
+⋮----
+/**
+ * Account Endpoints
+ */
+⋮----
+export interface GetClassicAccountRequestUTA {
+  accountType: 'FUNDING' | 'SPOT' | 'FUTURES' | 'CROSS' | 'ISOLATED';
+  accountSubtype?: string; // For ISOLATED (trading pair) or FUTURES (settlement currency)
+  currency?: string; // Up to 20 currencies, comma-separated
+}
+⋮----
+accountSubtype?: string; // For ISOLATED (trading pair) or FUTURES (settlement currency)
+currency?: string; // Up to 20 currencies, comma-separated
+⋮----
+export interface GetSubAccountRequestUTA {
+  UID?: string; // Up to 50 UIDs, comma-separated
+  pageSize?: number; // Default 10, max 50
+  lastId?: number;
+}
+⋮----
+UID?: string; // Up to 50 UIDs, comma-separated
+pageSize?: number; // Default 10, max 50
+⋮----
+export interface GetTransferQuotasRequestUTA {
+  currency: string;
+  accountType:
+    | 'FUNDING'
+    | 'SPOT'
+    | 'FUTURES'
+    | 'CROSS'
+    | 'ISOLATED'
+    | 'UNIFIED';
+  symbol?: string; // Required when accountType is ISOLATED
+}
+⋮----
+symbol?: string; // Required when accountType is ISOLATED
+⋮----
+export interface FlexTransferRequestUTA {
+  clientOid: string;
+  currency: string;
+  amount: string;
+  type: '0' | '1' | '2' | '3'; // 0=INTERNAL, 1=PARENT_TO_SUB, 2=SUB_TO_PARENT, 3=SUB_TO_SUB
+  fromAccountType:
+    | 'FUNDING'
+    | 'SPOT'
+    | 'FUTURES'
+    | 'CROSS'
+    | 'ISOLATED'
+    | 'UNIFIED';
+  toAccountType:
+    | 'FUNDING'
+    | 'SPOT'
+    | 'FUTURES'
+    | 'CROSS'
+    | 'ISOLATED'
+    | 'UNIFIED';
+  fromAccountSymbol?: string; // Required when fromAccountType is ISOLATED
+  toAccountSymbol?: string; // Required when toAccountType is ISOLATED
+  fromUid?: string; // Required for SUB transfers
+  toUid?: string; // Required for SUB transfers
+}
+⋮----
+type: '0' | '1' | '2' | '3'; // 0=INTERNAL, 1=PARENT_TO_SUB, 2=SUB_TO_PARENT, 3=SUB_TO_SUB
+⋮----
+fromAccountSymbol?: string; // Required when fromAccountType is ISOLATED
+toAccountSymbol?: string; // Required when toAccountType is ISOLATED
+fromUid?: string; // Required for SUB transfers
+toUid?: string; // Required for SUB transfers
+⋮----
+export interface SetSubAccountTransferPermissionRequestUTA {
+  subUids: string; // Comma-separated sub account UIDs
+  subToSub: boolean;
+}
+⋮----
+subUids: string; // Comma-separated sub account UIDs
+⋮----
+export interface SetAccountModeRequestUTA {
+  accountType: 'CLASSIC' | 'UNIFIED';
+}
+⋮----
+export interface GetFeeRateRequestUTA {
+  tradeType: 'SPOT' | 'FUTURES';
+  symbol: string; // Spot: up to 10 symbols comma-separated, Futures: 1 symbol only
+}
+⋮----
+symbol: string; // Spot: up to 10 symbols comma-separated, Futures: 1 symbol only
+⋮----
+export interface GetAccountLedgerRequestUTA {
+  accountType:
+    | 'FUNDING'
+    | 'SPOT'
+    | 'FUTURES'
+    | 'CROSS'
+    | 'ISOLATED'
+    | 'UNIFIED';
+  currency?: string; // Up to 10 currencies, comma-separated
+  direction?: 'IN' | 'OUT';
+  businessType?:
+    | 'TRADE_EXCHANGE'
+    | 'TRANSFER'
+    | 'SUB_TRANSFER'
+    | 'RETURNED_FEES'
+    | 'DEDUCTION_FEES'
+    | 'OTHER'
+    | 'SUB_TO_SUB_TRANSFER'
+    | 'SPOT_EXCHANGE'
+    | 'SPOT_EXCHANGE_REBATE'
+    | 'FUTURES_EXCHANGE_OPEN'
+    | 'FUTURES_EXCHANGE_CLOSE'
+    | 'FUTURES_EXCHANGE_REBATE'
+    | 'FUNDING_FEE'
+    | 'LIABILITY_INTEREST'
+    | 'KCS_DEDUCTION_FEES'
+    | 'KCS_RETURNED_FEES'
+    | 'AUTO_EXCHANGE_USER';
+  lastId?: number;
+  startAt?: number; // milliseconds
+  endAt?: number; // milliseconds
+  pageSize?: number; // Default 100, max 200
+}
+⋮----
+currency?: string; // Up to 10 currencies, comma-separated
+⋮----
+startAt?: number; // milliseconds
+endAt?: number; // milliseconds
+pageSize?: number; // Default 100, max 200
+⋮----
+export interface GetInterestHistoryRequestUTA {
+  accountType: 'UNIFIED';
+  currency?: string;
+  startTime?: number; // milliseconds
+  endTime?: number; // milliseconds
+  page?: number;
+  size?: number; // Default 50, max 1000
+}
+⋮----
+startTime?: number; // milliseconds
+endTime?: number; // milliseconds
+⋮----
+size?: number; // Default 50, max 1000
+⋮----
+export interface GetBorrowingRatesAndLimitsRequestUTA {
+  currency: string;
+}
+⋮----
+export interface ModifyLeverageRequestUTA {
+  symbol: string;
+  leverage: string;
+}
+⋮----
+/** UTA cross margin only — path includes accountMode (typically unified) */
+export interface ModifyMarginCrossLeverageRequestUTA {
+  leverage: string;
+  /** Cross margin currency (e.g. BTC) */
+  currency?: string;
+}
+⋮----
+/** Cross margin currency (e.g. BTC) */
+⋮----
+export interface GetLeverageRequestUTA {
+  tradeType: 'MARGIN' | 'FUTURES';
+  marginMode: 'CROSS' | 'ISOLATED';
+  /** Required for MARGIN when not returning all; optional => all for MARGIN */
+  currency?: string;
+  /** Required for FUTURES when not returning all; optional => all for FUTURES */
+  symbol?: string;
+}
+⋮----
+/** Required for MARGIN when not returning all; optional => all for MARGIN */
+⋮----
+/** Required for FUTURES when not returning all; optional => all for FUTURES */
+⋮----
+export interface GetDepositAddressRequestUTA {
+  currency: string;
+  chain?: string; // If both currency and chain provided, address will be created if not exists
+}
+⋮----
+chain?: string; // If both currency and chain provided, address will be created if not exists
+⋮----
+/**
+ * Order Endpoints
+ */
+⋮----
+export interface PlaceOrderRequestUTA {
+  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS' | 'MARGIN';
+  clientOid?: string; // Mandatory for futures and margin; optional otherwise. Max 40 chars
+  symbol: string;
+  side: 'BUY' | 'SELL';
+  positionSide?: 'BOTH' | 'LONG' | 'SHORT'; // For Classic Futures only
+  orderType: 'LIMIT' | 'MARKET';
+  size: string;
+  sizeUnit: 'BASECCY' | 'QUOTECCY' | 'UNIT'; // Required for UTA, UNIT for Futures
+  price?: string;
+  leverage?: number; // Only for Classic Mode isolated margin
+  reduceOnly?: boolean; // Only for Futures
+  marginMode?: 'ISOLATED' | 'CROSS'; // Only for Classic Futures
+  stp?: 'DC' | 'CO' | 'CN' | 'CB';
+  /**
+   * Time in Force. Added 'RPI' as of 2025.01.02
+   * - GTC: Good Till Cancel (default)
+   * - FOK: Fill Or Kill
+   * - IOC: Immediate Or Cancel
+   * - GTT: Good Till Time (not supported for Futures)
+   * - RPI: Retail Price Improvement Order (Phase 1: Futures only)
+   */
+  timeInForce?: 'GTC' | 'IOC' | 'GTT' | 'FOK' | 'RPI';
+  cancelAfter?: number; // Only effective when timeInForce is GTT
+  postOnly?: boolean;
+  autoBorrow?: boolean; // Only for Isolated/Cross Margin (Classic only)
+  autoRepay?: boolean; // Only for Isolated/Cross Margin (Classic only)
+  tags?: string; // Max length 20
+  triggerDirection?: 'DOWN' | 'UP'; // Required when triggerPrice is set
+  triggerPrice?: string;
+  triggerPriceType?: 'TP' | 'IP' | 'MP'; // Only for Futures
+  tpTriggerPrice?: string; // Only for Futures
+  tpTriggerPriceType?: 'TP' | 'IP' | 'MP';
+  slTriggerPrice?: string; // Only for Futures
+  slTriggerPriceType?: 'TP' | 'IP' | 'MP';
+}
+⋮----
+clientOid?: string; // Mandatory for futures and margin; optional otherwise. Max 40 chars
+⋮----
+positionSide?: 'BOTH' | 'LONG' | 'SHORT'; // For Classic Futures only
+⋮----
+sizeUnit: 'BASECCY' | 'QUOTECCY' | 'UNIT'; // Required for UTA, UNIT for Futures
+⋮----
+leverage?: number; // Only for Classic Mode isolated margin
+reduceOnly?: boolean; // Only for Futures
+marginMode?: 'ISOLATED' | 'CROSS'; // Only for Classic Futures
+⋮----
+/**
+   * Time in Force. Added 'RPI' as of 2025.01.02
+   * - GTC: Good Till Cancel (default)
+   * - FOK: Fill Or Kill
+   * - IOC: Immediate Or Cancel
+   * - GTT: Good Till Time (not supported for Futures)
+   * - RPI: Retail Price Improvement Order (Phase 1: Futures only)
+   */
+⋮----
+cancelAfter?: number; // Only effective when timeInForce is GTT
+⋮----
+autoBorrow?: boolean; // Only for Isolated/Cross Margin (Classic only)
+autoRepay?: boolean; // Only for Isolated/Cross Margin (Classic only)
+tags?: string; // Max length 20
+triggerDirection?: 'DOWN' | 'UP'; // Required when triggerPrice is set
+⋮----
+triggerPriceType?: 'TP' | 'IP' | 'MP'; // Only for Futures
+tpTriggerPrice?: string; // Only for Futures
+⋮----
+slTriggerPrice?: string; // Only for Futures
+⋮----
+export interface BatchPlaceOrderRequestUTA {
+  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS' | 'MARGIN';
+  orderList: Omit<PlaceOrderRequestUTA, 'tradeType'>[];
+}
+⋮----
+export interface GetOrderDetailsRequestUTA {
+  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS' | 'MARGIN';
+  symbol: string;
+  orderId?: string; // At least one of orderId or clientOid required
+  clientOid?: string; // At least one of orderId or clientOid required
+}
+⋮----
+orderId?: string; // At least one of orderId or clientOid required
+clientOid?: string; // At least one of orderId or clientOid required
+⋮----
+export interface GetOpenOrderListRequestUTA {
+  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS' | 'MARGIN';
+  symbol?: string; // Required for SPOT, ISOLATED, and CROSS
+  orderFilter?: 'NORMAL' | 'CONDITION'; // Defaults to NORMAL
+  startAt?: number; // milliseconds
+  endAt?: number; // milliseconds
+  pageNumber?: number;
+  pageSize?: number; // Default 50, max 200
+}
+⋮----
+symbol?: string; // Required for SPOT, ISOLATED, and CROSS
+orderFilter?: 'NORMAL' | 'CONDITION'; // Defaults to NORMAL
+startAt?: number; // milliseconds
+endAt?: number; // milliseconds
+⋮----
+pageSize?: number; // Default 50, max 200
+⋮----
+export interface GetOrderHistoryRequestUTA {
+  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS' | 'MARGIN';
+  symbol?: string; // Required for SPOT, ISOLATED, and CROSS
+  side?: 'BUY' | 'SELL';
+  orderFilter?: 'NORMAL' | 'CONDITION'; // Defaults to NORMAL
+  startAt?: number; // milliseconds
+  endAt?: number; // milliseconds
+  lastId?: string;
+  pageSize?: number; // Default 50, max 200
+}
+⋮----
+symbol?: string; // Required for SPOT, ISOLATED, and CROSS
+⋮----
+orderFilter?: 'NORMAL' | 'CONDITION'; // Defaults to NORMAL
+startAt?: number; // milliseconds
+endAt?: number; // milliseconds
+⋮----
+pageSize?: number; // Default 50, max 200
+⋮----
+export interface GetTradeHistoryRequestUTA {
+  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS' | 'MARGIN';
+  symbol?: string; // Required for SPOT, ISOLATED, and CROSS
+  orderId?: string;
+  side?: 'BUY' | 'SELL';
+  type?: 'LIMIT' | 'MARKET';
+  startAt?: number; // milliseconds
+  endAt?: number; // milliseconds
+  lastId?: string;
+  pageSize?: number; // Default 50, max 200
+}
+⋮----
+symbol?: string; // Required for SPOT, ISOLATED, and CROSS
+⋮----
+startAt?: number; // milliseconds
+endAt?: number; // milliseconds
+⋮----
+pageSize?: number; // Default 50, max 200
+⋮----
+export interface CancelOrderRequestUTA {
+  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS' | 'MARGIN';
+  symbol: string; // For FUTURES optional for single order cancellation (ignored if orderId provided); For UTA FUTURES, required
+  orderId?: string; // At least one of orderId or clientOid required
+  clientOid?: string; // At least one of orderId or clientOid required
+}
+⋮----
+symbol: string; // For FUTURES optional for single order cancellation (ignored if orderId provided); For UTA FUTURES, required
+orderId?: string; // At least one of orderId or clientOid required
+clientOid?: string; // At least one of orderId or clientOid required
+⋮----
+export interface CancelOrderItemRequestUTA {
+  symbol: string;
+  orderId?: string; // At least one of orderId or clientOid required
+  clientOid?: string; // At least one of orderId or clientOid required
+}
+⋮----
+orderId?: string; // At least one of orderId or clientOid required
+clientOid?: string; // At least one of orderId or clientOid required
+⋮----
+export interface BatchCancelOrdersRequestUTA {
+  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS' | 'MARGIN';
+  cancelOrderList: CancelOrderItemRequestUTA[]; // Maximum 20 orders
+}
+⋮----
+cancelOrderList: CancelOrderItemRequestUTA[]; // Maximum 20 orders
+⋮----
+/** Batch cancel orders by symbol (POST /order/cancel-all) */
+export interface BatchCancelOrdersBySymbolRequestUTA {
+  tradeType: 'SPOT' | 'FUTURES' | 'MARGIN';
+  symbol: string;
+  marginMode?: 'CROSS' | 'ISOLATED';
+  orderFilter?: 'NORMAL' | 'ADVANCED';
+}
+⋮----
+export interface SetDCPRequestUTA {
+  tradeType: 'SPOT' | 'FUTURES' | 'MARGIN';
+  timeout: number; // Range: timeout=-1 (unset) or 5 <= timeout <= 86400 seconds
+  symbols?: string[]; // Up to 50 trading pairs. Empty means all trading pairs
+}
+⋮----
+timeout: number; // Range: timeout=-1 (unset) or 5 <= timeout <= 86400 seconds
+symbols?: string[]; // Up to 50 trading pairs. Empty means all trading pairs
+⋮----
+export interface GetDCPRequestUTA {
+  tradeType: 'SPOT' | 'FUTURES' | 'MARGIN';
+}
+⋮----
+/**
+ * Position Endpoints
+ */
+⋮----
+export interface GetPositionListRequestUTA {
+  symbol?: string; // Optional, if not provided returns all open positions
+  pageNumber?: number;
+  pageSize?: number;
+}
+⋮----
+symbol?: string; // Optional, if not provided returns all open positions
+⋮----
+/** Third-party custody (OES) custodian codes */
+export type ThirdPartyCustodyCustodianUTA =
+  | 'BITGO_SG'
+  | 'BITGO_SD'
+  | 'CACTUS'
+  | 'CEFFU';
+⋮----
+/**
+ * Get Third-Party Custody Currencies (public)
+ * Settlement currencies supported per custodian.
+ */
+export interface GetThirdPartyCustodyCurrenciesRequestUTA {
+  /** If omitted, returns all custodian rows */
+  custodian?: ThirdPartyCustodyCustodianUTA;
+  /** If omitted, all currencies for the selected custodian(s) */
+  currency?: string;
+}
+⋮----
+/** If omitted, returns all custodian rows */
+⋮----
+/** If omitted, all currencies for the selected custodian(s) */
+⋮----
+/**
+ * Get Third-Party Custody Account Currency Limits (private)
+ * Remaining OES custody quota per custodian/currency.
+ */
+export interface GetThirdPartyCustodyQuotaRequestUTA {
+  /**
+   * If sub-account API key is used, this parameter is ignored; only the
+   * custodian bound to the sub-account is returned (per API docs).
+   */
+  custodian?: ThirdPartyCustodyCustodianUTA;
+  /** If omitted, limits for all currencies under the custodian */
+  currency?: string;
+}
+⋮----
+/**
+   * If sub-account API key is used, this parameter is ignored; only the
+   * custodian bound to the sub-account is returned (per API docs).
+   */
+⋮----
+/** If omitted, limits for all currencies under the custodian */
+⋮----
+export interface GetPositionsHistoryRequestUTA {
+  symbol?: string;
+  startAt?: number; // milliseconds
+  endAt?: number; // milliseconds
+  lastId?: number; // For cursor-based pagination
+  pageSize?: number; // Default 10, max 200
+}
+⋮----
+startAt?: number; // milliseconds
+endAt?: number; // milliseconds
+lastId?: number; // For cursor-based pagination
+pageSize?: number; // Default 10, max 200
+⋮----
+/** Settled funding fee history (private) */
+export interface GetPrivateFundingFeeHistoryRequestUTA {
+  symbol?: string;
+  startAt?: number;
+  endAt?: number;
+  lastId?: number;
+  pageSize?: number;
+}
+⋮----
+export interface GetAccountPositionTiersRequestUTA {
+  symbol: string; // Supports up to 10 symbols, comma-separated
+  tradeType?: 'FUTURES' | 'MARGIN'; // Not support margin for the time being
+  marginMode?: 'ISOLATED' | 'CROSS'; // Not support cross for the time being
+  data?: 'RISK_LIMIT' | 'BORROW'; // Not support borrow for the time being
+}
+⋮----
+symbol: string; // Supports up to 10 symbols, comma-separated
+tradeType?: 'FUTURES' | 'MARGIN'; // Not support margin for the time being
+marginMode?: 'ISOLATED' | 'CROSS'; // Not support cross for the time being
+data?: 'RISK_LIMIT' | 'BORROW'; // Not support borrow for the time being
+
+================
+File: src/types/response/uta-types.ts
+================
+/**
+ * Unified Trading Account Response Types
+ */
+⋮----
+export interface AnnouncementItemUTA {
+  id: number;
+  title: string;
+  type: string[];
+  description: string;
+  releaseTime: number;
+  language: string;
+  url: string;
+}
+⋮----
+export interface GetAnnouncementsResponseUTA {
+  totalNumber: number;
+  totalPage: number;
+  pageNumber: number;
+  pageSize: number;
+  list: AnnouncementItemUTA[];
+}
+⋮----
+export interface CurrencyChainUTA {
+  chainName: string;
+  minWithdrawSize: string | null;
+  minDepositSize: string | null;
+  withdrawFeeRate: string;
+  minWithdrawFee: string;
+  isWithdrawEnabled: boolean;
+  isDepositEnabled: boolean;
+  confirms: number;
+  preConfirms: number;
+  contractAddress: string;
+  withdrawPrecision: number;
+  maxWithdrawSize: string | null;
+  maxDepositSize: string | null;
+  needTag: boolean;
+  chainId: string;
+}
+⋮----
+export interface GetCurrencyResponseUTA {
+  currency: string;
+  name: string;
+  fullName: string;
+  precision: number;
+  confirms: number | null;
+  contractAddress: string | null;
+  isMarginEnabled: boolean;
+  isDebitEnabled: boolean;
+  list: CurrencyChainUTA[];
+}
+⋮----
+export interface SymbolUTA {
+  symbol: string;
+  name?: string;
+  baseCurrency: string;
+  quoteCurrency: string;
+  market?: string;
+  minBaseOrderSize?: string;
+  minQuoteOrderSize?: string;
+  maxBaseOrderSize?: string | number;
+  maxQuoteOrderSize?: string;
+  baseOrderStep?: string;
+  quoteOrderStep?: string;
+  tickSize?: string | number;
+  feeCurrency?: string;
+  tradingStatus?: string;
+  marginMode?: string;
+  priceLimitRatio?: string;
+  feeCategory?: number;
+  makerFeeCoefficient?: string;
+  takerFeeCoefficient?: string;
+  st?: boolean;
+  settlementCurrency?: string;
+  contractType?: string;
+  isInverse?: boolean;
+  launchTime?: number;
+  expiryTime?: number | null;
+  settlementTime?: number | null;
+  maxPrice?: string | number;
+  lotSize?: string | number;
+  /**
+   * Unit size. As of 2026.01.12:
+   * - For inverse contracts: changed from -1 to 1 (1 contract = 1 USD)
+   * - For Futures: unitSize indicates contract size
+   */
+  unitSize?: string | number;
+  makerFeeRate?: string | number;
+  takerFeeRate?: string | number;
+  settlementFeeRate?: string | number | null;
+  maxLeverage?: number;
+  indexSourceExchanges?: string[];
+  k?: string | number;
+  m?: string | number;
+  f?: string | number;
+  mmrLimit?: string | number;
+  mmrLevConstant?: string | number;
+  alertRiskRatio?: string;
+  liquidationRiskRatio?: string;
+  baseBorrowEnable?: boolean | string;
+  quoteBorrowEnable?: boolean | string;
+  baseTransferInEnable?: boolean | string;
+  quoteTransferInEnable?: boolean | string;
+  /** Display symbol for Futures (added 2025.12.26 & 2026.01.12) */
+  displaySymbol?: string;
+  /** Display base currency for Futures (added 2025.12.26 & 2026.01.12) */
+  displayBaseCurrency?: string;
+}
+⋮----
+/**
+   * Unit size. As of 2026.01.12:
+   * - For inverse contracts: changed from -1 to 1 (1 contract = 1 USD)
+   * - For Futures: unitSize indicates contract size
+   */
+⋮----
+/** Display symbol for Futures (added 2025.12.26 & 2026.01.12) */
+⋮----
+/** Display base currency for Futures (added 2025.12.26 & 2026.01.12) */
+⋮----
+export interface GetSymbolResponseUTA {
+  tradeType: string;
+  list: SymbolUTA[];
+}
+⋮----
+export interface TickerUTA {
+  symbol: string;
+  name?: string;
+  bestBidPrice: string;
+  bestBidSize: string;
+  bestAskPrice: string;
+  bestAskSize: string;
+  high: string;
+  low: string;
+  baseVolume: string;
+  quoteVolume: string;
+  lastPrice: string;
+  open: string;
+  size: string;
+}
+⋮----
+export interface GetTickerResponseUTA {
+  tradeType: string;
+  /** Timestamp in nanoseconds (as of 2026.01.12) */
+  ts: number;
+  list: TickerUTA[];
+}
+⋮----
+/** Timestamp in nanoseconds (as of 2026.01.12) */
+⋮----
+export interface TradeUTA {
+  sequence: string | number;
+  tradeId: string;
+  price: string;
+  size: string;
+  side: 'buy' | 'sell';
+  /** Timestamp in nanoseconds */
+  ts: number;
+  /** Whether it is an RPI trade (Futures only) */
+  isRpiTrade?: boolean;
+}
+⋮----
+/** Timestamp in nanoseconds */
+⋮----
+/** Whether it is an RPI trade (Futures only) */
+⋮----
+export interface GetTradesResponseUTA {
+  tradeType: string;
+  list: TradeUTA[];
+}
+⋮----
+export interface GetOrderBookResponseUTA {
+  tradeType: string;
+  symbol: string;
+  /** Sequence number. Changed from string to number for Spot as of 2026.01.17 */
+  sequence: number;
+  /**
+   * Bids array, ordered from high to low.
+   * When rpiFilter=0 (or not set): each entry is [price, size]
+   * When rpiFilter=1: each entry is [price, noneRPISize, RPISize]
+   * As of 2026.01.17: All values are strings
+   */
+  bids: string[][];
+  /**
+   * Asks array, ordered from low to high.
+   * When rpiFilter=0 (or not set): each entry is [price, size]
+   * When rpiFilter=1: each entry is [price, noneRPISize, RPISize]
+   * As of 2026.01.17: All values are strings
+   */
+  asks: string[][];
+  /** Timestamp in nanoseconds (Futures only) */
+  ts?: number;
+}
+⋮----
+/** Sequence number. Changed from string to number for Spot as of 2026.01.17 */
+⋮----
+/**
+   * Bids array, ordered from high to low.
+   * When rpiFilter=0 (or not set): each entry is [price, size]
+   * When rpiFilter=1: each entry is [price, noneRPISize, RPISize]
+   * As of 2026.01.17: All values are strings
+   */
+⋮----
+/**
+   * Asks array, ordered from low to high.
+   * When rpiFilter=0 (or not set): each entry is [price, size]
+   * When rpiFilter=1: each entry is [price, noneRPISize, RPISize]
+   * As of 2026.01.17: All values are strings
+   */
+⋮----
+/** Timestamp in nanoseconds (Futures only) */
+⋮----
+export interface GetKlinesResponseUTA {
+  tradeType: string;
+  symbol: string;
+  list: string[][]; // [time, open, close, high, low, volume, turnover]
+}
+⋮----
+list: string[][]; // [time, open, close, high, low, volume, turnover]
+⋮----
+export interface GetCurrentFundingRateResponseUTA {
+  symbol: string;
+  nextFundingRate: number;
+  fundingTime: number;
+  fundingRateCap: number;
+  fundingRateFloor: number;
+  /** Current funding settlement interval (ms); as of 2026.04.19 */
+  currentGranularity: number;
+  /** New interval after change (ms); as of 2026.04.19 */
+  newGranularity: number;
+  /** When newGranularity takes effect (ms); as of 2026.04.19 */
+  newGranularityStartTime: number;
+}
+⋮----
+/** Current funding settlement interval (ms); as of 2026.04.19 */
+⋮----
+/** New interval after change (ms); as of 2026.04.19 */
+⋮----
+/** When newGranularity takes effect (ms); as of 2026.04.19 */
+⋮----
+export interface FundingRateHistoryItemUTA {
+  fundingRate: number;
+  ts: number;
+}
+⋮----
+export interface GetHistoryFundingRateResponseUTA {
+  symbol: string;
+  list: FundingRateHistoryItemUTA[];
+}
+⋮----
+export interface ModifyMarginCrossLeverageResponseUTA {
+  currency?: string;
+  leverage?: string;
+}
+⋮----
+/** One row from Get Leverage (UTA) — margin uses currency, futures uses symbol */
+export interface GetLeverageItemUTA {
+  leverage: string;
+  marginMode: string;
+  currency?: string;
+  symbol?: string;
+}
+⋮----
+export interface PrivateFundingFeeHistoryItemUTA {
+  symbol: string;
+  marginMode: 'CROSS' | 'ISOLATED';
+  fundingRate: string;
+  markPrice: string;
+  size: string;
+  positionValue: string;
+  fundingFee: string;
+  settleCurrency: string;
+  settlementTime: number;
+}
+⋮----
+export interface GetPrivateFundingFeeHistoryResponseUTA {
+  lastId: number;
+  items: PrivateFundingFeeHistoryItemUTA[];
+}
+⋮----
+export interface GetBorrowingRatesAndLimitsResponseUTA {
+  currentRateHourly: string;
+  currentRateDaily: string;
+  borrowLimitTotal: string;
+  borrowLimitTotalHold: string;
+  borrowLimitHold: string;
+  interestFreeBorrowLimit: string;
+}
+⋮----
+export interface BorrowableCurrencyUTA {
+  currency: string;
+}
+⋮----
+export interface GetCrossMarginConfigResponseUTA {
+  maxLeverage: number;
+  alertRiskRatio: string;
+  liquidationRiskRatio: string;
+  currencyList: string[];
+}
+⋮----
+export interface GetServiceStatusResponseUTA {
+  tradeType: string;
+  serverStatus: 'open' | 'close' | 'cancelonly';
+  msg: string;
+}
+⋮----
+/**
+ * Account Response Types
+ */
+⋮----
+export interface AccountCurrencyUTA {
+  currency: string;
+  hold: string;
+  available: string;
+  balance: string;
+  equity: string;
+  /** Potential borrow reserved by open orders (UTA; as of 2026.04.19) */
+  potentialBorrow?: string;
+  liability?: string;
+  totalCrossMargin?: string;
+  crossPosMargin?: string;
+  crossOrderMargin?: string;
+  crossUnPnl?: string;
+  isolatedPosMargin?: string;
+  isolatedOrderMargin?: string;
+  isolatedFundingFeeMargin?: string;
+  isolatedUnPnl?: string;
+  liabilityPrinciple?: string;
+  liabilityInterest?: string;
+  unrealisedPnl?: string;
+}
+⋮----
+/** Potential borrow reserved by open orders (UTA; as of 2026.04.19) */
+⋮----
+export interface AccountDataUTA {
+  accountSubtype?: string; // For ISOLATED (trading pair) or FUTURES (settlement currency)
+  riskRatio?: string;
+  currencies: AccountCurrencyUTA[];
+}
+⋮----
+accountSubtype?: string; // For ISOLATED (trading pair) or FUTURES (settlement currency)
+⋮----
+export interface GetClassicAccountResponseUTA {
+  accountType: string;
+  ts: number;
+  accounts: AccountDataUTA[];
+}
+⋮----
+export interface GetAccountOverviewResponseUTA {
+  accountType: string;
+  riskRatio: string;
+  equity: string;
+  liability: string;
+  availableMargin: string;
+  adjustedEquity: string;
+  im: string;
+  mm: string;
+}
+⋮----
+export interface SubAccountUserUTA {
+  uid: number;
+  accountList: {
+    accountType:
+      | 'FUNDING'
+      | 'SPOT'
+      | 'FUTURES'
+      | 'CROSS'
+      | 'ISOLATED'
+      | 'OPTIONS'
+      | 'UNIFIED';
+    accountSubType: string | null;
+    currencyList: AccountCurrencyUTA[];
+  }[];
+}
+⋮----
+export interface GetSubAccountResponseUTA {
+  ts: number;
+  userList: SubAccountUserUTA[];
+}
+⋮----
+export interface GetTransferQuotasResponseUTA {
+  currency: string;
+  transferable: string;
+  accountType: string;
+}
+⋮----
+export interface FlexTransferResponseUTA {
+  orderId: string;
+  clientOid: string;
+}
+⋮----
+export interface SubAccountTransferPermissionUTA {
+  subUid: string;
+  subToSub: boolean;
+}
+⋮----
+export interface GetAccountModeResponseUTA {
+  selfAccountMode: 'CLASSIC' | 'UNIFIED';
+  unifiedSubAccount: number[];
+  classicSubAccount: number[];
+}
+⋮----
+export interface FeeRateItemUTA {
+  symbol: string;
+  takerFeeRate: string;
+  makerFeeRate: string;
+}
+⋮----
+export interface GetFeeRateResponseUTA {
+  tradeType: string;
+  list: FeeRateItemUTA[];
+}
+⋮----
+export interface AccountLedgerItemUTA {
+  accountType:
+    | 'FUNDING'
+    | 'SPOT'
+    | 'FUTURES'
+    | 'CROSS'
+    | 'ISOLATED'
+    | 'UNIFIED';
+  id: string;
+  currency: string;
+  direction: 'IN' | 'OUT';
+  businessType: string;
+  amount: string;
+  balance: string;
+  fee: string;
+  tax: string;
+  remark: string;
+  /** Timestamp in nanoseconds (standardized as of 2026.01.12) */
+  ts: number;
+}
+⋮----
+/** Timestamp in nanoseconds (standardized as of 2026.01.12) */
+⋮----
+export interface GetAccountLedgerResponseUTA {
+  lastId?: number;
+  items?: AccountLedgerItemUTA[];
+}
+⋮----
+export type GetAccountLedgerResponseClassicUTA = AccountLedgerItemUTA[];
+⋮----
+export interface InterestHistoryItemUTA {
+  liability: string;
+  interest: string;
+  hourlyInterestRate: string;
+  currency: string;
+  ts: number;
+  interestFreeLiability: string;
+}
+⋮----
+export interface GetInterestHistoryResponseUTA {
+  items: InterestHistoryItemUTA[];
+  lastId: number;
+}
+⋮----
+export interface DepositAddressUTA {
+  address: string;
+  memo: string;
+  chainId: string;
+  to: 'MAIN' | 'TRADE';
+  currency: string;
+  contractAddress: string;
+  chainName: string;
+  expirationDate: string;
+  remark: string;
+}
+⋮----
+/**
+ * Order Response Types
+ */
+⋮----
+export interface PlaceOrderResponseUTA {
+  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS' | 'MARGIN';
+  orderId: string;
+  clientOid: string;
+  /** Timestamp when system completes order request in nanoseconds. Classic mode not supported */
+  ts?: number;
+  /** Borrow amount. Unified mode not supported */
+  borrowSize?: string;
+  /** Loan order ID. Unified mode not supported */
+  loanApplyId?: string;
+}
+⋮----
+/** Timestamp when system completes order request in nanoseconds. Classic mode not supported */
+⋮----
+/** Borrow amount. Unified mode not supported */
+⋮----
+/** Loan order ID. Unified mode not supported */
+⋮----
+export interface BatchPlaceOrderItemResponseUTA {
+  orderId?: string;
+  clientOid?: string;
+  symbol?: string;
+  code?: string;
+  msg?: string;
+}
+⋮----
+export interface BatchPlaceOrderResponseUTA {
+  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS' | 'MARGIN';
+  items: BatchPlaceOrderItemResponseUTA[];
+}
+⋮----
+export interface OrderDetailsUTA {
+  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS' | 'MARGIN';
+  orderId: string;
+  clientOid: string;
+  /**
+   * Order status:
+   * - 0: notTriggered (conditional order, not triggered)
+   * - 1: triggered (conditional order, triggered but not live)
+   * - 2: live (not filled)
+   * - 3: filled (fully filled)
+   * - 4: partial filled (partially filled, still active)
+   * - 5: canceled (no fills, fully canceled)
+   * - 6: partial canceled (partially filled, remainder canceled)
+   * Changed from String to Number for UTA as of 2026.01.17
+   */
+  status: number;
+  filledSize: string;
+  avgPrice: string;
+  fee: string;
+  feeCurrency: string;
+  tax: string;
+  tradeId: string;
+  symbol: string;
+  side: 'BUY' | 'SELL';
+  positionSide?: 'BOTH' | 'LONG' | 'SHORT';
+  orderType: 'LIMIT' | 'MARKET';
+  size: string;
+  sizeUnit: 'BASECCY' | 'QUOTECCY' | 'UNIT';
+  price: string;
+  leverage?: string;
+  reduceOnly?: boolean;
+  marginMode?: 'ISOLATED' | 'CROSS';
+  stp?: 'DC' | 'CO' | 'CN' | 'CB' | '';
+  /**
+   * Time in Force. Added 'RPI' as of 2025.01.02
+   */
+  timeInForce: 'GTC' | 'IOC' | 'GTT' | 'FOK' | 'RPI';
+  cancelReason?: number;
+  cancelSize: string;
+  cancelAfter?: number;
+  triggerDirection?: 'UP' | 'DOWN';
+  triggerPrice?: string;
+  triggerPriceType?: 'TP' | 'IP' | 'MP';
+  tpTriggerPrice?: string;
+  tpTriggerPriceType?: 'TP' | 'IP' | 'MP';
+  tpOrderPrice?: string;
+  slTriggerPrice?: string;
+  slTriggerPriceType?: 'TP' | 'IP' | 'MP';
+  slOrderPrice?: string;
+  postOnly?: boolean;
+  tags?: string;
+  triggerOrderId?: string;
+  /** Order creation time in nanoseconds (standardized as of 2026.01.12) */
+  orderTime: number;
+  /** Latest order update time in nanoseconds (standardized as of 2026.01.12) */
+  updatedTime: number;
+}
+⋮----
+/**
+   * Order status:
+   * - 0: notTriggered (conditional order, not triggered)
+   * - 1: triggered (conditional order, triggered but not live)
+   * - 2: live (not filled)
+   * - 3: filled (fully filled)
+   * - 4: partial filled (partially filled, still active)
+   * - 5: canceled (no fills, fully canceled)
+   * - 6: partial canceled (partially filled, remainder canceled)
+   * Changed from String to Number for UTA as of 2026.01.17
+   */
+⋮----
+/**
+   * Time in Force. Added 'RPI' as of 2025.01.02
+   */
+⋮----
+/** Order creation time in nanoseconds (standardized as of 2026.01.12) */
+⋮----
+/** Latest order update time in nanoseconds (standardized as of 2026.01.12) */
+⋮----
+export interface GetOpenOrderListResponseUTA {
+  pageNumber: number;
+  pageSize?: number;
+  totalNum?: number;
+  totalPage?: number;
+  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS' | 'MARGIN';
+  items: OrderDetailsUTA[];
+}
+⋮----
+export interface GetOrderHistoryResponseUTA {
+  lastId: number;
+  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS' | 'MARGIN';
+  items: OrderDetailsUTA[];
+}
+⋮----
+export interface TradeHistoryItemUTA {
+  tradeId: string;
+  orderId: string;
+  symbol: string;
+  side: 'BUY' | 'SELL';
+  positionSide?: 'BOTH' | 'LONG' | 'SHORT';
+  type: 'LIMIT' | 'MARKET';
+  price: string;
+  size: string;
+  sizeUnit: 'BASECCY' | 'QUOTECCY' | 'UNIT';
+  value: string;
+  feeRate: string;
+  fee: string;
+  feeCurrency: string;
+  tax: string;
+  liquidity: 'TAKER' | 'MAKER';
+  /** Execution time in nanoseconds (standardized as of 2026.01.12) */
+  executionTime: number;
+  /** Whether it is an RPI trade (added 2025.01.02, Futures only) */
+  isRpiTrade?: boolean;
+}
+⋮----
+/** Execution time in nanoseconds (standardized as of 2026.01.12) */
+⋮----
+/** Whether it is an RPI trade (added 2025.01.02, Futures only) */
+⋮----
+export interface GetTradeHistoryResponseUTA {
+  lastId: number;
+  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS' | 'MARGIN';
+  items: TradeHistoryItemUTA[];
+}
+⋮----
+export interface CancelOrderResponseUTA {
+  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS' | 'MARGIN';
+  orderId?: string;
+  clientOid?: string;
+  /** Timestamp when system completes order cancellation request (nanoseconds). Only for unified accounts */
+  ts?: number;
+}
+⋮----
+/** Timestamp when system completes order cancellation request (nanoseconds). Only for unified accounts */
+⋮----
+export interface BatchCancelOrderItemResponseUTA {
+  code?: string;
+  msg?: string;
+  orderId?: string;
+  clientOid?: string;
+  /** Timestamp when system completes order cancellation request (nanoseconds). Not supported for classic accounts */
+  ts?: number;
+}
+⋮----
+/** Timestamp when system completes order cancellation request (nanoseconds). Not supported for classic accounts */
+⋮----
+export interface BatchCancelOrdersResponseUTA {
+  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS' | 'MARGIN';
+  items: BatchCancelOrderItemResponseUTA[];
+}
+⋮----
+/** Batch cancel by symbol - Classic response (orderId list) */
+export interface BatchCancelOrdersBySymbolItemClassicUTA {
+  orderId: string;
+}
+⋮----
+/** Batch cancel by symbol - UTA response (full result per order) */
+export interface BatchCancelOrdersBySymbolItemUTA {
+  code?: string;
+  msg?: string;
+  orderId?: string;
+  ts?: number;
+  clientOid?: string | null;
+}
+⋮----
+export interface BatchCancelOrdersBySymbolResponseUTA {
+  tradeType: 'SPOT' | 'FUTURES' | 'MARGIN';
+  ts?: number;
+  items:
+    | BatchCancelOrdersBySymbolItemClassicUTA[]
+    | BatchCancelOrdersBySymbolItemUTA[];
+}
+⋮----
+export interface DCPResponseUTA {
+  tradeType: 'SPOT' | 'FUTURES' | 'MARGIN';
+  symbol: string[]; // Empty means effective for all symbols
+  systemTime: number; // Time when system received request (in seconds)
+  triggerTime: number; // Trigger cancellation time (in seconds)
+}
+⋮----
+symbol: string[]; // Empty means effective for all symbols
+systemTime: number; // Time when system received request (in seconds)
+triggerTime: number; // Trigger cancellation time (in seconds)
+⋮----
+/**
+ * Position Response Types
+ */
+⋮----
+export interface PositionUTA {
+  id: string;
+  symbol: string;
+  marginMode: 'CROSS' | 'ISOLATED';
+  size: string; // Positive = long, negative = short
+  entryPrice: string;
+  positionValue: string;
+  markPrice: string;
+  leverage: string;
+  unrealizedPnL: string;
+  realizedPnL: string;
+  initialMargin: string;
+  mmr: string; // Maintenance Margin Rate
+  maintenanceMargin: string;
+  /** Timestamp when position was first opened (nanoseconds, standardized as of 2026.01.12) */
+  creationTime: number;
+  /** Estimated liquidation price (as of 2026.04.09) */
+  liquidationPrice: string;
+}
+⋮----
+size: string; // Positive = long, negative = short
+⋮----
+mmr: string; // Maintenance Margin Rate
+⋮----
+/** Timestamp when position was first opened (nanoseconds, standardized as of 2026.01.12) */
+⋮----
+/** Estimated liquidation price (as of 2026.04.09) */
+⋮----
+export interface PositionHistoryItemUTA {
+  closeId: string;
+  symbol: string;
+  marginMode: 'CROSS' | 'ISOLATED';
+  side: 'LONG' | 'SHORT';
+  entryPrice: string;
+  closePrice: string;
+  avgClosePrice: string;
+  maxSize: string;
+  leverage: string;
+  realizedPnL: string;
+  fee: string;
+  tax: string;
+  fundingFee: string;
+  /** Position opening timestamp (nanoseconds, standardized as of 2026.01.12) */
+  creationTime: number;
+  /** Position closing timestamp (nanoseconds, standardized as of 2026.01.12) */
+  closingTime: number;
+}
+⋮----
+/** Position opening timestamp (nanoseconds, standardized as of 2026.01.12) */
+⋮----
+/** Position closing timestamp (nanoseconds, standardized as of 2026.01.12) */
+⋮----
+export interface GetPositionsHistoryResponseUTA {
+  items: PositionHistoryItemUTA[];
+  lastId?: number;
+}
+⋮----
+/** Row from Get Third-Party Custody Currencies */
+export interface ThirdPartyCustodyCurrencyUTA {
+  custodian: string;
+  currency: string;
+  precision: number;
+}
+⋮----
+/** Row from Get Third-Party Custody Account Currency Limits */
+export interface ThirdPartyCustodyQuotaUTA {
+  custodian: string;
+  currency: string;
+  /** Remaining custodial quota (shared across custodian sub-accounts under master) */
+  custodyQuota: string;
+}
+⋮----
+/** Remaining custodial quota (shared across custodian sub-accounts under master) */
+⋮----
+export interface PositionTierUTA {
+  symbol: string;
+  tier: number; // Current tier of user
+  maxSize: string; // Upper limit (USDT) (included)
+  minSize: string; // Lower limit (USDT)
+  maxLeverage: string;
+  initialMarginRate: string;
+  maintainMarginRate: string;
+}
+⋮----
+tier: number; // Current tier of user
+maxSize: string; // Upper limit (USDT) (included)
+minSize: string; // Lower limit (USDT)
 
 ================
 File: src/types/websockets/ws-general.ts
@@ -11370,488 +11640,6 @@ updateAutoDepositStatus(params: {
 }): Promise<APISuccessResponse<any>>
 
 ================
-File: src/UnifiedAPIClient.ts
-================
-import { BaseRestClient } from './lib/BaseRestClient.js';
-import { REST_CLIENT_TYPE_ENUM, RestClientType } from './lib/requestUtils.js';
-import {
-  BatchCancelOrdersBySymbolRequestUTA,
-  BatchCancelOrdersRequestUTA,
-  BatchPlaceOrderRequestUTA,
-  CancelOrderRequestUTA,
-  FlexTransferRequestUTA,
-  GetAccountLedgerRequestUTA,
-  GetAccountPositionTiersRequestUTA,
-  GetAnnouncementsRequestUTA,
-  GetClassicAccountRequestUTA,
-  GetCurrencyRequestUTA,
-  GetCurrentFundingRateRequestUTA,
-  GetDCPRequestUTA,
-  GetDepositAddressRequestUTA,
-  GetFeeRateRequestUTA,
-  GetHistoryFundingRateRequestUTA,
-  GetInterestHistoryRequestUTA,
-  GetKlinesRequestUTA,
-  GetOpenOrderListRequestUTA,
-  GetOrderBookRequestUTA,
-  GetOrderDetailsRequestUTA,
-  GetOrderHistoryRequestUTA,
-  GetPositionListRequestUTA,
-  GetPositionsHistoryRequestUTA,
-  GetServiceStatusRequestUTA,
-  GetSubAccountRequestUTA,
-  GetSymbolRequestUTA,
-  GetTickerRequestUTA,
-  GetTradeHistoryRequestUTA,
-  GetTradesRequestUTA,
-  GetTransferQuotasRequestUTA,
-  ModifyLeverageRequestUTA,
-  PlaceOrderRequestUTA,
-  SetAccountModeRequestUTA,
-  SetDCPRequestUTA,
-  SetSubAccountTransferPermissionRequestUTA,
-} from './types/request/uta-types.js';
-import { APISuccessResponse } from './types/response/shared.types.js';
-import {
-  BatchCancelOrdersBySymbolResponseUTA,
-  BatchCancelOrdersResponseUTA,
-  BatchPlaceOrderResponseUTA,
-  CancelOrderResponseUTA,
-  DCPResponseUTA,
-  DepositAddressUTA,
-  FlexTransferResponseUTA,
-  GetAccountLedgerResponseClassicUTA,
-  GetAccountLedgerResponseUTA,
-  GetAccountModeResponseUTA,
-  GetAccountOverviewResponseUTA,
-  GetAnnouncementsResponseUTA,
-  GetClassicAccountResponseUTA,
-  GetCrossMarginConfigResponseUTA,
-  GetCurrencyResponseUTA,
-  GetCurrentFundingRateResponseUTA,
-  GetFeeRateResponseUTA,
-  GetHistoryFundingRateResponseUTA,
-  GetInterestHistoryResponseUTA,
-  GetKlinesResponseUTA,
-  GetOpenOrderListResponseUTA,
-  GetOrderBookResponseUTA,
-  GetOrderHistoryResponseUTA,
-  GetPositionsHistoryResponseUTA,
-  GetServiceStatusResponseUTA,
-  GetSubAccountResponseUTA,
-  GetSymbolResponseUTA,
-  GetTickerResponseUTA,
-  GetTradeHistoryResponseUTA,
-  GetTradesResponseUTA,
-  GetTransferQuotasResponseUTA,
-  OrderDetailsUTA,
-  PlaceOrderResponseUTA,
-  PositionTierUTA,
-  PositionUTA,
-  SubAccountTransferPermissionUTA,
-} from './types/response/uta-types.js';
-⋮----
-/**
- * Unified Trading Account Client
- *
- * This client provides access to the Unified Trading Account API endpoints
- * that unify market data access across Spot, Futures, and Margin trading.
- */
-export class UnifiedAPIClient extends BaseRestClient
-⋮----
-getClientType(): RestClientType
-⋮----
-/**
-   *
-   * REST - Unified Trading Account - Market Data
-   *
-   */
-⋮----
-/**
-   * Get Announcements
-   * This interface can obtain the latest news announcements, and the default
-   * page search is for announcements within a month.
-   */
-getAnnouncements(
-    params?: GetAnnouncementsRequestUTA,
-): Promise<APISuccessResponse<GetAnnouncementsResponseUTA>>
-⋮----
-/**
-   * Get Currency
-   * Request the currency details of a specified currency via this endpoint.
-   */
-getCurrency(
-    params?: GetCurrencyRequestUTA,
-): Promise<APISuccessResponse<GetCurrencyResponseUTA>>
-⋮----
-/**
-   * Get Symbol
-   * Request a list of available currency pairs for trading via this endpoint.
-   */
-getSymbols(
-    params: GetSymbolRequestUTA,
-): Promise<APISuccessResponse<GetSymbolResponseUTA>>
-⋮----
-/**
-   * Get Ticker
-   * Request market tickers for the trading pairs in the market (including 24h volume).
-   */
-getTickers(
-    params: GetTickerRequestUTA,
-): Promise<APISuccessResponse<GetTickerResponseUTA>>
-⋮----
-/**
-   * Get Trades
-   * Request via this endpoint to get the latest 100 public trades of the specified symbol.
-   */
-getTrades(
-    params: GetTradesRequestUTA,
-): Promise<APISuccessResponse<GetTradesResponseUTA>>
-⋮----
-/**
-   * Get OrderBook
-   * Query order book depth information (aggregated by price).
-   */
-getOrderBook(
-    params: GetOrderBookRequestUTA,
-): Promise<APISuccessResponse<GetOrderBookResponseUTA>>
-⋮----
-/**
-   * Get Klines
-   * Get the Kline of the symbol. Data are returned in grouped buckets based on requested type.
-   */
-getKlines(
-    params: GetKlinesRequestUTA,
-): Promise<APISuccessResponse<GetKlinesResponseUTA>>
-⋮----
-/**
-   * Get Current Funding Rate
-   * Get current Futures funding fee rate.
-   */
-getCurrentFundingRate(
-    params: GetCurrentFundingRateRequestUTA,
-): Promise<APISuccessResponse<GetCurrentFundingRateResponseUTA>>
-⋮----
-/**
-   * Get History Funding Rate
-   * Query the Futures funding rate at each settlement time point within a certain time range.
-   */
-getHistoryFundingRate(
-    params: GetHistoryFundingRateRequestUTA,
-): Promise<APISuccessResponse<GetHistoryFundingRateResponseUTA>>
-⋮----
-/**
-   * Get Cross Margin Config
-   * Request the configure info of the 'spot cross margin' via this endpoint.
-   */
-getCrossMarginConfig(): Promise<
-    APISuccessResponse<GetCrossMarginConfigResponseUTA>
-  > {
-    return this.get('api/ua/v1/market/cross-config');
-⋮----
-/**
-   * Get Service Status
-   * Get the service status.
-   */
-getServiceStatus(
-    params: GetServiceStatusRequestUTA,
-): Promise<APISuccessResponse<GetServiceStatusResponseUTA>>
-⋮----
-/**
-   *
-   * REST - Unified Trading Account - Account
-   *
-   */
-⋮----
-/**
-   * Get Account (Classic)
-   * Get information for Classic Account (FUNDING, SPOT, FUTURES, CROSS, ISOLATED).
-   * Note: AccountType enum value changed from TRADING to SPOT as of 2026.01.17.
-   */
-getClassicAccount(
-    params: GetClassicAccountRequestUTA,
-): Promise<APISuccessResponse<GetClassicAccountResponseUTA>>
-⋮----
-/**
-   * Get Account (UTA)
-   * Get information for Unified Trading Account.
-   */
-getAccount(): Promise<APISuccessResponse<GetClassicAccountResponseUTA>>
-⋮----
-/**
-   * Get Account Overview (UTA)
-   * Get account overview for Unified Trading Account.
-   */
-getAccountOverview(): Promise<
-    APISuccessResponse<GetAccountOverviewResponseUTA>
-  > {
-    return this.getPrivate('api/ua/v1/unified/account/overview');
-⋮----
-/**
-   * Get Sub Account
-   * Request sub account info via this endpoint.
-   */
-getSubAccount(
-    params?: GetSubAccountRequestUTA,
-): Promise<APISuccessResponse<GetSubAccountResponseUTA>>
-⋮----
-/**
-   * Get Transfer Quotas
-   * This endpoint returns the transferable balance of a specified account.
-   * Note: AccountType enum value changed from TRADING to SPOT as of 2026.01.17.
-   */
-getTransferQuotas(
-    params: GetTransferQuotasRequestUTA,
-): Promise<APISuccessResponse<GetTransferQuotasResponseUTA>>
-⋮----
-/**
-   * Flex Transfer
-   * This interface can be used for transfers between master- and sub-accounts and transfers.
-   * Note: AccountType enum value changed from TRADING to SPOT as of 2026.01.17.
-   */
-flexTransfer(
-    params: FlexTransferRequestUTA,
-): Promise<APISuccessResponse<FlexTransferResponseUTA>>
-⋮----
-/**
-   * Set Sub Account Transfer Permission
-   * This endpoint supports setting whether the specified sub-account needs to open the SUB_TO_SUB transfer permission.
-   */
-setSubAccountTransferPermission(
-    params: SetSubAccountTransferPermissionRequestUTA,
-): Promise<APISuccessResponse<SubAccountTransferPermissionUTA[]>>
-⋮----
-/**
-   * Get Account Mode
-   * This interface supports query the list of unified and classic sub-accounts and current account mode.
-   */
-getAccountMode(): Promise<APISuccessResponse<GetAccountModeResponseUTA>>
-⋮----
-/**
-   * Set Account Mode
-   * This interface supports set account mode to UTA.
-   */
-setAccountMode(
-    params: SetAccountModeRequestUTA,
-): Promise<APISuccessResponse<null>>
-⋮----
-/**
-   * Get Fee Rate
-   * This interface is for the trading pair's actual fee rate.
-   * You can inquire about fee rates of 10 trading pairs each time at most for Spot.
-   * Futures only supports 1 symbol at a time.
-   */
-getFeeRate(
-    params: GetFeeRateRequestUTA,
-): Promise<APISuccessResponse<GetFeeRateResponseUTA>>
-⋮----
-/**
-   * Get Account Ledger
-   * This API endpoint returns all transfer (in and out) records and supports multi-coin queries.
-   * The query results are sorted in descending order by createdAt and ID.
-   * Note: AccountType enum value changed from TRADING to SPOT as of 2026.01.17.
-   * Note: direction values unified to uppercase IN/OUT as of 2026.01.17.
-   * Note: For Futures - id changed from Number to String, balance/amount changed from Number to String as of 2026.01.17.
-   * Note: ts standardized to nanoseconds as of 2026.01.12.
-   */
-getAccountLedger(
-    params: GetAccountLedgerRequestUTA,
-  ): Promise<
-    APISuccessResponse<
-      GetAccountLedgerResponseUTA | GetAccountLedgerResponseClassicUTA
-    >
-  > {
-    return this.getPrivate('api/ua/v1/account/ledger', params);
-⋮----
-/**
-   * Get Interest History (UTA)
-   * Request the interest records via this endpoint.
-   */
-getInterestHistory(
-    params: GetInterestHistoryRequestUTA,
-): Promise<APISuccessResponse<GetInterestHistoryResponseUTA>>
-⋮----
-/**
-   * Modify Leverage (UTA)
-   * This interface supports modify leverage of the specified symbol.
-   */
-modifyLeverage(
-    params: ModifyLeverageRequestUTA,
-): Promise<APISuccessResponse<null>>
-⋮----
-/**
-   * Get Deposit Address
-   * Return a deposit address; when both currency and chain are provided,
-   * the address will be created if it does not exist.
-   * URL unified to GET /api/ua/v1/asset/deposit/address as of 2026.01.17.
-   */
-getDepositAddress(
-    params: GetDepositAddressRequestUTA,
-): Promise<APISuccessResponse<DepositAddressUTA[]>>
-⋮----
-/**
-   *
-   * REST - Unified Trading Account - Orders
-   *
-   */
-⋮----
-/**
-   * Place Order
-   * This interface can be used to place orders.
-   * Supports RPI (Retail Price Improvement) orders for Futures as of 2025.01.02.
-   * Note: timeInForce supports 'RPI' value for Futures only (Phase 1).
-   * Note: For Classic mode, tradeType is required in query param.
-   * Note: For Unified mode, tradeType should not be in query param.
-   */
-placeOrder(
-    params: PlaceOrderRequestUTA,
-    accountMode: 'classic' | 'unified' = 'unified',
-): Promise<APISuccessResponse<PlaceOrderResponseUTA>>
-⋮----
-/**
-   * Batch Place Order (Classic)
-   * This interface can be used for placing batch orders.
-   * URL changed to /api/ua/v1/{accountMode}/order/place-batch as of 2026.01.17.
-   * Note: timeInForce supports 'RPI' value for Futures as of 2025.01.02.
-   */
-batchPlaceOrder(
-    params: BatchPlaceOrderRequestUTA,
-    accountMode: 'classic' | 'unified' = 'classic',
-): Promise<APISuccessResponse<BatchPlaceOrderResponseUTA>>
-⋮----
-/**
-   * Get Order Details
-   * This interface can be used getting single order details.
-   * Note: timeInForce returns 'RPI' value for Futures RPI orders as of 2025.01.02.
-   * Note: status changed from String to Number for UTA as of 2026.01.17.
-   * Note: orderTime/updatedTime standardized to nanoseconds as of 2026.01.12.
-   */
-getOrderDetails(
-    params: GetOrderDetailsRequestUTA,
-    accountMode: 'classic' | 'unified' = 'unified',
-): Promise<APISuccessResponse<OrderDetailsUTA>>
-⋮----
-/**
-   * Get Open Order List
-   * This interface can be used getting open order list.
-   * Note: timeInForce returns 'RPI' value for Futures RPI orders as of 2025.01.02.
-   * Note: status changed from String to Number for UTA as of 2026.01.17.
-   * Note: orderTime/updatedTime standardized to nanoseconds as of 2026.01.12.
-   */
-getOpenOrderList(
-    params: GetOpenOrderListRequestUTA,
-    accountMode: 'classic' | 'unified' = 'unified',
-): Promise<APISuccessResponse<GetOpenOrderListResponseUTA>>
-⋮----
-/**
-   * Get Order History
-   * This interface can be used for getting order history.
-   * Note: timeInForce returns 'RPI' value for Futures RPI orders as of 2025.01.02.
-   * Note: status changed from String to Number for UTA as of 2026.01.17.
-   * Note: orderTime/updatedTime standardized to nanoseconds as of 2026.01.12.
-   */
-getOrderHistory(
-    params: GetOrderHistoryRequestUTA,
-    accountMode: 'classic' | 'unified' = 'unified',
-): Promise<APISuccessResponse<GetOrderHistoryResponseUTA>>
-⋮----
-/**
-   * Get Trade History
-   * This interface can be used for getting trade execution history.
-   * Note: executionTime standardized to nanoseconds as of 2026.01.12.
-   * Note: isRpiTrade added for Futures as of 2025.01.02.
-   */
-getTradeHistory(
-    params: GetTradeHistoryRequestUTA,
-    accountMode: 'classic' | 'unified' = 'unified',
-): Promise<APISuccessResponse<GetTradeHistoryResponseUTA>>
-⋮----
-/**
-   * Cancel Order
-   * This interface can be used to cancel orders.
-   * Note: ts (timestamp in nanoseconds) only effective for unified account mode.
-   */
-cancelOrder(
-    params: CancelOrderRequestUTA,
-    accountMode: 'classic' | 'unified' = 'unified',
-): Promise<APISuccessResponse<CancelOrderResponseUTA>>
-⋮----
-/**
-   * Batch Cancel Orders
-   * This interface can be used for batch cancel orders (maximum 20 orders).
-   * Note: tradeType required for Classic accounts only; ignored in UTA (UNIFIED) mode.
-   * Note: ts (timestamp in nanoseconds) not supported for classic accounts.
-   */
-batchCancelOrders(
-    params: BatchCancelOrdersRequestUTA,
-    accountMode: 'classic' | 'unified' = 'unified',
-): Promise<APISuccessResponse<BatchCancelOrdersResponseUTA>>
-⋮----
-/**
-   * Batch Cancel Orders By Symbol
-   * Cancels orders in batch by symbol. UTA only. Supports SPOT (non-margin) and Futures Cross Margin.
-   */
-batchCancelOrdersBySymbol(
-    params: BatchCancelOrdersBySymbolRequestUTA,
-): Promise<APISuccessResponse<BatchCancelOrdersBySymbolResponseUTA>>
-⋮----
-/**
-   * Set DCP (Disconnection Protect / Deadman Switch) - Classic Only
-   * Set automatic order cancellation after specified time.
-   * Call this interface to automatically cancel all orders of the set trading pair after the specified time.
-   * Note: Order cancellation delay is between 0 and 10 seconds.
-   * Note: timeout range: -1 (unset) or 5 <= timeout <= 86400 seconds.
-   */
-setDCP(
-    params: SetDCPRequestUTA,
-): Promise<APISuccessResponse<DCPResponseUTA>>
-⋮----
-/**
-   * Get DCP (Disconnection Protect / Deadman Switch) - Classic Only
-   * Get automatic order cancellation settings.
-   * If data is empty, it means DCP is not set.
-   */
-getDCP(
-    params: GetDCPRequestUTA,
-): Promise<APISuccessResponse<DCPResponseUTA>>
-⋮----
-/**
-   *
-   * REST - Unified Trading Account - Positions
-   *
-   */
-⋮----
-/**
-   * Get Position List (UTA)
-   * Get the position details of all open positions.
-   * Note: creationTime standardized to nanoseconds as of 2026.01.12.
-   */
-getPositionList(
-    params?: GetPositionListRequestUTA,
-): Promise<APISuccessResponse<PositionUTA[]>>
-⋮----
-/**
-   * Get Positions History (UTA)
-   * Query position history information records.
-   * Note: Data retained for up to 3 months.
-   * Note: Each query limited to 7 days time range.
-   * Note: creationTime and closingTime standardized to nanoseconds as of 2026.01.12.
-   */
-getPositionsHistory(
-    params?: GetPositionsHistoryRequestUTA,
-): Promise<APISuccessResponse<GetPositionsHistoryResponseUTA>>
-⋮----
-/**
-   * Get Account Position Tiers
-   * Request account position tiers (risk limit) info.
-   * Note: Currently only queries of classic - futures isolated margin are supported.
-   */
-getAccountPositionTiers(
-    params: GetAccountPositionTiersRequestUTA,
-    accountMode: 'classic' | 'unified' = 'classic',
-): Promise<APISuccessResponse<PositionTierUTA[]>>
-
-================
 File: src/WebsocketAPIClient.ts
 ================
 import { DefaultLogger } from './lib/websocket/logger.js';
@@ -12058,6 +11846,1090 @@ private setupDefaultEventListeners()
 // Blind JSON.stringify can fail on circular references
 ⋮----
 // JSON.stringify({ ...data, target: 'WebSocket' }),
+
+================
+File: src/UnifiedAPIClient.ts
+================
+import { BaseRestClient } from './lib/BaseRestClient.js';
+import { REST_CLIENT_TYPE_ENUM, RestClientType } from './lib/requestUtils.js';
+import {
+  BatchCancelOrdersBySymbolRequestUTA,
+  BatchCancelOrdersRequestUTA,
+  BatchPlaceOrderRequestUTA,
+  CancelOrderRequestUTA,
+  FlexTransferRequestUTA,
+  GetAccountLedgerRequestUTA,
+  GetAccountPositionTiersRequestUTA,
+  GetAnnouncementsRequestUTA,
+  GetBorrowingRatesAndLimitsRequestUTA,
+  GetClassicAccountRequestUTA,
+  GetCurrencyRequestUTA,
+  GetCurrentFundingRateRequestUTA,
+  GetDCPRequestUTA,
+  GetDepositAddressRequestUTA,
+  GetFeeRateRequestUTA,
+  GetHistoryFundingRateRequestUTA,
+  GetInterestHistoryRequestUTA,
+  GetKlinesRequestUTA,
+  GetLeverageRequestUTA,
+  GetOpenOrderListRequestUTA,
+  GetOrderBookRequestUTA,
+  GetOrderDetailsRequestUTA,
+  GetOrderHistoryRequestUTA,
+  GetPositionListRequestUTA,
+  GetPositionsHistoryRequestUTA,
+  GetPrivateFundingFeeHistoryRequestUTA,
+  GetServiceStatusRequestUTA,
+  GetSubAccountRequestUTA,
+  GetSymbolRequestUTA,
+  GetThirdPartyCustodyCurrenciesRequestUTA,
+  GetThirdPartyCustodyQuotaRequestUTA,
+  GetTickerRequestUTA,
+  GetTradeHistoryRequestUTA,
+  GetTradesRequestUTA,
+  GetTransferQuotasRequestUTA,
+  ModifyLeverageRequestUTA,
+  ModifyMarginCrossLeverageRequestUTA,
+  PlaceOrderRequestUTA,
+  SetAccountModeRequestUTA,
+  SetDCPRequestUTA,
+  SetSubAccountTransferPermissionRequestUTA,
+} from './types/request/uta-types.js';
+import { APISuccessResponse } from './types/response/shared.types.js';
+import {
+  BatchCancelOrdersBySymbolResponseUTA,
+  BatchCancelOrdersResponseUTA,
+  BatchPlaceOrderResponseUTA,
+  BorrowableCurrencyUTA,
+  CancelOrderResponseUTA,
+  DCPResponseUTA,
+  DepositAddressUTA,
+  FlexTransferResponseUTA,
+  GetAccountLedgerResponseClassicUTA,
+  GetAccountLedgerResponseUTA,
+  GetAccountModeResponseUTA,
+  GetAccountOverviewResponseUTA,
+  GetAnnouncementsResponseUTA,
+  GetBorrowingRatesAndLimitsResponseUTA,
+  GetClassicAccountResponseUTA,
+  GetCrossMarginConfigResponseUTA,
+  GetCurrencyResponseUTA,
+  GetCurrentFundingRateResponseUTA,
+  GetFeeRateResponseUTA,
+  GetHistoryFundingRateResponseUTA,
+  GetInterestHistoryResponseUTA,
+  GetKlinesResponseUTA,
+  GetLeverageItemUTA,
+  GetOpenOrderListResponseUTA,
+  GetOrderBookResponseUTA,
+  GetOrderHistoryResponseUTA,
+  GetPositionsHistoryResponseUTA,
+  GetPrivateFundingFeeHistoryResponseUTA,
+  GetServiceStatusResponseUTA,
+  GetSubAccountResponseUTA,
+  GetSymbolResponseUTA,
+  GetTickerResponseUTA,
+  GetTradeHistoryResponseUTA,
+  GetTradesResponseUTA,
+  GetTransferQuotasResponseUTA,
+  ModifyMarginCrossLeverageResponseUTA,
+  OrderDetailsUTA,
+  PlaceOrderResponseUTA,
+  PositionTierUTA,
+  PositionUTA,
+  SubAccountTransferPermissionUTA,
+  ThirdPartyCustodyCurrencyUTA,
+  ThirdPartyCustodyQuotaUTA,
+} from './types/response/uta-types.js';
+⋮----
+/**
+ * Unified Trading Account Client
+ *
+ * This client provides access to the Unified Trading Account API endpoints
+ * that unify market data access across Spot, Futures, and Margin trading.
+ */
+export class UnifiedAPIClient extends BaseRestClient
+⋮----
+getClientType(): RestClientType
+⋮----
+/**
+   *
+   * REST - Unified Trading Account - Market Data
+   *
+   */
+⋮----
+/**
+   * Get Announcements
+   * This interface can obtain the latest news announcements, and the default
+   * page search is for announcements within a month.
+   */
+getAnnouncements(
+    params?: GetAnnouncementsRequestUTA,
+): Promise<APISuccessResponse<GetAnnouncementsResponseUTA>>
+⋮----
+/**
+   * Get Currency
+   * Request the currency details of a specified currency via this endpoint.
+   */
+getCurrency(
+    params?: GetCurrencyRequestUTA,
+): Promise<APISuccessResponse<GetCurrencyResponseUTA>>
+⋮----
+/**
+   * Get Third-Party Custody Currencies
+   * Query settlement currencies supported by third-party (OES) custodian institutions.
+   */
+getThirdPartyCustodyCurrencies(
+    params?: GetThirdPartyCustodyCurrenciesRequestUTA,
+): Promise<APISuccessResponse<ThirdPartyCustodyCurrencyUTA[]>>
+⋮----
+/**
+   * Get Symbol
+   * Request a list of available currency pairs for trading via this endpoint.
+   */
+getSymbols(
+    params: GetSymbolRequestUTA,
+): Promise<APISuccessResponse<GetSymbolResponseUTA>>
+⋮----
+/**
+   * Get Ticker
+   * Request market tickers for the trading pairs in the market (including 24h volume).
+   */
+getTickers(
+    params: GetTickerRequestUTA,
+): Promise<APISuccessResponse<GetTickerResponseUTA>>
+⋮----
+/**
+   * Get Trades
+   * Request via this endpoint to get the latest 100 public trades of the specified symbol.
+   */
+getTrades(
+    params: GetTradesRequestUTA,
+): Promise<APISuccessResponse<GetTradesResponseUTA>>
+⋮----
+/**
+   * Get OrderBook
+   * Query order book depth information (aggregated by price).
+   */
+getOrderBook(
+    params: GetOrderBookRequestUTA,
+): Promise<APISuccessResponse<GetOrderBookResponseUTA>>
+⋮----
+/**
+   * Get Klines
+   * Get the Kline of the symbol. Data are returned in grouped buckets based on requested type.
+   */
+getKlines(
+    params: GetKlinesRequestUTA,
+): Promise<APISuccessResponse<GetKlinesResponseUTA>>
+⋮----
+/**
+   * Get Current Funding Rate
+   * Get current Futures funding fee rate.
+   */
+getCurrentFundingRate(
+    params: GetCurrentFundingRateRequestUTA,
+): Promise<APISuccessResponse<GetCurrentFundingRateResponseUTA>>
+⋮----
+/**
+   * Get History Funding Rate
+   * Query the Futures funding rate at each settlement time point within a certain time range.
+   */
+getHistoryFundingRate(
+    params: GetHistoryFundingRateRequestUTA,
+): Promise<APISuccessResponse<GetHistoryFundingRateResponseUTA>>
+⋮----
+/**
+   * Get Cross Margin Config
+   * Request the configure info of the 'spot cross margin' via this endpoint.
+   */
+getCrossMarginConfig(): Promise<
+    APISuccessResponse<GetCrossMarginConfigResponseUTA>
+  > {
+    return this.get('api/ua/v1/market/cross-config');
+⋮----
+/**
+   * Get Borrowable Currencies
+   * List of borrowable currencies (UTA / public).
+   */
+getBorrowableCurrencies(): Promise<
+    APISuccessResponse<BorrowableCurrencyUTA[]>
+  > {
+    return this.get('api/ua/v1/market/borrowable-currency');
+⋮----
+/**
+   * Get Service Status
+   * Get the service status.
+   */
+getServiceStatus(
+    params: GetServiceStatusRequestUTA,
+): Promise<APISuccessResponse<GetServiceStatusResponseUTA>>
+⋮----
+/**
+   *
+   * REST - Unified Trading Account - Account
+   *
+   */
+⋮----
+/**
+   * Get Account (Classic)
+   * Get information for Classic Account (FUNDING, SPOT, FUTURES, CROSS, ISOLATED).
+   * Note: AccountType enum value changed from TRADING to SPOT as of 2026.01.17.
+   */
+getClassicAccount(
+    params: GetClassicAccountRequestUTA,
+): Promise<APISuccessResponse<GetClassicAccountResponseUTA>>
+⋮----
+/**
+   * Get Account (UTA)
+   * Get information for Unified Trading Account.
+   */
+getAccount(): Promise<APISuccessResponse<GetClassicAccountResponseUTA>>
+⋮----
+/**
+   * Get Account Overview (UTA)
+   * Get account overview for Unified Trading Account.
+   */
+getAccountOverview(): Promise<
+    APISuccessResponse<GetAccountOverviewResponseUTA>
+  > {
+    return this.getPrivate('api/ua/v1/unified/account/overview');
+⋮----
+/**
+   * Get Sub Account
+   * Request sub account info via this endpoint.
+   */
+getSubAccount(
+    params?: GetSubAccountRequestUTA,
+): Promise<APISuccessResponse<GetSubAccountResponseUTA>>
+⋮----
+/**
+   * Get Transfer Quotas
+   * This endpoint returns the transferable balance of a specified account.
+   * Note: AccountType enum value changed from TRADING to SPOT as of 2026.01.17.
+   */
+getTransferQuotas(
+    params: GetTransferQuotasRequestUTA,
+): Promise<APISuccessResponse<GetTransferQuotasResponseUTA>>
+⋮----
+/**
+   * Flex Transfer
+   * This interface can be used for transfers between master- and sub-accounts and transfers.
+   * Note: AccountType enum value changed from TRADING to SPOT as of 2026.01.17.
+   */
+flexTransfer(
+    params: FlexTransferRequestUTA,
+): Promise<APISuccessResponse<FlexTransferResponseUTA>>
+⋮----
+/**
+   * Set Sub Account Transfer Permission
+   * This endpoint supports setting whether the specified sub-account needs to open the SUB_TO_SUB transfer permission.
+   */
+setSubAccountTransferPermission(
+    params: SetSubAccountTransferPermissionRequestUTA,
+): Promise<APISuccessResponse<SubAccountTransferPermissionUTA[]>>
+⋮----
+/**
+   * Get Account Mode
+   * This interface supports query the list of unified and classic sub-accounts and current account mode.
+   */
+getAccountMode(): Promise<APISuccessResponse<GetAccountModeResponseUTA>>
+⋮----
+/**
+   * Set Account Mode
+   * This interface supports set account mode to UTA.
+   */
+setAccountMode(
+    params: SetAccountModeRequestUTA,
+): Promise<APISuccessResponse<null>>
+⋮----
+/**
+   * Get Fee Rate
+   * This interface is for the trading pair's actual fee rate.
+   * You can inquire about fee rates of 10 trading pairs each time at most for Spot.
+   * Futures only supports 1 symbol at a time.
+   */
+getFeeRate(
+    params: GetFeeRateRequestUTA,
+): Promise<APISuccessResponse<GetFeeRateResponseUTA>>
+⋮----
+/**
+   * Get Account Ledger
+   * This API endpoint returns all transfer (in and out) records and supports multi-coin queries.
+   * The query results are sorted in descending order by createdAt and ID.
+   * Note: AccountType enum value changed from TRADING to SPOT as of 2026.01.17.
+   * Note: direction values unified to uppercase IN/OUT as of 2026.01.17.
+   * Note: For Futures - id changed from Number to String, balance/amount changed from Number to String as of 2026.01.17.
+   * Note: ts standardized to nanoseconds as of 2026.01.12.
+   */
+getAccountLedger(
+    params: GetAccountLedgerRequestUTA,
+  ): Promise<
+    APISuccessResponse<
+      GetAccountLedgerResponseUTA | GetAccountLedgerResponseClassicUTA
+    >
+  > {
+    return this.getPrivate('api/ua/v1/account/ledger', params);
+⋮----
+/**
+   * Get Interest History (UTA)
+   * Request the interest records via this endpoint.
+   */
+getInterestHistory(
+    params: GetInterestHistoryRequestUTA,
+): Promise<APISuccessResponse<GetInterestHistoryResponseUTA>>
+⋮----
+/**
+   * Get Borrowing Rates and Limits
+   * Hourly/daily rates and borrow limits (UTA).
+   */
+getBorrowingRatesAndLimits(
+    params: GetBorrowingRatesAndLimitsRequestUTA,
+): Promise<APISuccessResponse<GetBorrowingRatesAndLimitsResponseUTA>>
+⋮----
+/**
+   * Modify Leverage (UTA)
+   * This interface supports modify leverage of the specified symbol.
+   */
+modifyLeverage(
+    params: ModifyLeverageRequestUTA,
+): Promise<APISuccessResponse<null>>
+⋮----
+/**
+   * Modify Leverage Margin Cross (UTA)
+   * Update leverage for a currency in UTA cross margin.
+   */
+modifyMarginCrossLeverage(
+    params: ModifyMarginCrossLeverageRequestUTA,
+    accountMode: 'unified' = 'unified',
+): Promise<APISuccessResponse<ModifyMarginCrossLeverageResponseUTA>>
+⋮----
+/**
+   * Get Leverage (UTA)
+   * Query leverage for MARGIN (currency) or FUTURES (symbol).
+   */
+getLeverage(
+    params: GetLeverageRequestUTA,
+): Promise<APISuccessResponse<GetLeverageItemUTA[]>>
+⋮----
+/**
+   * Get Deposit Address
+   * Return a deposit address; when both currency and chain are provided,
+   * the address will be created if it does not exist.
+   * URL unified to GET /api/ua/v1/asset/deposit/address as of 2026.01.17.
+   */
+getDepositAddress(
+    params: GetDepositAddressRequestUTA,
+): Promise<APISuccessResponse<DepositAddressUTA[]>>
+⋮----
+/**
+   * Get Third-Party Custody Account Currency Limits
+   * OES remaining custody quota per custodian and settlement currency.
+   */
+getThirdPartyCustodyQuota(
+    params?: GetThirdPartyCustodyQuotaRequestUTA,
+): Promise<APISuccessResponse<ThirdPartyCustodyQuotaUTA[]>>
+⋮----
+/**
+   *
+   * REST - Unified Trading Account - Orders
+   *
+   */
+⋮----
+/**
+   * Place Order
+   * This interface can be used to place orders.
+   * Supports RPI (Retail Price Improvement) orders for Futures as of 2025.01.02.
+   * Note: timeInForce supports 'RPI' value for Futures only (Phase 1).
+   * Note: For Classic mode, tradeType is required in query param.
+   * Note: For Unified mode, tradeType is sent in the request body (incl. MARGIN as of 2026.04.19).
+   */
+placeOrder(
+    params: PlaceOrderRequestUTA,
+    accountMode: 'classic' | 'unified' = 'unified',
+): Promise<APISuccessResponse<PlaceOrderResponseUTA>>
+⋮----
+/**
+   * Batch Place Order (Classic)
+   * This interface can be used for placing batch orders.
+   * URL changed to /api/ua/v1/{accountMode}/order/place-batch as of 2026.01.17.
+   * Note: timeInForce supports 'RPI' value for Futures as of 2025.01.02.
+   */
+batchPlaceOrder(
+    params: BatchPlaceOrderRequestUTA,
+    accountMode: 'classic' | 'unified' = 'classic',
+): Promise<APISuccessResponse<BatchPlaceOrderResponseUTA>>
+⋮----
+/**
+   * Get Order Details
+   * This interface can be used getting single order details.
+   * Note: timeInForce returns 'RPI' value for Futures RPI orders as of 2025.01.02.
+   * Note: status changed from String to Number for UTA as of 2026.01.17.
+   * Note: orderTime/updatedTime standardized to nanoseconds as of 2026.01.12.
+   */
+getOrderDetails(
+    params: GetOrderDetailsRequestUTA,
+    accountMode: 'classic' | 'unified' = 'unified',
+): Promise<APISuccessResponse<OrderDetailsUTA>>
+⋮----
+/**
+   * Get Open Order List
+   * This interface can be used getting open order list.
+   * Note: timeInForce returns 'RPI' value for Futures RPI orders as of 2025.01.02.
+   * Note: status changed from String to Number for UTA as of 2026.01.17.
+   * Note: orderTime/updatedTime standardized to nanoseconds as of 2026.01.12.
+   */
+getOpenOrderList(
+    params: GetOpenOrderListRequestUTA,
+    accountMode: 'classic' | 'unified' = 'unified',
+): Promise<APISuccessResponse<GetOpenOrderListResponseUTA>>
+⋮----
+/**
+   * Get Order History
+   * This interface can be used for getting order history.
+   * Note: timeInForce returns 'RPI' value for Futures RPI orders as of 2025.01.02.
+   * Note: status changed from String to Number for UTA as of 2026.01.17.
+   * Note: orderTime/updatedTime standardized to nanoseconds as of 2026.01.12.
+   */
+getOrderHistory(
+    params: GetOrderHistoryRequestUTA,
+    accountMode: 'classic' | 'unified' = 'unified',
+): Promise<APISuccessResponse<GetOrderHistoryResponseUTA>>
+⋮----
+/**
+   * Get Trade History
+   * This interface can be used for getting trade execution history.
+   * Note: executionTime standardized to nanoseconds as of 2026.01.12.
+   * Note: isRpiTrade added for Futures as of 2025.01.02.
+   */
+getTradeHistory(
+    params: GetTradeHistoryRequestUTA,
+    accountMode: 'classic' | 'unified' = 'unified',
+): Promise<APISuccessResponse<GetTradeHistoryResponseUTA>>
+⋮----
+/**
+   * Cancel Order
+   * This interface can be used to cancel orders.
+   * Note: ts (timestamp in nanoseconds) only effective for unified account mode.
+   */
+cancelOrder(
+    params: CancelOrderRequestUTA,
+    accountMode: 'classic' | 'unified' = 'unified',
+): Promise<APISuccessResponse<CancelOrderResponseUTA>>
+⋮----
+/**
+   * Batch Cancel Orders
+   * This interface can be used for batch cancel orders (maximum 20 orders).
+   * Note: tradeType required for Classic accounts only; ignored in UTA (UNIFIED) mode.
+   * Note: ts (timestamp in nanoseconds) not supported for classic accounts.
+   */
+batchCancelOrders(
+    params: BatchCancelOrdersRequestUTA,
+    accountMode: 'classic' | 'unified' = 'unified',
+): Promise<APISuccessResponse<BatchCancelOrdersResponseUTA>>
+⋮----
+/**
+   * Batch Cancel Orders By Symbol
+   * Cancels orders in batch by symbol. UTA only. Supports SPOT (non-margin) and Futures Cross Margin.
+   */
+batchCancelOrdersBySymbol(
+    params: BatchCancelOrdersBySymbolRequestUTA,
+): Promise<APISuccessResponse<BatchCancelOrdersBySymbolResponseUTA>>
+⋮----
+/**
+   * Set DCP (Disconnection Protect / Deadman Switch) - Classic Only
+   * Set automatic order cancellation after specified time.
+   * Call this interface to automatically cancel all orders of the set trading pair after the specified time.
+   * Note: Order cancellation delay is between 0 and 10 seconds.
+   * Note: timeout range: -1 (unset) or 5 <= timeout <= 86400 seconds.
+   */
+setDCP(
+    params: SetDCPRequestUTA,
+): Promise<APISuccessResponse<DCPResponseUTA>>
+⋮----
+/**
+   * Get DCP (Disconnection Protect / Deadman Switch) - Classic Only
+   * Get automatic order cancellation settings.
+   * If data is empty, it means DCP is not set.
+   */
+getDCP(
+    params: GetDCPRequestUTA,
+): Promise<APISuccessResponse<DCPResponseUTA>>
+⋮----
+/**
+   *
+   * REST - Unified Trading Account - Positions
+   *
+   */
+⋮----
+/**
+   * Get Position List (UTA)
+   * Get the position details of all open positions.
+   * Note: creationTime standardized to nanoseconds as of 2026.01.12.
+   * Note: pageNumber, pageSize query params and liquidationPrice in each position (as of 2026.04.09).
+   */
+getPositionList(
+    params?: GetPositionListRequestUTA,
+): Promise<APISuccessResponse<PositionUTA[]>>
+⋮----
+/**
+   * Get Positions History (UTA)
+   * Query position history information records.
+   * Note: Data retained for up to 3 months.
+   * Note: Each query limited to 7 days time range.
+   * Note: creationTime and closingTime standardized to nanoseconds as of 2026.01.12.
+   */
+getPositionsHistory(
+    params?: GetPositionsHistoryRequestUTA,
+): Promise<APISuccessResponse<GetPositionsHistoryResponseUTA>>
+⋮----
+/**
+   * Get Private Funding Fee History
+   * Settled funding fee records for the current account.
+   */
+getPrivateFundingFeeHistory(
+    params?: GetPrivateFundingFeeHistoryRequestUTA,
+): Promise<APISuccessResponse<GetPrivateFundingFeeHistoryResponseUTA>>
+⋮----
+/**
+   * Get Account Position Tiers
+   * Request account position tiers (risk limit) info.
+   * Note: Currently only queries of classic - futures isolated margin are supported.
+   */
+getAccountPositionTiers(
+    params: GetAccountPositionTiersRequestUTA,
+    accountMode: 'classic' | 'unified' = 'classic',
+): Promise<APISuccessResponse<PositionTierUTA[]>>
+
+================
+File: src/lib/BaseWSClient.ts
+================
+import EventEmitter from 'events';
+import WebSocket from 'isomorphic-ws';
+⋮----
+import { WsOperation } from '../types/websockets/ws-api.js';
+import {
+  isMessageEvent,
+  MessageEventLike,
+} from '../types/websockets/ws-events.js';
+import {
+  WebsocketClientOptions,
+  WSClientConfigurableOptions,
+  WsEventInternalSrc,
+} from '../types/websockets/ws-general.js';
+import { WS_LOGGER_CATEGORY } from '../WebsocketClient.js';
+import { checkWebCryptoAPISupported } from './webCryptoAPI.js';
+import { DefaultLogger } from './websocket/logger.js';
+import {
+  bufferLooksLikeText,
+  decompressMessageEvent,
+  isBufferMessageEvent,
+  safeTerminateWs,
+  WsTopicRequest,
+  WsTopicRequestOrStringTopic,
+} from './websocket/websocket-util.js';
+import { WsStore } from './websocket/WsStore.js';
+import {
+  WSConnectedResult,
+  WsConnectionStateEnum,
+} from './websocket/WsStore.types.js';
+⋮----
+type UseTheExceptionEventInstead = never;
+⋮----
+interface WSClientEventMap<WsKey extends string> {
+  /** Connection opened. If this connection was previously opened and reconnected, expect the reconnected event instead */
+  open: (evt: {
+    wsKey: WsKey;
+    event: any;
+    wsUrl: string;
+    ws: WebSocket;
+  }) => void;
+
+  /** Reconnecting a dropped connection */
+  reconnect: (evt: { wsKey: WsKey; event: any }) => void;
+
+  /** Successfully reconnected a connection that dropped */
+  reconnected: (evt: {
+    wsKey: WsKey;
+    event: any;
+    wsUrl: string;
+    ws: WebSocket;
+  }) => void;
+
+  /** Connection closed */
+  close: (evt: { wsKey: WsKey; event: any }) => void;
+
+  /** Received reply to websocket command (e.g. after subscribing to topics) */
+  response: (response: any & { wsKey: WsKey }) => void;
+
+  /** Received data for topic */
+  update: (response: any & { wsKey: WsKey }) => void;
+
+  /** Exception from ws client OR custom listeners (e.g. if you throw inside your event handler) */
+  exception: (response: any & { wsKey: WsKey }) => void;
+
+  /**
+   * See for more information: https://github.com/tiagosiebler/bybit-api/issues/413
+   * @deprecated Use the 'exception' event instead. The 'error' event had the unintended consequence of throwing an unhandled promise rejection.
+   */
+  error: UseTheExceptionEventInstead;
+
+  /** Confirmation that a connection successfully authenticated */
+  authenticated: (event: { wsKey: WsKey; event: any }) => void;
+}
+⋮----
+/** Connection opened. If this connection was previously opened and reconnected, expect the reconnected event instead */
+⋮----
+/** Reconnecting a dropped connection */
+⋮----
+/** Successfully reconnected a connection that dropped */
+⋮----
+/** Connection closed */
+⋮----
+/** Received reply to websocket command (e.g. after subscribing to topics) */
+⋮----
+/** Received data for topic */
+⋮----
+/** Exception from ws client OR custom listeners (e.g. if you throw inside your event handler) */
+⋮----
+/**
+   * See for more information: https://github.com/tiagosiebler/bybit-api/issues/413
+   * @deprecated Use the 'exception' event instead. The 'error' event had the unintended consequence of throwing an unhandled promise rejection.
+   */
+⋮----
+/** Confirmation that a connection successfully authenticated */
+⋮----
+export interface EmittableEvent<TEvent = any> {
+  eventType:
+    | 'response'
+    | 'update'
+    | 'exception'
+    | 'connectionReadyForAuth' // tied to specific events we need to wait for, before we can begin post-connect auth
+    | 'authenticated'
+    | 'connectionReady'; // tied to "requireConnectionReadyConfirmation"
+  event: TEvent;
+  isWSAPIResponse?: boolean;
+}
+⋮----
+| 'connectionReadyForAuth' // tied to specific events we need to wait for, before we can begin post-connect auth
+⋮----
+| 'connectionReady'; // tied to "requireConnectionReadyConfirmation"
+⋮----
+// Type safety for on and emit handlers: https://stackoverflow.com/a/61609010/880837
+export interface BaseWebsocketClient<TWSKey extends string> {
+  on<U extends keyof WSClientEventMap<TWSKey>>(
+    event: U,
+    listener: WSClientEventMap<TWSKey>[U],
+  ): this;
+
+  emit<U extends keyof WSClientEventMap<TWSKey>>(
+    event: U,
+    ...args: Parameters<WSClientEventMap<TWSKey>[U]>
+  ): boolean;
+}
+⋮----
+on<U extends keyof WSClientEventMap<TWSKey>>(
+    event: U,
+    listener: WSClientEventMap<TWSKey>[U],
+  ): this;
+⋮----
+emit<U extends keyof WSClientEventMap<TWSKey>>(
+    event: U,
+    ...args: Parameters<WSClientEventMap<TWSKey>[U]>
+  ): boolean;
+⋮----
+/**
+ * Appends wsKey and isWSAPIResponse to all events.
+ * Some events are arrays, this handles that nested scenario too.
+ */
+function getFinalEmittable(
+  emittable: EmittableEvent | EmittableEvent[],
+  wsKey: any,
+  isWSAPIResponse?: boolean,
+): any
+⋮----
+// Some topics just emit an array.
+// This is consistent with how it was before the WS API upgrade:
+⋮----
+// const { event, ...others } = emittable;
+// return {
+//   ...others,
+//   event: event.map((subEvent) =>
+//     getFinalEmittable(subEvent, wsKey, isWSAPIResponse),
+//   ),
+// };
+⋮----
+/**
+ * Users can conveniently pass topics as strings or objects (object has topic name + optional params).
+ *
+ * This method normalises topics into objects (object has topic name + optional params).
+ */
+function getNormalisedTopicRequests(
+  wsTopicRequests: WsTopicRequestOrStringTopic<string>[],
+): WsTopicRequest<string>[]
+⋮----
+// passed as string, convert to object
+⋮----
+// already a normalised object, thanks to user
+⋮----
+type WSTopic = string;
+⋮----
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export abstract class BaseWebsocketClient<
+TWSKey extends string,
+⋮----
+constructor(options?: WSClientConfigurableOptions, logger?: DefaultLogger)
+⋮----
+// Requires a confirmation "response" from the ws connection before assuming it is ready
+⋮----
+// Automatically auth after opening a connection?
+⋮----
+// Automatically include auth/sign with every WS request
+⋮----
+// Automatically re-auth WS API, if we were auth'd before and get reconnected
+⋮----
+// Whether to use native heartbeats (depends on the exchange)
+⋮----
+// Check Web Crypto API support when credentials are provided and no custom sign function is used
+⋮----
+protected abstract sendPingEvent(wsKey: TWSKey, ws: WebSocket): void;
+⋮----
+protected abstract sendPongEvent(wsKey: TWSKey, ws: WebSocket): void;
+⋮----
+protected abstract isWsPing(data: any): boolean;
+⋮----
+protected abstract isWsPong(data: any): boolean;
+⋮----
+protected abstract getWsAuthRequestEvent(
+    wsKey: TWSKey,
+    eventToAuth?: object,
+  ): Promise<object | string | 'waitForEvent' | void>;
+⋮----
+protected abstract isPrivateTopicRequest(
+    request: WsTopicRequest<WSTopic>,
+    wsKey: TWSKey,
+  ): boolean;
+⋮----
+/**
+   * Returns a list of string events that can be individually sent upstream to complete subscribing/unsubscribing/etc to these topics
+   */
+protected abstract getWsOperationEventsForTopics(
+    topics: WsTopicRequest<WSTopic>[],
+    wsKey: TWSKey,
+    operation: WsOperation,
+  ): Promise<string[]>;
+⋮----
+protected abstract getPrivateWSKeys(): TWSKey[];
+⋮----
+protected abstract getWsUrl(wsKey: TWSKey): Promise<string>;
+⋮----
+protected abstract getMaxTopicsPerSubscribeEvent(
+    wsKey: TWSKey,
+  ): number | null;
+⋮----
+/**
+   * Abstraction called to sort ws events into emittable event types (response to a request, data update, etc)
+   */
+protected abstract resolveEmittableEvents(
+    wsKey: TWSKey,
+    event: MessageEventLike,
+  ): EmittableEvent[];
+⋮----
+/**
+   * Request connection of all dependent (public & private) websockets, instead of waiting for automatic connection by library
+   */
+protected abstract connectAll(): Promise<(WSConnectedResult | undefined)[]>;
+⋮----
+protected isPrivateWsKey(wsKey: TWSKey): boolean
+⋮----
+/** Returns auto-incrementing request ID, used to track promise references for async requests */
+protected getNewRequestId(): string
+⋮----
+// protected abstract sendWSAPIRequest(
+//   wsKey: TWSKey,
+//   operation: string,
+//   params?: any,
+// ): Promise<unknown>;
+⋮----
+/**
+   * Subscribe to one or more topics on a WS connection (identified by WS Key).
+   *
+   * - Topics are automatically cached
+   * - Connections are automatically opened, if not yet connected
+   * - Authentication is automatically handled
+   * - Topics are automatically resubscribed to, if something happens to the connection, unless you call unsubsribeTopicsForWsKey(topics, key).
+   *
+   * @param wsTopicRequests array of topics to subscribe to
+   * @param wsKey ws key referring to the ws connection these topics should be subscribed on
+   */
+public subscribeTopicsForWsKey(
+    wsTopicRequests: WsTopicRequestOrStringTopic<WSTopic>[],
+    wsKey: TWSKey,
+)
+⋮----
+// Store topics, so future automation (post-auth, post-reconnect) has everything needed to resubscribe automatically
+⋮----
+// start connection process if it hasn't yet begun. Topics are automatically subscribed to on-connect
+⋮----
+// Subscribe should happen automatically once connected, nothing to do here after topics are added to wsStore.
+⋮----
+/**
+       * Are we in the process of connection? Nothing to send yet.
+       */
+⋮----
+// We're connected. Check if auth is needed and if already authenticated
+⋮----
+/**
+       * If not authenticated yet and auth is required, don't request topics yet.
+       *
+       * Auth should already automatically be in progress, so no action needed from here. Topics will automatically subscribe post-auth success.
+       */
+⋮----
+// Finally, request subscription to topics if the connection is healthy and ready
+⋮----
+protected unsubscribeTopicsForWsKey(
+    wsTopicRequests: WsTopicRequestOrStringTopic<string>[],
+    wsKey: TWSKey,
+)
+⋮----
+// Store topics, so future automation (post-auth, post-reconnect) has everything needed to resubscribe automatically
+⋮----
+// If not connected, don't need to do anything.
+// Removing the topic from the store is enough to stop it from being resubscribed to on reconnect.
+⋮----
+// We're connected. Check if auth is needed and if already authenticated
+⋮----
+/**
+       * If not authenticated yet and auth is required, don't need to do anything.
+       * We don't subscribe to topics until auth is complete anyway.
+       */
+⋮----
+// Finally, request subscription to topics if the connection is healthy and ready
+⋮----
+/**
+   * Splits topic requests into two groups, public & private topic requests
+   */
+private sortTopicRequestsIntoPublicPrivate(
+    wsTopicRequests: WsTopicRequest<string>[],
+    wsKey: TWSKey,
+):
+⋮----
+/** Get the WsStore that tracks websockets & topics */
+public getWsStore(): WsStore<TWSKey, WsTopicRequest<string>>
+⋮----
+public close(wsKey: TWSKey, force?: boolean)
+⋮----
+public closeAll(force?: boolean)
+⋮----
+public isConnected(wsKey: TWSKey): boolean
+⋮----
+/**
+   * Request connection to a specific websocket, instead of waiting for automatic connection.
+   */
+public async connect(
+    wsKey: TWSKey,
+    customUrl?: string | undefined,
+    throwOnError?: boolean,
+): Promise<WSConnectedResult | undefined>
+⋮----
+// Important: don't check for RECONNECTING here, or this clashes with reconnectWithDelay()!
+⋮----
+private connectToWsUrl(url: string, wsKey: TWSKey): WebSocket
+⋮----
+// Native ws ping/pong frames are not in use for okx
+⋮----
+private parseWsError(context: string, error: any, wsKey: TWSKey): boolean
+⋮----
+// Allow retry by default (in some places that call this). Prevent deadloop in hard failure (401)
+⋮----
+/** Get a signature, build the auth request and send it */
+private async sendAuthRequest(
+    wsKey: TWSKey,
+    eventToAuth?: object,
+): Promise<unknown>
+⋮----
+// If not required, this won't return anything
+⋮----
+// Short-circuit this for the next time it's called
+⋮----
+private reconnectWithDelay(wsKey: TWSKey, connectionDelayMs: number)
+⋮----
+private ping(wsKey: TWSKey)
+⋮----
+private clearTimers(wsKey: TWSKey)
+⋮----
+// Send a ping at intervals
+private clearPingTimer(wsKey: TWSKey)
+⋮----
+// Expect a pong within a time limit
+private clearPongTimer(wsKey: TWSKey)
+⋮----
+// this.logger.trace(`Cleared pong timeout for "${wsKey}"`);
+⋮----
+// this.logger.trace(`No active pong timer for "${wsKey}"`);
+⋮----
+/**
+   * Simply builds and sends subscribe events for a list of topics for a ws key
+   *
+   * @private Use the `subscribe(topics)` or `subscribeTopicsForWsKey(topics, wsKey)` method to subscribe to topics. Send WS message to subscribe to topics.
+   */
+private async requestSubscribeTopics(
+    wsKey: TWSKey,
+    topics: WsTopicRequest<string>[],
+)
+⋮----
+// Automatically splits requests into smaller batches, if needed
+⋮----
+`Subscribing to ${topics.length} "${wsKey}" topics in ${subscribeWsMessages.length} batches.`, // Events: "${JSON.stringify(topics)}"
+⋮----
+/**
+   * Simply builds and sends unsubscribe events for a list of topics for a ws key
+   *
+   * @private Use the `unsubscribe(topics)` method to unsubscribe from topics. Send WS message to unsubscribe from topics.
+   */
+private async requestUnsubscribeTopics(
+    wsKey: TWSKey,
+    wsTopicRequests: WsTopicRequest<string>[],
+)
+⋮----
+/**
+   * Try sending a string event on a WS connection (identified by the WS Key)
+   */
+public tryWsSend(
+    wsKey: TWSKey,
+    wsMessage: string,
+    throwExceptions?: boolean,
+)
+⋮----
+private async onWsOpen(
+    event: WebSocket.Event,
+    wsKey: TWSKey,
+    url: string,
+    ws: WebSocket,
+)
+⋮----
+// Resolve & cleanup deferred "connection attempt in progress" promise
+⋮----
+// Remove before continuing, in case there's more requests queued
+⋮----
+/**
+   * Called automatically once a connection is ready.
+   * - Some exchanges are ready immediately after the connections open.
+   * - Some exchanges send an event to confirm the connection is ready for us.
+   *
+   * This method is called to act when the connection is ready. Use `requireConnectionReadyConfirmation` to control how this is called.
+   */
+private async onWsReadyForEvents(wsKey: TWSKey)
+⋮----
+// Resolve & cleanup deferred "connection attempt in progress" promise
+⋮----
+// Remove before resolving, in case there's more requests queued
+⋮----
+// Some websockets require an auth packet to be sent after opening the connection
+⋮----
+// Reconnect to topics known before it connected
+⋮----
+// Request sub to public topics, if any
+⋮----
+// Request sub to private topics, if auth on connect isn't needed
+⋮----
+/**
+   * Handle subscription to private topics _after_ authentication successfully completes asynchronously.
+   *
+   * Only used for exchanges that require auth before sending private topic subscription requests
+   */
+private onWsAuthenticated(
+    wsKey: TWSKey,
+    event: { isWSAPI?: boolean; WSAPIAuthChannel?: string },
+)
+⋮----
+// Resolve & cleanup deferred "auth attempt in progress" promise
+⋮----
+// Remove before continuing, in case there's more requests queued
+⋮----
+private onWsPing(
+    event: any,
+    wsKey: TWSKey,
+    ws: WebSocket,
+    source: WsEventInternalSrc,
+)
+⋮----
+private onWsPong(event: any, wsKey: TWSKey, source: WsEventInternalSrc)
+⋮----
+private async onWsMessage(
+    event: unknown,
+    wsKey: TWSKey,
+    ws: WebSocket,
+    didDecompress = false,
+): Promise<unknown>
+⋮----
+// any message can clear the pong timer - wouldn't get a message if the ws wasn't working
+⋮----
+// console.log(`raw event: `, { data, dataType, emittableEvents });
+⋮----
+// Other event types are automatically emitted here
+// this.logger.trace(
+//   `onWsMessage().emit(${emittable.eventType})`,
+//   emittableFinalEvent,
+// );
+⋮----
+// this.logger.trace(
+//   `onWsMessage().emit(${emittable.eventType}).done()`,
+//   emittableFinalEvent,
+// );
+⋮----
+// eventStr: JSON.stringify(event, null, 2),
+⋮----
+private onWsClose(event: unknown, wsKey: TWSKey)
+⋮----
+// unintentional close, attempt recovery
+⋮----
+// clean up any pending promises for this connection
+⋮----
+// intentional close - clean up
+// clean up any pending promises for this connection
+⋮----
+// This was an intentional close, delete all state for this connection, as if it never existed:
+⋮----
+private getWs(wsKey: TWSKey)
+⋮----
+private setWsState(wsKey: TWSKey, state: WsConnectionStateEnum)
+⋮----
+/**
+   * Promise-driven method to assert that a ws has successfully connected (will await until connection is open)
+   */
+protected async assertIsConnected(wsKey: TWSKey): Promise<unknown>
+⋮----
+// Already in progress? Await shared promise and retry
+⋮----
+// this.logger.trace('assertIsConnected(): awaiting...');
+⋮----
+// this.logger.trace('assertIsConnected(): awaiting...connected!');
+⋮----
+// Start connection, it should automatically store/return a promise.
+// this.logger.trace('assertIsConnected(): connecting...');
+⋮----
+// this.logger.trace('assertIsConnected(): connecting...newly connected!');
+⋮----
+/**
+   * Promise-driven method to assert that a ws has been successfully authenticated (will await until auth is confirmed)
+   */
+public async assertIsAuthenticated(wsKey: TWSKey): Promise<unknown>
+⋮----
+// this.logger.trace('assertIsAuthenticated(): connecting...');
+⋮----
+// Already in progress? Await shared promise and retry
+⋮----
+// this.logger.trace('assertIsAuthenticated(): awaiting...');
+⋮----
+// this.logger.trace('assertIsAuthenticated(): authenticated!');
+⋮----
+// this.logger.trace('assertIsAuthenticated(): ok');
+⋮----
+// Start authentication, it should automatically store/return a promise.
+// this.logger.trace('assertIsAuthenticated(): authenticating...');
+⋮----
+// this.logger.trace('assertIsAuthenticated(): newly authenticated!');
 
 ================
 File: src/SpotClient.ts
@@ -14486,536 +15358,6 @@ getIsolatedMarginAccount(params: {
 }): Promise<APISuccessResponse<SingleIsolatedMarginAccountInfo>>
 
 ================
-File: src/lib/BaseWSClient.ts
-================
-import EventEmitter from 'events';
-import WebSocket from 'isomorphic-ws';
-⋮----
-import { WsOperation } from '../types/websockets/ws-api.js';
-import {
-  isMessageEvent,
-  MessageEventLike,
-} from '../types/websockets/ws-events.js';
-import {
-  WebsocketClientOptions,
-  WSClientConfigurableOptions,
-  WsEventInternalSrc,
-} from '../types/websockets/ws-general.js';
-import { WS_LOGGER_CATEGORY } from '../WebsocketClient.js';
-import { checkWebCryptoAPISupported } from './webCryptoAPI.js';
-import { DefaultLogger } from './websocket/logger.js';
-import {
-  bufferLooksLikeText,
-  decompressMessageEvent,
-  isBufferMessageEvent,
-  safeTerminateWs,
-  WsTopicRequest,
-  WsTopicRequestOrStringTopic,
-} from './websocket/websocket-util.js';
-import { WsStore } from './websocket/WsStore.js';
-import {
-  WSConnectedResult,
-  WsConnectionStateEnum,
-} from './websocket/WsStore.types.js';
-⋮----
-type UseTheExceptionEventInstead = never;
-⋮----
-interface WSClientEventMap<WsKey extends string> {
-  /** Connection opened. If this connection was previously opened and reconnected, expect the reconnected event instead */
-  open: (evt: {
-    wsKey: WsKey;
-    event: any;
-    wsUrl: string;
-    ws: WebSocket;
-  }) => void;
-
-  /** Reconnecting a dropped connection */
-  reconnect: (evt: { wsKey: WsKey; event: any }) => void;
-
-  /** Successfully reconnected a connection that dropped */
-  reconnected: (evt: {
-    wsKey: WsKey;
-    event: any;
-    wsUrl: string;
-    ws: WebSocket;
-  }) => void;
-
-  /** Connection closed */
-  close: (evt: { wsKey: WsKey; event: any }) => void;
-
-  /** Received reply to websocket command (e.g. after subscribing to topics) */
-  response: (response: any & { wsKey: WsKey }) => void;
-
-  /** Received data for topic */
-  update: (response: any & { wsKey: WsKey }) => void;
-
-  /** Exception from ws client OR custom listeners (e.g. if you throw inside your event handler) */
-  exception: (response: any & { wsKey: WsKey }) => void;
-
-  /**
-   * See for more information: https://github.com/tiagosiebler/bybit-api/issues/413
-   * @deprecated Use the 'exception' event instead. The 'error' event had the unintended consequence of throwing an unhandled promise rejection.
-   */
-  error: UseTheExceptionEventInstead;
-
-  /** Confirmation that a connection successfully authenticated */
-  authenticated: (event: { wsKey: WsKey; event: any }) => void;
-}
-⋮----
-/** Connection opened. If this connection was previously opened and reconnected, expect the reconnected event instead */
-⋮----
-/** Reconnecting a dropped connection */
-⋮----
-/** Successfully reconnected a connection that dropped */
-⋮----
-/** Connection closed */
-⋮----
-/** Received reply to websocket command (e.g. after subscribing to topics) */
-⋮----
-/** Received data for topic */
-⋮----
-/** Exception from ws client OR custom listeners (e.g. if you throw inside your event handler) */
-⋮----
-/**
-   * See for more information: https://github.com/tiagosiebler/bybit-api/issues/413
-   * @deprecated Use the 'exception' event instead. The 'error' event had the unintended consequence of throwing an unhandled promise rejection.
-   */
-⋮----
-/** Confirmation that a connection successfully authenticated */
-⋮----
-export interface EmittableEvent<TEvent = any> {
-  eventType:
-    | 'response'
-    | 'update'
-    | 'exception'
-    | 'connectionReadyForAuth' // tied to specific events we need to wait for, before we can begin post-connect auth
-    | 'authenticated'
-    | 'connectionReady'; // tied to "requireConnectionReadyConfirmation"
-  event: TEvent;
-  isWSAPIResponse?: boolean;
-}
-⋮----
-| 'connectionReadyForAuth' // tied to specific events we need to wait for, before we can begin post-connect auth
-⋮----
-| 'connectionReady'; // tied to "requireConnectionReadyConfirmation"
-⋮----
-// Type safety for on and emit handlers: https://stackoverflow.com/a/61609010/880837
-export interface BaseWebsocketClient<TWSKey extends string> {
-  on<U extends keyof WSClientEventMap<TWSKey>>(
-    event: U,
-    listener: WSClientEventMap<TWSKey>[U],
-  ): this;
-
-  emit<U extends keyof WSClientEventMap<TWSKey>>(
-    event: U,
-    ...args: Parameters<WSClientEventMap<TWSKey>[U]>
-  ): boolean;
-}
-⋮----
-on<U extends keyof WSClientEventMap<TWSKey>>(
-    event: U,
-    listener: WSClientEventMap<TWSKey>[U],
-  ): this;
-⋮----
-emit<U extends keyof WSClientEventMap<TWSKey>>(
-    event: U,
-    ...args: Parameters<WSClientEventMap<TWSKey>[U]>
-  ): boolean;
-⋮----
-/**
- * Appends wsKey and isWSAPIResponse to all events.
- * Some events are arrays, this handles that nested scenario too.
- */
-function getFinalEmittable(
-  emittable: EmittableEvent | EmittableEvent[],
-  wsKey: any,
-  isWSAPIResponse?: boolean,
-): any
-⋮----
-// Some topics just emit an array.
-// This is consistent with how it was before the WS API upgrade:
-⋮----
-// const { event, ...others } = emittable;
-// return {
-//   ...others,
-//   event: event.map((subEvent) =>
-//     getFinalEmittable(subEvent, wsKey, isWSAPIResponse),
-//   ),
-// };
-⋮----
-/**
- * Users can conveniently pass topics as strings or objects (object has topic name + optional params).
- *
- * This method normalises topics into objects (object has topic name + optional params).
- */
-function getNormalisedTopicRequests(
-  wsTopicRequests: WsTopicRequestOrStringTopic<string>[],
-): WsTopicRequest<string>[]
-⋮----
-// passed as string, convert to object
-⋮----
-// already a normalised object, thanks to user
-⋮----
-type WSTopic = string;
-⋮----
-// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
-export abstract class BaseWebsocketClient<
-TWSKey extends string,
-⋮----
-constructor(options?: WSClientConfigurableOptions, logger?: DefaultLogger)
-⋮----
-// Requires a confirmation "response" from the ws connection before assuming it is ready
-⋮----
-// Automatically auth after opening a connection?
-⋮----
-// Automatically include auth/sign with every WS request
-⋮----
-// Automatically re-auth WS API, if we were auth'd before and get reconnected
-⋮----
-// Whether to use native heartbeats (depends on the exchange)
-⋮----
-// Check Web Crypto API support when credentials are provided and no custom sign function is used
-⋮----
-protected abstract sendPingEvent(wsKey: TWSKey, ws: WebSocket): void;
-⋮----
-protected abstract sendPongEvent(wsKey: TWSKey, ws: WebSocket): void;
-⋮----
-protected abstract isWsPing(data: any): boolean;
-⋮----
-protected abstract isWsPong(data: any): boolean;
-⋮----
-protected abstract getWsAuthRequestEvent(
-    wsKey: TWSKey,
-    eventToAuth?: object,
-  ): Promise<object | string | 'waitForEvent' | void>;
-⋮----
-protected abstract isPrivateTopicRequest(
-    request: WsTopicRequest<WSTopic>,
-    wsKey: TWSKey,
-  ): boolean;
-⋮----
-/**
-   * Returns a list of string events that can be individually sent upstream to complete subscribing/unsubscribing/etc to these topics
-   */
-protected abstract getWsOperationEventsForTopics(
-    topics: WsTopicRequest<WSTopic>[],
-    wsKey: TWSKey,
-    operation: WsOperation,
-  ): Promise<string[]>;
-⋮----
-protected abstract getPrivateWSKeys(): TWSKey[];
-⋮----
-protected abstract getWsUrl(wsKey: TWSKey): Promise<string>;
-⋮----
-protected abstract getMaxTopicsPerSubscribeEvent(
-    wsKey: TWSKey,
-  ): number | null;
-⋮----
-/**
-   * Abstraction called to sort ws events into emittable event types (response to a request, data update, etc)
-   */
-protected abstract resolveEmittableEvents(
-    wsKey: TWSKey,
-    event: MessageEventLike,
-  ): EmittableEvent[];
-⋮----
-/**
-   * Request connection of all dependent (public & private) websockets, instead of waiting for automatic connection by library
-   */
-protected abstract connectAll(): Promise<(WSConnectedResult | undefined)[]>;
-⋮----
-protected isPrivateWsKey(wsKey: TWSKey): boolean
-⋮----
-/** Returns auto-incrementing request ID, used to track promise references for async requests */
-protected getNewRequestId(): string
-⋮----
-// protected abstract sendWSAPIRequest(
-//   wsKey: TWSKey,
-//   operation: string,
-//   params?: any,
-// ): Promise<unknown>;
-⋮----
-/**
-   * Subscribe to one or more topics on a WS connection (identified by WS Key).
-   *
-   * - Topics are automatically cached
-   * - Connections are automatically opened, if not yet connected
-   * - Authentication is automatically handled
-   * - Topics are automatically resubscribed to, if something happens to the connection, unless you call unsubsribeTopicsForWsKey(topics, key).
-   *
-   * @param wsTopicRequests array of topics to subscribe to
-   * @param wsKey ws key referring to the ws connection these topics should be subscribed on
-   */
-public subscribeTopicsForWsKey(
-    wsTopicRequests: WsTopicRequestOrStringTopic<WSTopic>[],
-    wsKey: TWSKey,
-)
-⋮----
-// Store topics, so future automation (post-auth, post-reconnect) has everything needed to resubscribe automatically
-⋮----
-// start connection process if it hasn't yet begun. Topics are automatically subscribed to on-connect
-⋮----
-// Subscribe should happen automatically once connected, nothing to do here after topics are added to wsStore.
-⋮----
-/**
-       * Are we in the process of connection? Nothing to send yet.
-       */
-⋮----
-// We're connected. Check if auth is needed and if already authenticated
-⋮----
-/**
-       * If not authenticated yet and auth is required, don't request topics yet.
-       *
-       * Auth should already automatically be in progress, so no action needed from here. Topics will automatically subscribe post-auth success.
-       */
-⋮----
-// Finally, request subscription to topics if the connection is healthy and ready
-⋮----
-protected unsubscribeTopicsForWsKey(
-    wsTopicRequests: WsTopicRequestOrStringTopic<string>[],
-    wsKey: TWSKey,
-)
-⋮----
-// Store topics, so future automation (post-auth, post-reconnect) has everything needed to resubscribe automatically
-⋮----
-// If not connected, don't need to do anything.
-// Removing the topic from the store is enough to stop it from being resubscribed to on reconnect.
-⋮----
-// We're connected. Check if auth is needed and if already authenticated
-⋮----
-/**
-       * If not authenticated yet and auth is required, don't need to do anything.
-       * We don't subscribe to topics until auth is complete anyway.
-       */
-⋮----
-// Finally, request subscription to topics if the connection is healthy and ready
-⋮----
-/**
-   * Splits topic requests into two groups, public & private topic requests
-   */
-private sortTopicRequestsIntoPublicPrivate(
-    wsTopicRequests: WsTopicRequest<string>[],
-    wsKey: TWSKey,
-):
-⋮----
-/** Get the WsStore that tracks websockets & topics */
-public getWsStore(): WsStore<TWSKey, WsTopicRequest<string>>
-⋮----
-public close(wsKey: TWSKey, force?: boolean)
-⋮----
-public closeAll(force?: boolean)
-⋮----
-public isConnected(wsKey: TWSKey): boolean
-⋮----
-/**
-   * Request connection to a specific websocket, instead of waiting for automatic connection.
-   */
-public async connect(
-    wsKey: TWSKey,
-    customUrl?: string | undefined,
-    throwOnError?: boolean,
-): Promise<WSConnectedResult | undefined>
-⋮----
-// Important: don't check for RECONNECTING here, or this clashes with reconnectWithDelay()!
-⋮----
-private connectToWsUrl(url: string, wsKey: TWSKey): WebSocket
-⋮----
-// Native ws ping/pong frames are not in use for okx
-⋮----
-private parseWsError(context: string, error: any, wsKey: TWSKey): boolean
-⋮----
-// Allow retry by default (in some places that call this). Prevent deadloop in hard failure (401)
-⋮----
-/** Get a signature, build the auth request and send it */
-private async sendAuthRequest(
-    wsKey: TWSKey,
-    eventToAuth?: object,
-): Promise<unknown>
-⋮----
-// If not required, this won't return anything
-⋮----
-// Short-circuit this for the next time it's called
-⋮----
-private reconnectWithDelay(wsKey: TWSKey, connectionDelayMs: number)
-⋮----
-private ping(wsKey: TWSKey)
-⋮----
-private clearTimers(wsKey: TWSKey)
-⋮----
-// Send a ping at intervals
-private clearPingTimer(wsKey: TWSKey)
-⋮----
-// Expect a pong within a time limit
-private clearPongTimer(wsKey: TWSKey)
-⋮----
-// this.logger.trace(`Cleared pong timeout for "${wsKey}"`);
-⋮----
-// this.logger.trace(`No active pong timer for "${wsKey}"`);
-⋮----
-/**
-   * Simply builds and sends subscribe events for a list of topics for a ws key
-   *
-   * @private Use the `subscribe(topics)` or `subscribeTopicsForWsKey(topics, wsKey)` method to subscribe to topics. Send WS message to subscribe to topics.
-   */
-private async requestSubscribeTopics(
-    wsKey: TWSKey,
-    topics: WsTopicRequest<string>[],
-)
-⋮----
-// Automatically splits requests into smaller batches, if needed
-⋮----
-`Subscribing to ${topics.length} "${wsKey}" topics in ${subscribeWsMessages.length} batches.`, // Events: "${JSON.stringify(topics)}"
-⋮----
-/**
-   * Simply builds and sends unsubscribe events for a list of topics for a ws key
-   *
-   * @private Use the `unsubscribe(topics)` method to unsubscribe from topics. Send WS message to unsubscribe from topics.
-   */
-private async requestUnsubscribeTopics(
-    wsKey: TWSKey,
-    wsTopicRequests: WsTopicRequest<string>[],
-)
-⋮----
-/**
-   * Try sending a string event on a WS connection (identified by the WS Key)
-   */
-public tryWsSend(
-    wsKey: TWSKey,
-    wsMessage: string,
-    throwExceptions?: boolean,
-)
-⋮----
-private async onWsOpen(
-    event: WebSocket.Event,
-    wsKey: TWSKey,
-    url: string,
-    ws: WebSocket,
-)
-⋮----
-// Resolve & cleanup deferred "connection attempt in progress" promise
-⋮----
-// Remove before continuing, in case there's more requests queued
-⋮----
-/**
-   * Called automatically once a connection is ready.
-   * - Some exchanges are ready immediately after the connections open.
-   * - Some exchanges send an event to confirm the connection is ready for us.
-   *
-   * This method is called to act when the connection is ready. Use `requireConnectionReadyConfirmation` to control how this is called.
-   */
-private async onWsReadyForEvents(wsKey: TWSKey)
-⋮----
-// Resolve & cleanup deferred "connection attempt in progress" promise
-⋮----
-// Remove before resolving, in case there's more requests queued
-⋮----
-// Some websockets require an auth packet to be sent after opening the connection
-⋮----
-// Reconnect to topics known before it connected
-⋮----
-// Request sub to public topics, if any
-⋮----
-// Request sub to private topics, if auth on connect isn't needed
-⋮----
-/**
-   * Handle subscription to private topics _after_ authentication successfully completes asynchronously.
-   *
-   * Only used for exchanges that require auth before sending private topic subscription requests
-   */
-private onWsAuthenticated(
-    wsKey: TWSKey,
-    event: { isWSAPI?: boolean; WSAPIAuthChannel?: string },
-)
-⋮----
-// Resolve & cleanup deferred "auth attempt in progress" promise
-⋮----
-// Remove before continuing, in case there's more requests queued
-⋮----
-private onWsPing(
-    event: any,
-    wsKey: TWSKey,
-    ws: WebSocket,
-    source: WsEventInternalSrc,
-)
-⋮----
-private onWsPong(event: any, wsKey: TWSKey, source: WsEventInternalSrc)
-⋮----
-private async onWsMessage(
-    event: unknown,
-    wsKey: TWSKey,
-    ws: WebSocket,
-    didDecompress = false,
-): Promise<unknown>
-⋮----
-// any message can clear the pong timer - wouldn't get a message if the ws wasn't working
-⋮----
-// console.log(`raw event: `, { data, dataType, emittableEvents });
-⋮----
-// Other event types are automatically emitted here
-// this.logger.trace(
-//   `onWsMessage().emit(${emittable.eventType})`,
-//   emittableFinalEvent,
-// );
-⋮----
-// this.logger.trace(
-//   `onWsMessage().emit(${emittable.eventType}).done()`,
-//   emittableFinalEvent,
-// );
-⋮----
-// eventStr: JSON.stringify(event, null, 2),
-⋮----
-private onWsClose(event: unknown, wsKey: TWSKey)
-⋮----
-// unintentional close, attempt recovery
-⋮----
-// clean up any pending promises for this connection
-⋮----
-// intentional close - clean up
-// clean up any pending promises for this connection
-⋮----
-// This was an intentional close, delete all state for this connection, as if it never existed:
-⋮----
-private getWs(wsKey: TWSKey)
-⋮----
-private setWsState(wsKey: TWSKey, state: WsConnectionStateEnum)
-⋮----
-/**
-   * Promise-driven method to assert that a ws has successfully connected (will await until connection is open)
-   */
-protected async assertIsConnected(wsKey: TWSKey): Promise<unknown>
-⋮----
-// Already in progress? Await shared promise and retry
-⋮----
-// this.logger.trace('assertIsConnected(): awaiting...');
-⋮----
-// this.logger.trace('assertIsConnected(): awaiting...connected!');
-⋮----
-// Start connection, it should automatically store/return a promise.
-// this.logger.trace('assertIsConnected(): connecting...');
-⋮----
-// this.logger.trace('assertIsConnected(): connecting...newly connected!');
-⋮----
-/**
-   * Promise-driven method to assert that a ws has been successfully authenticated (will await until auth is confirmed)
-   */
-public async assertIsAuthenticated(wsKey: TWSKey): Promise<unknown>
-⋮----
-// this.logger.trace('assertIsAuthenticated(): connecting...');
-⋮----
-// Already in progress? Await shared promise and retry
-⋮----
-// this.logger.trace('assertIsAuthenticated(): awaiting...');
-⋮----
-// this.logger.trace('assertIsAuthenticated(): authenticated!');
-⋮----
-// this.logger.trace('assertIsAuthenticated(): ok');
-⋮----
-// Start authentication, it should automatically store/return a promise.
-// this.logger.trace('assertIsAuthenticated(): authenticating...');
-⋮----
-// this.logger.trace('assertIsAuthenticated(): newly authenticated!');
-
-================
 File: src/types/websockets/ws-api.ts
 ================
 import { WS_KEY_MAP, WsKey } from '../../lib/websocket/websocket-util.js';
@@ -16076,7 +16418,7 @@ File: package.json
 ================
 {
   "name": "kucoin-api",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "Complete & robust Node.js SDK for Kucoin's REST APIs and WebSockets, with TypeScript & strong end to end tests.",
   "scripts": {
     "clean": "rm -rf dist",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kucoin-api",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kucoin-api",
-      "version": "2.5.1",
+      "version": "2.5.2",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kucoin-api",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "Complete & robust Node.js SDK for Kucoin's REST APIs and WebSockets, with TypeScript & strong end to end tests.",
   "scripts": {
     "clean": "rm -rf dist",

--- a/src/UnifiedAPIClient.ts
+++ b/src/UnifiedAPIClient.ts
@@ -9,6 +9,7 @@ import {
   GetAccountLedgerRequestUTA,
   GetAccountPositionTiersRequestUTA,
   GetAnnouncementsRequestUTA,
+  GetBorrowingRatesAndLimitsRequestUTA,
   GetClassicAccountRequestUTA,
   GetCurrencyRequestUTA,
   GetCurrentFundingRateRequestUTA,
@@ -18,20 +19,25 @@ import {
   GetHistoryFundingRateRequestUTA,
   GetInterestHistoryRequestUTA,
   GetKlinesRequestUTA,
+  GetLeverageRequestUTA,
   GetOpenOrderListRequestUTA,
   GetOrderBookRequestUTA,
   GetOrderDetailsRequestUTA,
   GetOrderHistoryRequestUTA,
   GetPositionListRequestUTA,
   GetPositionsHistoryRequestUTA,
+  GetPrivateFundingFeeHistoryRequestUTA,
   GetServiceStatusRequestUTA,
   GetSubAccountRequestUTA,
   GetSymbolRequestUTA,
+  GetThirdPartyCustodyCurrenciesRequestUTA,
+  GetThirdPartyCustodyQuotaRequestUTA,
   GetTickerRequestUTA,
   GetTradeHistoryRequestUTA,
   GetTradesRequestUTA,
   GetTransferQuotasRequestUTA,
   ModifyLeverageRequestUTA,
+  ModifyMarginCrossLeverageRequestUTA,
   PlaceOrderRequestUTA,
   SetAccountModeRequestUTA,
   SetDCPRequestUTA,
@@ -42,6 +48,7 @@ import {
   BatchCancelOrdersBySymbolResponseUTA,
   BatchCancelOrdersResponseUTA,
   BatchPlaceOrderResponseUTA,
+  BorrowableCurrencyUTA,
   CancelOrderResponseUTA,
   DCPResponseUTA,
   DepositAddressUTA,
@@ -51,6 +58,7 @@ import {
   GetAccountModeResponseUTA,
   GetAccountOverviewResponseUTA,
   GetAnnouncementsResponseUTA,
+  GetBorrowingRatesAndLimitsResponseUTA,
   GetClassicAccountResponseUTA,
   GetCrossMarginConfigResponseUTA,
   GetCurrencyResponseUTA,
@@ -59,10 +67,12 @@ import {
   GetHistoryFundingRateResponseUTA,
   GetInterestHistoryResponseUTA,
   GetKlinesResponseUTA,
+  GetLeverageItemUTA,
   GetOpenOrderListResponseUTA,
   GetOrderBookResponseUTA,
   GetOrderHistoryResponseUTA,
   GetPositionsHistoryResponseUTA,
+  GetPrivateFundingFeeHistoryResponseUTA,
   GetServiceStatusResponseUTA,
   GetSubAccountResponseUTA,
   GetSymbolResponseUTA,
@@ -70,11 +80,14 @@ import {
   GetTradeHistoryResponseUTA,
   GetTradesResponseUTA,
   GetTransferQuotasResponseUTA,
+  ModifyMarginCrossLeverageResponseUTA,
   OrderDetailsUTA,
   PlaceOrderResponseUTA,
   PositionTierUTA,
   PositionUTA,
   SubAccountTransferPermissionUTA,
+  ThirdPartyCustodyCurrencyUTA,
+  ThirdPartyCustodyQuotaUTA,
 } from './types/response/uta-types.js';
 
 /**
@@ -113,6 +126,16 @@ export class UnifiedAPIClient extends BaseRestClient {
     params?: GetCurrencyRequestUTA,
   ): Promise<APISuccessResponse<GetCurrencyResponseUTA>> {
     return this.get('api/ua/v1/market/currency', params);
+  }
+
+  /**
+   * Get Third-Party Custody Currencies
+   * Query settlement currencies supported by third-party (OES) custodian institutions.
+   */
+  getThirdPartyCustodyCurrencies(
+    params?: GetThirdPartyCustodyCurrenciesRequestUTA,
+  ): Promise<APISuccessResponse<ThirdPartyCustodyCurrencyUTA[]>> {
+    return this.get('api/ua/v1/oes/currency', params);
   }
 
   /**
@@ -193,6 +216,16 @@ export class UnifiedAPIClient extends BaseRestClient {
     APISuccessResponse<GetCrossMarginConfigResponseUTA>
   > {
     return this.get('api/ua/v1/market/cross-config');
+  }
+
+  /**
+   * Get Borrowable Currencies
+   * List of borrowable currencies (UTA / public).
+   */
+  getBorrowableCurrencies(): Promise<
+    APISuccessResponse<BorrowableCurrencyUTA[]>
+  > {
+    return this.get('api/ua/v1/market/borrowable-currency');
   }
 
   /**
@@ -342,6 +375,16 @@ export class UnifiedAPIClient extends BaseRestClient {
   }
 
   /**
+   * Get Borrowing Rates and Limits
+   * Hourly/daily rates and borrow limits (UTA).
+   */
+  getBorrowingRatesAndLimits(
+    params: GetBorrowingRatesAndLimitsRequestUTA,
+  ): Promise<APISuccessResponse<GetBorrowingRatesAndLimitsResponseUTA>> {
+    return this.getPrivate('api/ua/v1/account/interest-limits', params);
+  }
+
+  /**
    * Modify Leverage (UTA)
    * This interface supports modify leverage of the specified symbol.
    */
@@ -352,6 +395,30 @@ export class UnifiedAPIClient extends BaseRestClient {
       'api/ua/v1/unified/account/modify-leverage',
       params,
     );
+  }
+
+  /**
+   * Modify Leverage Margin Cross (UTA)
+   * Update leverage for a currency in UTA cross margin.
+   */
+  modifyMarginCrossLeverage(
+    params: ModifyMarginCrossLeverageRequestUTA,
+    accountMode: 'unified' = 'unified',
+  ): Promise<APISuccessResponse<ModifyMarginCrossLeverageResponseUTA>> {
+    return this.postPrivate(
+      `api/ua/v1/${accountMode}/account/modify-leverage-margin-cross`,
+      params,
+    );
+  }
+
+  /**
+   * Get Leverage (UTA)
+   * Query leverage for MARGIN (currency) or FUTURES (symbol).
+   */
+  getLeverage(
+    params: GetLeverageRequestUTA,
+  ): Promise<APISuccessResponse<GetLeverageItemUTA[]>> {
+    return this.getPrivate('api/ua/v1/unified/account/leverage', params);
   }
 
   /**
@@ -367,6 +434,16 @@ export class UnifiedAPIClient extends BaseRestClient {
   }
 
   /**
+   * Get Third-Party Custody Account Currency Limits
+   * OES remaining custody quota per custodian and settlement currency.
+   */
+  getThirdPartyCustodyQuota(
+    params?: GetThirdPartyCustodyQuotaRequestUTA,
+  ): Promise<APISuccessResponse<ThirdPartyCustodyQuotaUTA[]>> {
+    return this.getPrivate('api/ua/v1/oes/custody-quota', params);
+  }
+
+  /**
    *
    * REST - Unified Trading Account - Orders
    *
@@ -378,7 +455,7 @@ export class UnifiedAPIClient extends BaseRestClient {
    * Supports RPI (Retail Price Improvement) orders for Futures as of 2025.01.02.
    * Note: timeInForce supports 'RPI' value for Futures only (Phase 1).
    * Note: For Classic mode, tradeType is required in query param.
-   * Note: For Unified mode, tradeType should not be in query param.
+   * Note: For Unified mode, tradeType is sent in the request body (incl. MARGIN as of 2026.04.19).
    */
   placeOrder(
     params: PlaceOrderRequestUTA,
@@ -389,6 +466,9 @@ export class UnifiedAPIClient extends BaseRestClient {
       accountMode === 'classic'
         ? `api/ua/v1/${accountMode}/order/place?tradeType=${tradeType}`
         : `api/ua/v1/${accountMode}/order/place`;
+    if (accountMode === 'unified') {
+      return this.postPrivate(url, { ...bodyParams, tradeType });
+    }
     return this.postPrivate(url, bodyParams);
   }
 
@@ -541,6 +621,7 @@ export class UnifiedAPIClient extends BaseRestClient {
    * Get Position List (UTA)
    * Get the position details of all open positions.
    * Note: creationTime standardized to nanoseconds as of 2026.01.12.
+   * Note: pageNumber, pageSize query params and liquidationPrice in each position (as of 2026.04.09).
    */
   getPositionList(
     params?: GetPositionListRequestUTA,
@@ -559,6 +640,16 @@ export class UnifiedAPIClient extends BaseRestClient {
     params?: GetPositionsHistoryRequestUTA,
   ): Promise<APISuccessResponse<GetPositionsHistoryResponseUTA>> {
     return this.getPrivate('api/ua/v1/position/history', params);
+  }
+
+  /**
+   * Get Private Funding Fee History
+   * Settled funding fee records for the current account.
+   */
+  getPrivateFundingFeeHistory(
+    params?: GetPrivateFundingFeeHistoryRequestUTA,
+  ): Promise<APISuccessResponse<GetPrivateFundingFeeHistoryResponseUTA>> {
+    return this.getPrivate('api/ua/v1/position/funding-history', params);
   }
 
   /**

--- a/src/types/request/uta-types.ts
+++ b/src/types/request/uta-types.ts
@@ -221,9 +221,29 @@ export interface GetInterestHistoryRequestUTA {
   size?: number; // Default 50, max 1000
 }
 
+export interface GetBorrowingRatesAndLimitsRequestUTA {
+  currency: string;
+}
+
 export interface ModifyLeverageRequestUTA {
   symbol: string;
   leverage: string;
+}
+
+/** UTA cross margin only — path includes accountMode (typically unified) */
+export interface ModifyMarginCrossLeverageRequestUTA {
+  leverage: string;
+  /** Cross margin currency (e.g. BTC) */
+  currency?: string;
+}
+
+export interface GetLeverageRequestUTA {
+  tradeType: 'MARGIN' | 'FUTURES';
+  marginMode: 'CROSS' | 'ISOLATED';
+  /** Required for MARGIN when not returning all; optional => all for MARGIN */
+  currency?: string;
+  /** Required for FUTURES when not returning all; optional => all for FUTURES */
+  symbol?: string;
 }
 
 export interface GetDepositAddressRequestUTA {
@@ -236,7 +256,7 @@ export interface GetDepositAddressRequestUTA {
  */
 
 export interface PlaceOrderRequestUTA {
-  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS';
+  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS' | 'MARGIN';
   clientOid?: string; // Mandatory for futures and margin; optional otherwise. Max 40 chars
   symbol: string;
   side: 'BUY' | 'SELL';
@@ -273,19 +293,19 @@ export interface PlaceOrderRequestUTA {
 }
 
 export interface BatchPlaceOrderRequestUTA {
-  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS';
+  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS' | 'MARGIN';
   orderList: Omit<PlaceOrderRequestUTA, 'tradeType'>[];
 }
 
 export interface GetOrderDetailsRequestUTA {
-  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS';
+  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS' | 'MARGIN';
   symbol: string;
   orderId?: string; // At least one of orderId or clientOid required
   clientOid?: string; // At least one of orderId or clientOid required
 }
 
 export interface GetOpenOrderListRequestUTA {
-  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS';
+  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS' | 'MARGIN';
   symbol?: string; // Required for SPOT, ISOLATED, and CROSS
   orderFilter?: 'NORMAL' | 'CONDITION'; // Defaults to NORMAL
   startAt?: number; // milliseconds
@@ -295,7 +315,7 @@ export interface GetOpenOrderListRequestUTA {
 }
 
 export interface GetOrderHistoryRequestUTA {
-  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS';
+  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS' | 'MARGIN';
   symbol?: string; // Required for SPOT, ISOLATED, and CROSS
   side?: 'BUY' | 'SELL';
   orderFilter?: 'NORMAL' | 'CONDITION'; // Defaults to NORMAL
@@ -306,7 +326,7 @@ export interface GetOrderHistoryRequestUTA {
 }
 
 export interface GetTradeHistoryRequestUTA {
-  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS';
+  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS' | 'MARGIN';
   symbol?: string; // Required for SPOT, ISOLATED, and CROSS
   orderId?: string;
   side?: 'BUY' | 'SELL';
@@ -318,7 +338,7 @@ export interface GetTradeHistoryRequestUTA {
 }
 
 export interface CancelOrderRequestUTA {
-  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS';
+  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS' | 'MARGIN';
   symbol: string; // For FUTURES optional for single order cancellation (ignored if orderId provided); For UTA FUTURES, required
   orderId?: string; // At least one of orderId or clientOid required
   clientOid?: string; // At least one of orderId or clientOid required
@@ -331,7 +351,7 @@ export interface CancelOrderItemRequestUTA {
 }
 
 export interface BatchCancelOrdersRequestUTA {
-  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS';
+  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS' | 'MARGIN';
   cancelOrderList: CancelOrderItemRequestUTA[]; // Maximum 20 orders
 }
 
@@ -359,6 +379,40 @@ export interface GetDCPRequestUTA {
 
 export interface GetPositionListRequestUTA {
   symbol?: string; // Optional, if not provided returns all open positions
+  pageNumber?: number;
+  pageSize?: number;
+}
+
+/** Third-party custody (OES) custodian codes */
+export type ThirdPartyCustodyCustodianUTA =
+  | 'BITGO_SG'
+  | 'BITGO_SD'
+  | 'CACTUS'
+  | 'CEFFU';
+
+/**
+ * Get Third-Party Custody Currencies (public)
+ * Settlement currencies supported per custodian.
+ */
+export interface GetThirdPartyCustodyCurrenciesRequestUTA {
+  /** If omitted, returns all custodian rows */
+  custodian?: ThirdPartyCustodyCustodianUTA;
+  /** If omitted, all currencies for the selected custodian(s) */
+  currency?: string;
+}
+
+/**
+ * Get Third-Party Custody Account Currency Limits (private)
+ * Remaining OES custody quota per custodian/currency.
+ */
+export interface GetThirdPartyCustodyQuotaRequestUTA {
+  /**
+   * If sub-account API key is used, this parameter is ignored; only the
+   * custodian bound to the sub-account is returned (per API docs).
+   */
+  custodian?: ThirdPartyCustodyCustodianUTA;
+  /** If omitted, limits for all currencies under the custodian */
+  currency?: string;
 }
 
 export interface GetPositionsHistoryRequestUTA {
@@ -367,6 +421,15 @@ export interface GetPositionsHistoryRequestUTA {
   endAt?: number; // milliseconds
   lastId?: number; // For cursor-based pagination
   pageSize?: number; // Default 10, max 200
+}
+
+/** Settled funding fee history (private) */
+export interface GetPrivateFundingFeeHistoryRequestUTA {
+  symbol?: string;
+  startAt?: number;
+  endAt?: number;
+  lastId?: number;
+  pageSize?: number;
 }
 
 export interface GetAccountPositionTiersRequestUTA {

--- a/src/types/response/uta-types.ts
+++ b/src/types/response/uta-types.ts
@@ -187,6 +187,12 @@ export interface GetCurrentFundingRateResponseUTA {
   fundingTime: number;
   fundingRateCap: number;
   fundingRateFloor: number;
+  /** Current funding settlement interval (ms); as of 2026.04.19 */
+  currentGranularity: number;
+  /** New interval after change (ms); as of 2026.04.19 */
+  newGranularity: number;
+  /** When newGranularity takes effect (ms); as of 2026.04.19 */
+  newGranularityStartTime: number;
 }
 
 export interface FundingRateHistoryItemUTA {
@@ -197,6 +203,49 @@ export interface FundingRateHistoryItemUTA {
 export interface GetHistoryFundingRateResponseUTA {
   symbol: string;
   list: FundingRateHistoryItemUTA[];
+}
+
+export interface ModifyMarginCrossLeverageResponseUTA {
+  currency?: string;
+  leverage?: string;
+}
+
+/** One row from Get Leverage (UTA) — margin uses currency, futures uses symbol */
+export interface GetLeverageItemUTA {
+  leverage: string;
+  marginMode: string;
+  currency?: string;
+  symbol?: string;
+}
+
+export interface PrivateFundingFeeHistoryItemUTA {
+  symbol: string;
+  marginMode: 'CROSS' | 'ISOLATED';
+  fundingRate: string;
+  markPrice: string;
+  size: string;
+  positionValue: string;
+  fundingFee: string;
+  settleCurrency: string;
+  settlementTime: number;
+}
+
+export interface GetPrivateFundingFeeHistoryResponseUTA {
+  lastId: number;
+  items: PrivateFundingFeeHistoryItemUTA[];
+}
+
+export interface GetBorrowingRatesAndLimitsResponseUTA {
+  currentRateHourly: string;
+  currentRateDaily: string;
+  borrowLimitTotal: string;
+  borrowLimitTotalHold: string;
+  borrowLimitHold: string;
+  interestFreeBorrowLimit: string;
+}
+
+export interface BorrowableCurrencyUTA {
+  currency: string;
 }
 
 export interface GetCrossMarginConfigResponseUTA {
@@ -222,6 +271,8 @@ export interface AccountCurrencyUTA {
   available: string;
   balance: string;
   equity: string;
+  /** Potential borrow reserved by open orders (UTA; as of 2026.04.19) */
+  potentialBorrow?: string;
   liability?: string;
   totalCrossMargin?: string;
   crossPosMargin?: string;
@@ -372,7 +423,7 @@ export interface DepositAddressUTA {
  */
 
 export interface PlaceOrderResponseUTA {
-  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS';
+  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS' | 'MARGIN';
   orderId: string;
   clientOid: string;
   /** Timestamp when system completes order request in nanoseconds. Classic mode not supported */
@@ -392,12 +443,12 @@ export interface BatchPlaceOrderItemResponseUTA {
 }
 
 export interface BatchPlaceOrderResponseUTA {
-  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS';
+  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS' | 'MARGIN';
   items: BatchPlaceOrderItemResponseUTA[];
 }
 
 export interface OrderDetailsUTA {
-  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS';
+  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS' | 'MARGIN';
   orderId: string;
   clientOid: string;
   /**
@@ -459,13 +510,13 @@ export interface GetOpenOrderListResponseUTA {
   pageSize?: number;
   totalNum?: number;
   totalPage?: number;
-  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS';
+  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS' | 'MARGIN';
   items: OrderDetailsUTA[];
 }
 
 export interface GetOrderHistoryResponseUTA {
   lastId: number;
-  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS';
+  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS' | 'MARGIN';
   items: OrderDetailsUTA[];
 }
 
@@ -493,12 +544,12 @@ export interface TradeHistoryItemUTA {
 
 export interface GetTradeHistoryResponseUTA {
   lastId: number;
-  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS';
+  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS' | 'MARGIN';
   items: TradeHistoryItemUTA[];
 }
 
 export interface CancelOrderResponseUTA {
-  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS';
+  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS' | 'MARGIN';
   orderId?: string;
   clientOid?: string;
   /** Timestamp when system completes order cancellation request (nanoseconds). Only for unified accounts */
@@ -515,7 +566,7 @@ export interface BatchCancelOrderItemResponseUTA {
 }
 
 export interface BatchCancelOrdersResponseUTA {
-  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS';
+  tradeType: 'SPOT' | 'FUTURES' | 'ISOLATED' | 'CROSS' | 'MARGIN';
   items: BatchCancelOrderItemResponseUTA[];
 }
 
@@ -568,6 +619,8 @@ export interface PositionUTA {
   maintenanceMargin: string;
   /** Timestamp when position was first opened (nanoseconds, standardized as of 2026.01.12) */
   creationTime: number;
+  /** Estimated liquidation price (as of 2026.04.09) */
+  liquidationPrice: string;
 }
 
 export interface PositionHistoryItemUTA {
@@ -593,6 +646,21 @@ export interface PositionHistoryItemUTA {
 export interface GetPositionsHistoryResponseUTA {
   items: PositionHistoryItemUTA[];
   lastId?: number;
+}
+
+/** Row from Get Third-Party Custody Currencies */
+export interface ThirdPartyCustodyCurrencyUTA {
+  custodian: string;
+  currency: string;
+  precision: number;
+}
+
+/** Row from Get Third-Party Custody Account Currency Limits */
+export interface ThirdPartyCustodyQuotaUTA {
+  custodian: string;
+  currency: string;
+  /** Remaining custodial quota (shared across custodian sub-accounts under master) */
+  custodyQuota: string;
 }
 
 export interface PositionTierUTA {


### PR DESCRIPTION
# Release notes (PR summary)

SDK updates aligned with KuCoin Pro / UTA API and WebSocket documentation.

---

## WebSocket examples & docs (2026.03.30)

- **`examples/WebSockets/ws-private-pro-v2.ts`**
  - Documented **Order** channel: `eT` may include `match`; notes on `O` (Risk Engine vs Match Engine for UTA Spot).
  - **Balance** subscription: prefer `accountType: 'SPOT'` (replaces documented `TRADING`; still accepted upstream).
  - Added **`execution.lite`** subscription (lighter payload; no `f` / `fC`).
- **`examples/WebSockets/ws-public-spot-pro-v2.ts`** & **`ws-public-futures-pro-v2.ts`**
  - Comments: **BBO (`obu`)** and **`trade`** use high-speed push path (lower latency).
  - Futures **trade** comment fixed (FUTURES vs spot wording).
- **`examples/WebSockets/README.md`**: short summary of Pro private/public changes.
- **`examples/kucoin-UNIFIED-examples-nodejs.md`**: private Pro v2 bullet updated (incl. execution.lite, balance, 2026.03.30 notes).

---

## REST: positions, OES custody, endpoint list (2026.04.09)

- **Types & client**
  - `GetPositionListRequestUTA`: **`pageNumber`**, **`pageSize`**.
  - `PositionUTA`: **`liquidationPrice`**.
  - `getThirdPartyCustodyCurrencies` → `GET /api/ua/v1/oes/currency` (public).
  - `getThirdPartyCustodyQuota` → `GET /api/ua/v1/oes/custody-quota` (private).
  - New types: `ThirdPartyCustodyCustodianUTA`, `GetThirdPartyCustody*RequestUTA`, `ThirdPartyCustodyCurrencyUTA`, `ThirdPartyCustodyQuotaUTA`.
- **`docs/endpointFunctionList.md`**: was updated in that PR pass to include new methods and line refs (re-run your generator if you use one).

---

## REST: UTA & market expansion (2026.04.19)

- **`tradeType`**: **`MARGIN`** added everywhere it applies for UTA order flows  
  (place, batch place, get order details / open / history / trade history, cancel, batch cancel) — request + response `tradeType` unions and `OrderDetailsUTA` list wrappers.
- **`placeOrder` (`unified`)**: sends **`tradeType` in the JSON body** (required for MARGIN and explicit product; classic unchanged — query `tradeType` only).
- **New `UnifiedAPIClient` methods**
  - `getBorrowableCurrencies` — `GET /api/ua/v1/market/borrowable-currency` (public).
  - `getBorrowingRatesAndLimits` — `GET /api/ua/v1/account/interest-limits`.
  - `modifyMarginCrossLeverage` — `POST /api/ua/v1/{accountMode}/account/modify-leverage-margin-cross`.
  - `getLeverage` — `GET /api/ua/v1/unified/account/leverage`.
  - `getPrivateFundingFeeHistory` — `GET /api/ua/v1/position/funding-history`.
- **Response / account**
  - `GetCurrentFundingRateResponseUTA`: **`currentGranularity`**, **`newGranularity`**, **`newGranularityStartTime`**.
  - `AccountCurrencyUTA`: optional **`potentialBorrow`** (UTA balance).
- **WebSocket examples (2026.04.19)**
  - Private: `order` / `orderAll` **`tradeType: UNIFIED`** note; `leverage` note (`c`, `tT`, `mM`); balance example `SPOT`.
  - Public: **ticker** multi-symbol via **`symbols`** (spot + futures examples).
- **`examples/WebSockets/README.md`** & **`kucoin-UNIFIED-examples-nodejs.md`**: new endpoints, funding-rate fields, account `potentialBorrow`, unified place-order body behavior, margin/funding examples.

---

## Files touched (high level)

| Area          | Paths                                                                                                                                  |
| ------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
| Types         | `src/types/request/uta-types.ts`, `src/types/response/uta-types.ts`                                                                    |
| Client        | `src/UnifiedAPIClient.ts`                                                                                                              |
| WS examples   | `examples/WebSockets/ws-private-pro-v2.ts`, `ws-public-spot-pro-v2.ts`, `ws-public-futures-pro-v2.ts`, `examples/WebSockets/README.md` |
| Unified guide | `examples/kucoin-UNIFIED-examples-nodejs.md`                                                                                           |
| Optional      | `docs/endpointFunctionList.md` (if updated in your branch)                                                                             |

