### PR TITLE
Update README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![npm downloads](https://img.shields.io/npm/dt/kucoin-api)][1]
 [![last commit](https://img.shields.io/github/last-commit/tiagosiebler/kucoin-api)][1]
 [![Telegram](https://img.shields.io/badge/chat-on%20telegram-blue.svg)](https://t.me/nodetraders)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/tiagosiebler/kucoin-api)
 
 <p align="center">
   <a href="https://www.npmjs.com/package/kucoin-api">


### PR DESCRIPTION
## Summary
- Move webpack-related optionalDependencies into devDependencies where applicable
- Bump patch version when package.json dependencies changed
- Add Ask DeepWiki badge to README

## Test plan
- [ ] CI passes
- [ ] `npm i` succeeds locally